### PR TITLE
CC-1333: Remove dependency on hive-exec and instead use hive-exec:core

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>kafka-connect-storage-common</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>kafka-connect-storage-core</artifactId>

--- a/format/pom.xml
+++ b/format/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>kafka-connect-storage-format</artifactId>

--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -30,6 +30,11 @@
     <packaging>jar</packaging>
     <name>kafka-connect-storage-hive</name>
 
+    <properties>
+        <commons.lang3.version>3.1</commons.lang3.version>
+        <kryo.version>2.22</kryo.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.confluent</groupId>
@@ -55,6 +60,33 @@
             <groupId>org.apache.hive.hcatalog</groupId>
             <artifactId>hive-hcatalog-core</artifactId>
             <version>${hive.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.hive</groupId>
+                    <artifactId>hive-exec</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-exec</artifactId>
+            <version>${hive.version}</version>
+            <classifier>core</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons.lang3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.esotericsoftware.kryo</groupId>
+            <artifactId>kryo</artifactId>
+            <version>${kryo.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro-mapred</artifactId>
+            <version>${avro.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>kafka-connect-storage-hive</artifactId>

--- a/package-kafka-connect-storage-common/pom.xml
+++ b/package-kafka-connect-storage-common/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>kafka-connect-storage-common-package</artifactId>

--- a/partitioner/pom.xml
+++ b/partitioner/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>kafka-connect-storage-partitioner</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>kafka-connect-storage-common-parent</artifactId>

--- a/wal/pom.xml
+++ b/wal/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>3.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>kafka-connect-storage-wal</artifactId>


### PR DESCRIPTION
The hive-exec library bundles all its dependencies and this creates conflicts
with Connect's libraries (for example, avro-1.8.2 in Connect conflicts with the
avro(-1.7.7) classes bundled in hive-exec). We also need to add commons-lang3
and kryo and avro-mapred here, since they are not pulled in by hive-exec's pom
but required at runtime.

Signed-off-by: Arjun Satish <arjun@confluent.io>