### PR TITLE
MINOR: Fix compilation error due to new method in SinkTaskContext

### DIFF
--- a/core/src/main/java/io/confluent/connect/storage/StorageSinkTestBase.java
+++ b/core/src/main/java/io/confluent/connect/storage/StorageSinkTestBase.java
@@ -154,6 +154,11 @@ public class StorageSinkTestBase {
     }
 
     @Override
+    public Map<String, String> configs() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void offset(Map<TopicPartition, Long> offsets) {
       this.offsets.putAll(offsets);
     }


### PR DESCRIPTION
Recently added a new method in SinkTaskContext. We don't call it, so we can implement by throwing UnsupportedOperationException.

This only has to be merged to `master`.