### PR TITLE
Fix casting of raw parsed config values.

### DIFF
--- a/hive/src/main/java/io/confluent/connect/storage/hive/HiveConfig.java
+++ b/hive/src/main/java/io/confluent/connect/storage/hive/HiveConfig.java
@@ -165,7 +165,7 @@ public class HiveConfig extends AbstractConfig implements ComposableConfig {
 
     @Override
     public List<Object> validValues(String name, Map<String, Object> connectorConfigs) {
-      boolean hiveIntegration = (Boolean) connectorConfigs.get(parentConfigName);
+      boolean hiveIntegration = (boolean) connectorConfigs.get(parentConfigName);
       if (hiveIntegration) {
         return Arrays.<Object>asList("BACKWARD", "FORWARD", "FULL");
       } else {
@@ -193,7 +193,7 @@ public class HiveConfig extends AbstractConfig implements ComposableConfig {
 
     @Override
     public boolean visible(String name, Map<String, Object> connectorConfigs) {
-      return (Boolean) connectorConfigs.get(parentConfigName);
+      return (boolean) connectorConfigs.get(parentConfigName);
     }
   }
 

--- a/hive/src/main/java/io/confluent/connect/storage/hive/schema/TimeBasedSchemaGenerator.java
+++ b/hive/src/main/java/io/confluent/connect/storage/hive/schema/TimeBasedSchemaGenerator.java
@@ -36,9 +36,8 @@ public class TimeBasedSchemaGenerator implements SchemaGenerator<FieldSchema> {
 
   @Override
   public List<FieldSchema> newPartitionFields(String format) {
-    String hiveIntegrationString = (String) config.get(HiveConfig.HIVE_INTEGRATION_CONFIG);
+    boolean hiveIntegration = (boolean) config.get(HiveConfig.HIVE_INTEGRATION_CONFIG);
     String delim = (String) config.get(StorageCommonConfig.DIRECTORY_DELIM_CONFIG);
-    boolean hiveIntegration = hiveIntegrationString != null && hiveIntegrationString.toLowerCase().equals("true");
     if (hiveIntegration && !verifyDateTimeFormat(format, delim)) {
       throw new IllegalArgumentException("Path format doesn't meet the requirements for Hive integration, "
           + "which require prefixing each DateTime component with its name.");

--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/PartitionerConfig.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/PartitionerConfig.java
@@ -187,7 +187,7 @@ public class PartitionerConfig extends AbstractConfig implements ComposableConfi
 
     @Override
     public boolean visible(String name, Map<String, Object> connectorConfigs) {
-      return (Boolean) connectorConfigs.get(parentConfigName);
+      return (boolean) connectorConfigs.get(parentConfigName);
     }
   }
 
@@ -200,27 +200,28 @@ public class PartitionerConfig extends AbstractConfig implements ComposableConfi
 
     @Override
     public boolean visible(String name, Map<String, Object> connectorConfigs) {
-      String partitionerName = (String) connectorConfigs.get(PARTITIONER_CLASS_CONFIG);
       try {
         @SuppressWarnings("unchecked")
-        Class<? extends Partitioner<?>> partitioner = (Class<? extends Partitioner<?>>) Class.forName(partitionerName);
-        if (classNameEquals(partitionerName, DefaultPartitioner.class)) {
+        Class<? extends Partitioner<?>> partitioner =
+            (Class<? extends Partitioner<?>>) connectorConfigs.get(PARTITIONER_CLASS_CONFIG);
+        if (DefaultPartitioner.class.isInstance(partitioner)) {
           return false;
         } else if (FieldPartitioner.class.isAssignableFrom(partitioner)) {
           // subclass of FieldPartitioner
           return name.equals(PARTITION_FIELD_NAME_CONFIG);
         } else if (TimeBasedPartitioner.class.isAssignableFrom(partitioner)) {
           // subclass of TimeBasedPartitioner
-          if (classNameEquals(partitionerName, DailyPartitioner.class) || classNameEquals(partitionerName, HourlyPartitioner.class)) {
+          if (DailyPartitioner.class.isInstance(partitioner) ||
+              HourlyPartitioner.class.isInstance(partitioner)) {
             return name.equals(LOCALE_CONFIG) || name.equals(TIMEZONE_CONFIG);
           } else {
             return name.equals(PARTITION_DURATION_MS_CONFIG) || name.equals(PATH_FORMAT_CONFIG) || name.equals(LOCALE_CONFIG) || name.equals(TIMEZONE_CONFIG);
           }
         } else {
-          throw new ConfigException("Not a valid partitioner class: " + partitionerName);
+          throw new ConfigException("Not a valid partitioner class: " + partitioner);
         }
-      } catch (ClassNotFoundException e) {
-        throw new ConfigException("Partitioner class not found: " + partitionerName);
+      } catch (ClassCastException e) {
+        throw new ConfigException("Partitioner class not found: " + PARTITIONER_CLASS_CONFIG);
       }
     }
   }

--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/TimeBasedPartitioner.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/TimeBasedPartitioner.java
@@ -82,7 +82,6 @@ public class TimeBasedPartitioner<T> extends DefaultPartitioner<T> {
                                 timeZoneString, "Timezone cannot be empty.");
     }
 
-
     Locale locale = new Locale(localeString);
     DateTimeZone timeZone = DateTimeZone.forID(timeZoneString);
     init(partitionDurationMs, pathFormat, locale, timeZone, config);


### PR DESCRIPTION
Hotfix addressing issues with casting which was discovered while using raw config values (`Object`s) in unit tests. 