### PR TITLE
HOTFIX: Add flush method to decouple commit and close in record writer

### DIFF
--- a/format/src/main/java/io/confluent/connect/storage/format/RecordWriter.java
+++ b/format/src/main/java/io/confluent/connect/storage/format/RecordWriter.java
@@ -35,4 +35,10 @@ public interface RecordWriter extends Closeable {
    * Close this writer.
    */
   void close();
+
+  /**
+   * Flush writer's data and commit the records in Kafka. Optionally, this operation might also
+   * close the writer.
+   */
+  void commit();
 }


### PR DESCRIPTION
Needed in order to decouple committing in Kafka from closing the writer.