### PR TITLE
DataUtils::getField returns field

### DIFF
--- a/core/src/main/java/io/confluent/connect/storage/util/DataUtils.java
+++ b/core/src/main/java/io/confluent/connect/storage/util/DataUtils.java
@@ -33,6 +33,7 @@ public class DataUtils {
       if (field == null) {
         throw new DataException(String.format("Unable to find nested field '%s'", fieldName));
       }
+      return field;
     }
     throw new DataException(String.format(
           "Argument not a Struct or Map. Cannot get field '%s' from: %s",


### PR DESCRIPTION
In case of map argument DataUtils::getField does not return value, it cause raising exception as described here:

https://github.com/confluentinc/kafka-connect-hdfs/issues/316