### PR TITLE
Fix #64 by using AvroDataConfig keys in the new map

### DIFF
--- a/core/src/main/java/io/confluent/connect/storage/StorageSinkConnectorConfig.java
+++ b/core/src/main/java/io/confluent/connect/storage/StorageSinkConnectorConfig.java
@@ -288,9 +288,10 @@ public class StorageSinkConnectorConfig extends AbstractConfig implements Compos
 
   public AvroDataConfig avroDataConfig() {
     Map<String, Object> props = new HashMap<>();
-    props.put(SCHEMA_CACHE_SIZE_CONFIG, get(SCHEMA_CACHE_SIZE_CONFIG));
-    props.put(ENHANCED_AVRO_SCHEMA_SUPPORT_CONFIG, get(ENHANCED_AVRO_SCHEMA_SUPPORT_CONFIG));
-    props.put(CONNECT_META_DATA_CONFIG, get(CONNECT_META_DATA_CONFIG));
+    props.put(AvroDataConfig.SCHEMAS_CACHE_SIZE_CONFIG, get(SCHEMA_CACHE_SIZE_CONFIG));
+    props.put(AvroDataConfig.ENHANCED_AVRO_SCHEMA_SUPPORT_CONFIG,
+        get(ENHANCED_AVRO_SCHEMA_SUPPORT_CONFIG));
+    props.put(AvroDataConfig.CONNECT_META_DATA_CONFIG, get(CONNECT_META_DATA_CONFIG));
     return new AvroDataConfig(props);
   }
 }


### PR DESCRIPTION
AvroDataConfig's SCHEMAS_CACHE_SIZE_CONFIG is not the same as StorageSinkConnectorConfig's SCHEMA_CACHE_SIZE_CONFIG, which leads to AvroDataConfig being created without the correct data for that configuration parameter.