### PR TITLE
CC-1333: Remove dependency on hive-exec and instead use hive-exec:core

### DIFF
--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -30,6 +30,11 @@
     <packaging>jar</packaging>
     <name>kafka-connect-storage-hive</name>
 
+    <properties>
+        <commons.lang3.version>3.1</commons.lang3.version>
+        <kryo.version>2.22</kryo.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.confluent</groupId>
@@ -55,6 +60,33 @@
             <groupId>org.apache.hive.hcatalog</groupId>
             <artifactId>hive-hcatalog-core</artifactId>
             <version>${hive.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.hive</groupId>
+                    <artifactId>hive-exec</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-exec</artifactId>
+            <version>${hive.version}</version>
+            <classifier>core</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons.lang3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.esotericsoftware.kryo</groupId>
+            <artifactId>kryo</artifactId>
+            <version>${kryo.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro-mapred</artifactId>
+            <version>${avro.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
The hive-exec library bundles all its dependencies and this creates conflicts
with Connect's libraries (for example, avro-1.8.2 in Connect conflicts with the
avro(-1.7.7) classes bundled in hive-exec). We also need to add commons-lang3
and kryo and avro-mapred here, since they are not pulled in by hive-exec's pom
but required at runtime.

Signed-off-by: Arjun Satish <arjun@confluent.io>