### PR TITLE
Timestamp information should be copied to projected SinkRecord

### DIFF
--- a/core/src/main/java/io/confluent/connect/storage/schema/StorageSchemaCompatibility.java
+++ b/core/src/main/java/io/confluent/connect/storage/schema/StorageSchemaCompatibility.java
@@ -169,7 +169,9 @@ public enum StorageSchemaCompatibility implements SchemaCompatibility {
                projected.getKey(),
                currentValueSchema,
                projected.getValue(),
-               record.kafkaOffset()
+               record.kafkaOffset(),
+               record.timestamp(),
+               record.timestampType()
            );
   }
 


### PR DESCRIPTION
Projected `SinkRecord` was missing timestamp information from the original `SinkRecord`