### PR TITLE
Fix #75 by passing original properties map

### DIFF
--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/DailyPartitioner.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/DailyPartitioner.java
@@ -23,15 +23,18 @@ import io.confluent.connect.storage.common.StorageCommonConfig;
 
 public class DailyPartitioner<T> extends TimeBasedPartitioner<T> {
   @Override
-  public void configure(Map<String, Object> config) {
-    long partitionDurationMs = TimeUnit.DAYS.toMillis(1);
+  public void configure(Map<String, String> props) {
+    String partitionDurationMs = String.valueOf(TimeUnit.DAYS.toMillis(1));
 
-    String delim = (String) config.get(StorageCommonConfig.DIRECTORY_DELIM_CONFIG);
+    PartitionerConfig localConf = new PartitionerConfig(
+        PartitionerConfig.getConfig(getPartitionerRecommender(), getStorageRecommender()),
+        props);
+    String delim = localConf.getString(StorageCommonConfig.DIRECTORY_DELIM_CONFIG);
     String pathFormat = "'year'=YYYY" + delim + "'month'=MM" + delim + "'day'=dd";
 
-    config.put(PartitionerConfig.PARTITION_DURATION_MS_CONFIG, partitionDurationMs);
-    config.put(PartitionerConfig.PATH_FORMAT_CONFIG, pathFormat);
+    props.put(PartitionerConfig.PARTITION_DURATION_MS_CONFIG, partitionDurationMs);
+    props.put(PartitionerConfig.PATH_FORMAT_CONFIG, pathFormat);
 
-    super.configure(config);
+    super.configure(props);
   }
 }

--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/FieldPartitioner.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/FieldPartitioner.java
@@ -27,7 +27,6 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 import java.util.Map;
 
-import io.confluent.connect.storage.common.StorageCommonConfig;
 import io.confluent.connect.storage.errors.PartitionException;
 
 public class FieldPartitioner<T> extends DefaultPartitioner<T> {
@@ -35,11 +34,10 @@ public class FieldPartitioner<T> extends DefaultPartitioner<T> {
   private List<String> fieldNames;
 
 
-  @SuppressWarnings("unchecked")
   @Override
-  public void configure(Map<String, Object> config) {
-    fieldNames = (List<String>) config.get(PartitionerConfig.PARTITION_FIELD_NAME_CONFIG);
-    delim = (String) config.get(StorageCommonConfig.DIRECTORY_DELIM_CONFIG);
+  public void configure(Map<String, String> props) {
+    super.configure(props);
+    fieldNames = config.getList(PartitionerConfig.PARTITION_FIELD_NAME_CONFIG);
   }
 
   @Override
@@ -87,7 +85,7 @@ public class FieldPartitioner<T> extends DefaultPartitioner<T> {
   @Override
   public List<T> partitionFields() {
     if (partitionFields == null) {
-      partitionFields = newSchemaGenerator(config).newPartitionFields(
+      partitionFields = newSchemaGenerator(props).newPartitionFields(
           Utils.join(fieldNames, ",")
       );
     }

--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/HourlyPartitioner.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/HourlyPartitioner.java
@@ -23,16 +23,19 @@ import io.confluent.connect.storage.common.StorageCommonConfig;
 
 public class HourlyPartitioner<T> extends TimeBasedPartitioner<T> {
   @Override
-  public void configure(Map<String, Object> config) {
-    long partitionDurationMs = TimeUnit.HOURS.toMillis(1);
+  public void configure(Map<String, String> props) {
+    String partitionDurationMs = String.valueOf(TimeUnit.HOURS.toMillis(1));
 
-    String delim = (String) config.get(StorageCommonConfig.DIRECTORY_DELIM_CONFIG);
+    PartitionerConfig localConf = new PartitionerConfig(
+        PartitionerConfig.getConfig(getPartitionerRecommender(), getStorageRecommender()),
+        props);
+    String delim = localConf.getString(StorageCommonConfig.DIRECTORY_DELIM_CONFIG);
     String pathFormat =
         "'year'=YYYY" + delim + "'month'=MM" + delim + "'day'=dd" + delim + "'hour'=HH";
 
-    config.put(PartitionerConfig.PARTITION_DURATION_MS_CONFIG, partitionDurationMs);
-    config.put(PartitionerConfig.PATH_FORMAT_CONFIG, pathFormat);
+    props.put(PartitionerConfig.PARTITION_DURATION_MS_CONFIG, partitionDurationMs);
+    props.put(PartitionerConfig.PATH_FORMAT_CONFIG, pathFormat);
 
-    super.configure(config);
+    super.configure(props);
   }
 }

--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/Partitioner.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/Partitioner.java
@@ -16,10 +16,13 @@
 
 package io.confluent.connect.storage.partitioner;
 
+import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.sink.SinkRecord;
 
 import java.util.List;
 import java.util.Map;
+
+import io.confluent.connect.storage.common.GenericRecommender;
 
 /**
  * Partition incoming records, and generates directories and file names in which to store the
@@ -28,7 +31,15 @@ import java.util.Map;
  * @param <T> The type representing the field schemas.
  */
 public interface Partitioner<T> {
-  void configure(Map<String, Object> config);
+  default ConfigDef.Recommender getPartitionerRecommender() {
+    return new GenericRecommender();
+  }
+
+  default ConfigDef.Recommender getStorageRecommender() {
+    return new GenericRecommender();
+  }
+
+  void configure(Map<String, String> props);
 
   String encodePartition(SinkRecord sinkRecord);
 

--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/PartitionerConfig.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/PartitionerConfig.java
@@ -24,11 +24,14 @@ import org.apache.kafka.common.config.ConfigDef.Width;
 import org.apache.kafka.common.config.ConfigException;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import io.confluent.connect.storage.common.ComposableConfig;
+import io.confluent.connect.storage.common.StorageCommonConfig;
 
 public class PartitionerConfig extends AbstractConfig implements ComposableConfig {
 
@@ -203,6 +206,29 @@ public class PartitionerConfig extends AbstractConfig implements ComposableConfi
     }
 
     return configDef;
+  }
+
+  public static ConfigDef getConfig(ConfigDef.Recommender partitionerClassRecommender,
+                                    ConfigDef.Recommender storageClassRecommender) {
+    // Define the names of the configurations we're going to override
+    Set<String> skip = new HashSet<>();
+
+    // Order added is important, so that group order is maintained
+    ConfigDef visible = new ConfigDef();
+    addAllConfigKeys(visible, newConfigDef(partitionerClassRecommender), skip);
+    addAllConfigKeys(visible, StorageCommonConfig.newConfigDef(storageClassRecommender), skip);
+
+    // Add overridden configurations here, if you add them
+
+    return visible;
+  }
+
+  private static void addAllConfigKeys(ConfigDef container, ConfigDef other, Set<String> skip) {
+    for (ConfigDef.ConfigKey key : other.configKeys().values()) {
+      if (skip != null && !skip.contains(key.name)) {
+        container.define(key);
+      }
+    }
   }
 
   public static class BooleanParentRecommender implements ConfigDef.Recommender {

--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/TimestampExtractor.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/TimestampExtractor.java
@@ -16,12 +16,23 @@
 
 package io.confluent.connect.storage.partitioner;
 
+import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.ConnectRecord;
 
 import java.util.Map;
 
+import io.confluent.connect.storage.common.GenericRecommender;
+
 public interface TimestampExtractor {
-  void configure(Map<String, Object> config);
+  default ConfigDef.Recommender getPartitionerRecommender() {
+    return new GenericRecommender();
+  }
+
+  default ConfigDef.Recommender getStorageRecommender() {
+    return new GenericRecommender();
+  }
+
+  void configure(Map<String, String> props);
 
   Long extract(ConnectRecord<?> record);
 }


### PR DESCRIPTION
The issue being fixed is that the way this interface is currently
designed leads to Partitioner being effectively un-extensible, unless
they don't need any parameters at all except those defined by the
connectors using the partitioner.

The new design puts the onus of turning properties into a configuration
map on the partitioner class. Because those classes use recommenders and
also use common storage configuration, the interface was extended with
two recommender getters, with a default implementation.

TimestampExtractor also gets the same treatment, as it is used from some
of the Partitioner implementations.

While this does break API, the existing API is difficult to extend to
begin with, which is the reason for the change.