### PR TITLE
Ability to use epoch and to also specify the format of a RecordField when using TimeBasedPartitioner

### DIFF
--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/PartitionerConfig.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/PartitionerConfig.java
@@ -32,6 +32,7 @@ import io.confluent.connect.storage.common.ComposableConfig;
 
 public class PartitionerConfig extends AbstractConfig implements ComposableConfig {
 
+  public static final String IS_EPOCH = "is.epoch";
   // Partitioner group
   public static final String PARTITIONER_CLASS_CONFIG = "partitioner.class";
   public static final String PARTITIONER_CLASS_DOC =
@@ -88,6 +89,7 @@ public class PartitionerConfig extends AbstractConfig implements ComposableConfi
   public static final String TIMESTAMP_EXTRACTOR_CLASS_DISPLAY = "Timestamp Extractor";
 
   public static final String TIMESTAMP_FIELD_NAME_CONFIG = "timestamp.field";
+  public static final String TIMESTAMP_FIELD_FORMAT_CONFIG = "timestamp.field.format";
   public static final String TIMESTAMP_FIELD_NAME_DOC =
       "The record field to be used as timestamp by the timestamp extractor.";
   public static final String TIMESTAMP_FIELD_NAME_DEFAULT = "timestamp";

--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/TimeBasedPartitioner.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/TimeBasedPartitioner.java
@@ -295,10 +295,15 @@ public class TimeBasedPartitioner<T> extends DefaultPartitioner<T> {
         switch (fieldSchema.type()) {
           case INT32:
           case INT64:
+            if (isEpoch)
+            	return ((Number) timestampValue).longValue() * 1000;
             return ((Number) timestampValue).longValue();
           case STRING:
-            if (fieldFormat == null)
+            if (fieldFormat == null) {
+              if (isEpoch)
+                return dateTime.parseMillis((String) timestampValue) * 1000;
               return dateTime.parseMillis((String) timestampValue);
+            }
             DateTimeFormatter fmt = DateTimeFormat.forPattern(fieldFormat);
             return fmt.parseDateTime((String) timestampValue).getMillis();
           default:
@@ -314,10 +319,16 @@ public class TimeBasedPartitioner<T> extends DefaultPartitioner<T> {
         Map<?, ?> map = (Map<?, ?>) value;
         Object timestampValue = DataUtils.getNestedFieldValue(map, fieldName);
         if (timestampValue instanceof Number) {
+          if (isEpoch)
+              	return ((Number) timestampValue).longValue() * 1000;
           return ((Number) timestampValue).longValue();
+          
         } else if (timestampValue instanceof String) {
-            if (fieldFormat == null)
-                return dateTime.parseMillis((String) timestampValue);
+            if (fieldFormat == null) { 
+                if (isEpoch)
+                    return dateTime.parseMillis((String) timestampValue) * 1000;
+                  return dateTime.parseMillis((String) timestampValue);
+              }
               DateTimeFormatter fmt = DateTimeFormat.forPattern(fieldFormat);
               return fmt.parseDateTime((String) timestampValue).getMillis();
         } else if (timestampValue instanceof Date) {

--- a/partitioner/src/test/java/io/confluent/connect/storage/partitioner/TimeBasedPartitionerTest.java
+++ b/partitioner/src/test/java/io/confluent/connect/storage/partitioner/TimeBasedPartitionerTest.java
@@ -34,6 +34,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.text.SimpleDateFormat;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -569,6 +570,41 @@ public class TimeBasedPartitionerTest extends StorageSinkTestBase {
   }
 
   @Test
+  public void testRecordFieldTimeStringWithFormatExtractor() {
+    String pattern = "yyyy/MM/dd HH:mm:ss";
+    SimpleDateFormat dtf = new SimpleDateFormat(pattern);
+    String timeStr = dtf.format(DATE_TIME.toDate());
+    Long ts = DATE_TIME.getMillis();
+
+    String timeFieldName = "timestamp";
+    Map<String, Object> config = new HashMap<>();
+    config.put(PartitionerConfig.TIMESTAMP_FIELD_FORMAT_CONFIG, pattern);
+
+    TimeBasedPartitioner<String> partitioner = configurePartitioner(
+          new TimeBasedPartitioner<>(), timeFieldName, config);
+
+    assertThat(partitioner.getTimestampExtractor(), instanceOf(
+          TimeBasedPartitioner.RecordFieldTimestampExtractor.class));
+
+    // Struct with time as formatted string
+    Schema schema = SchemaBuilder.struct().name("record")
+          .field(timeFieldName, Schema.STRING_SCHEMA);
+    Struct datum = new Struct(schema).put(timeFieldName, timeStr);
+    SinkRecord sinkRecord = createValuedSinkRecord(schema, datum, ts);
+    String encodedPartition = partitioner.encodePartition(sinkRecord);
+    validateEncodedPartition(encodedPartition);
+
+    // Create nested time field using map{string->struct}
+    Schema mapSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, schema);
+    Map<String, Struct> header = new HashMap<>();
+    header.put("header", datum);
+    sinkRecord = createValuedSinkRecord(mapSchema, header, ts);
+
+    encodedPartition = getEncodedPartition(String.format("header.%s", timeFieldName), sinkRecord, config);
+    validateEncodedPartition(encodedPartition);
+  }
+
+  @Test
   public void testRecordTimeExtractor() throws Exception {
     TimeBasedPartitioner<String> partitioner = configurePartitioner(
           new TimeBasedPartitioner<>(), null, null);
@@ -770,6 +806,12 @@ public class TimeBasedPartitionerTest extends StorageSinkTestBase {
     return partitioner.encodePartition(r);
   }
 
+  private String getEncodedPartition(String timeFieldName, SinkRecord r, Map<String, Object> config) {
+	    TimeBasedPartitioner<String> partitioner = configurePartitioner(
+	          new TimeBasedPartitioner<>(), timeFieldName, config);
+	    return partitioner.encodePartition(r);
+	  }
+  
   private String getEncodedPartition(String timeFieldName) {
     return getEncodedPartition(timeFieldName, getSinkRecord());
   }


### PR DESCRIPTION
Hi. I added some functionality to use epoch seconds and to also specify the format of a `RecordField` when using `TimeBasedPartitioner`. For this I added two configuration attributes. 

`is.epoch` can be true but defaults to false. 
`timestamp.field.format` which expects a java date format string. 

I think it is useful and would like to share it. Thanks.

-BW