### PR TITLE
Set version of maven-site and maven-project-info-reports to ensure compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,9 @@
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <licenses.version>3.2.4-SNAPSHOT</licenses.version>
         <maven-assembly.version>2.6</maven-assembly.version>
+        <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
+        <maven-project-info-reports-plugin.version>2.9</maven-project-info-reports-plugin.version>
+        <dependency.locations.enabled>false</dependency.locations.enabled>
     </properties>
 
     <repositories>
@@ -162,6 +165,23 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>${maven-site-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <version>${maven-project-info-reports-plugin.version}</version>
+                <configuration>
+                    <!-- 
+                    Disable dependency locations for latest maven-plugin-info-reports to eliminate blacklisting
+                    warnings: "The repository url '...' is invalid - Repository '...' will be blacklisted."
+                    -->
+                    <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
This is the same fix that has been applied to common to fix maven-site incompatibilities. This repository does not use common as a parent POM, so the same changes need to be applied here.