### PR TITLE
CC-2213 New Config Option introduced to handle late-arriving records

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC
+        "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+        "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+
+    <!-- TODO -->
+    <suppress
+            checks="(AbbreviationAsWordInName)"
+            files="WAL.java"
+    />
+
+    <suppress
+            checks="(CyclomaticComplexity)"
+            files="PartitionerConfig.java"
+    />
+
+    <suppress
+            checks="(ClassDataAbstractionCoupling|ClassFanOutComplexity)"
+            files="HiveMetaStore.java"
+    />
+
+    <suppress
+            checks="(MethodLength)"
+            files="StorageSinkConnectorConfig.java"
+    />
+
+</suppressions>

--- a/core/src/main/java/io/confluent/connect/storage/StorageSinkConnectorConfig.java
+++ b/core/src/main/java/io/confluent/connect/storage/StorageSinkConnectorConfig.java
@@ -58,6 +58,15 @@ public class StorageSinkConnectorConfig extends AbstractConfig implements Compos
   public static final long ROTATE_SCHEDULE_INTERVAL_MS_DEFAULT = -1L;
   public static final String ROTATE_SCHEDULE_INTERVAL_MS_DISPLAY = "Rotate Schedule Interval (ms)";
 
+  public static final String APPEND_LATE_DATA = "append.late.data";
+  public static final Boolean APPEND_LATE_DATA_DEFAULT = false;
+  public static final String APPEND_LATE_DATA_DOC = "If true, the partitions "
+      + "will append data from previous (already commited) partitions into the current, open"
+      + " partition. If false, late data intended for closed partitions will be rolled into "
+      + "files marked with the partition indicated by the extracted time, even if this creates"
+      + "many small files.";
+  public static final String APPEND_LATE_DATA_DISPLAY = "Append Late Data In Current Partition";
+
   public static final String RETRY_BACKOFF_CONFIG = "retry.backoff.ms";
   public static final String RETRY_BACKOFF_DOC =
       "The retry backoff in milliseconds. This config is used to "
@@ -173,6 +182,15 @@ public class StorageSinkConnectorConfig extends AbstractConfig implements Compos
           Width.LONG,
           FILENAME_OFFSET_ZERO_PAD_WIDTH_DISPLAY);
 
+      CONFIG_DEF.define(APPEND_LATE_DATA,
+          Type.BOOLEAN,
+          APPEND_LATE_DATA_DEFAULT,
+          Importance.LOW,
+          APPEND_LATE_DATA_DOC,
+          group,
+          ++orderInGroup,
+          Width.LONG,
+          APPEND_LATE_DATA_DISPLAY);
     }
   }
 


### PR DESCRIPTION
This will allow storage-connectors to put late arriving data from a previous time-based partition to be appended to the currently opened partition. This will let users override the existing/default behavior, which rolls new small files for records who do not belong in the currently open partition.

We rely on each connector that uses the config to implement it
