### PR TITLE
Added TimeFieldPartitioner that allows partitioning on a date-time field.

### DIFF
--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/FieldPartitioner.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/FieldPartitioner.java
@@ -30,7 +30,7 @@ import io.confluent.connect.storage.errors.PartitionException;
 
 public class FieldPartitioner<T> extends DefaultPartitioner<T> {
   private static final Logger log = LoggerFactory.getLogger(FieldPartitioner.class);
-  private static String fieldName;
+  private String fieldName;
 
   @Override
   public void configure(Map<String, Object> config) {

--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/PartitioningCommon.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/PartitioningCommon.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.storage.partitioner;
+
+import io.confluent.connect.storage.common.SchemaGenerator;
+import org.apache.kafka.common.config.ConfigException;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+public class PartitioningCommon {
+  static String getPathFormat(Map<String, Object> config) {
+    String pathFormat = (String) config.get(PartitionerConfig.PATH_FORMAT_CONFIG);
+    if (pathFormat.equals("")) {
+      throw new ConfigException(PartitionerConfig.PATH_FORMAT_CONFIG,
+              pathFormat, "Path format cannot be empty.");
+    }
+    return pathFormat;
+  }
+
+  static DateTimeFormatter loadDateTimeFormatterFromConfiguration(Map<String, Object> config, String pathFormat) {
+    String localeString = (String) config.get(PartitionerConfig.LOCALE_CONFIG);
+    if (localeString.equals("")) {
+      throw new ConfigException(PartitionerConfig.LOCALE_CONFIG,
+              localeString, "Locale cannot be empty.");
+    }
+    Locale locale = new Locale(localeString);
+
+    String timeZoneString = (String) config.get(PartitionerConfig.TIMEZONE_CONFIG);
+    if (timeZoneString.equals("")) {
+      throw new ConfigException(PartitionerConfig.TIMEZONE_CONFIG,
+              timeZoneString, "Timezone cannot be empty.");
+    }
+    DateTimeZone timeZone = DateTimeZone.forID(timeZoneString);
+
+    return DateTimeFormat.forPattern(pathFormat).withZone(timeZone).withLocale(locale);
+  }
+
+  static <T> List<T> loadDateTimePartitionFields(SchemaGenerator<T> schemaGenerator, String pathFormat) {
+    try {
+      return schemaGenerator.newPartitionFields(pathFormat);
+    } catch (IllegalArgumentException e) {
+      throw new ConfigException(PartitionerConfig.PATH_FORMAT_CONFIG, pathFormat, e.getMessage());
+    }
+  }
+
+  static long roundInstantToMs(long timeGranularityMs, long timestamp, DateTimeZone timeZone) {
+    if (timeGranularityMs < 1) {
+      return timestamp;
+    }
+
+    long adjustedTimeStamp = timeZone.convertUTCToLocal(timestamp);
+    long partitionedTime = (adjustedTimeStamp / timeGranularityMs) * timeGranularityMs;
+    return timeZone.convertLocalToUTC(partitionedTime, false);
+  }
+
+  static Date roundInstantToMs(long timeGranularityMs, Date timestamp, DateTimeZone timeZone) {
+    if (timeGranularityMs < 1) {
+      return timestamp;
+    }
+
+    long adjustedTimeStamp = timeZone.convertUTCToLocal(timestamp.getTime());
+    long partitionedTime = (adjustedTimeStamp / timeGranularityMs) * timeGranularityMs;
+    return new Date(timeZone.convertLocalToUTC(partitionedTime, false));
+  }
+}


### PR DESCRIPTION
The main feature I want to add is the `TimeFieldPartitioner` class that allows partitioning based on a date-time field. Currently, `FieldPartitioner` doesn't support date-time fields, and will simply generate a runtime exception. This new class uses the exact same configuration settings and partition naming logic of `TimeBasedPartitioner` but instead of using wall time, it uses the time value from the specified field.

I'm also adding some related bug fixes:

- Major Bug fix to `FieldPartitioner` where `fieldName` was a global static. It should be instance based. This was obviously a mistake in the original code.
- Minor fix to `HourlyPartitioner`: uses configurable `delim` field to build the path format string rather than assuming `/`. This behavior is identical to existing behavior in `DailyPartitioner`.
- Minor fix to `DailyPartitioner`: Added `PARTITION_DURATION_MS` constant to be analogous to the exiting constant in the similar `HourlyPartitioner` class.
- Feature: Allow `PARTITION_DURATION_MS_CONFIG` to not be user configured. Usually, this isn't needed. The date-time string formatting will automatically truncate to natural bucket partitions. Many users won't need additional date-time bucket rounding logic.
- Very minor code reorg to minimize code duplication related to adding `TimeFieldPartitioner`.