### PR TITLE
CC-5963: Improved ability to handle schema evolution with different names

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -13,7 +13,7 @@
 
     <suppress
             checks="(CyclomaticComplexity)"
-            files="PartitionerConfig.java"
+            files="(PartitionerConfig|StorageSchemaCompatibility).java"
     />
 
     <suppress

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -48,5 +48,17 @@
             <artifactId>junit</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>${mockito-all.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.easymock</groupId>
+            <artifactId>easymock</artifactId>
+            <version>${easymock.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/core/src/main/java/io/confluent/connect/storage/schema/StorageSchemaCompatibility.java
+++ b/core/src/main/java/io/confluent/connect/storage/schema/StorageSchemaCompatibility.java
@@ -24,9 +24,13 @@ import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.source.SourceRecord;
 
 import java.util.AbstractMap;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.Set;
 
 public enum StorageSchemaCompatibility implements SchemaCompatibility {
   NONE {
@@ -48,6 +52,17 @@ public enum StorageSchemaCompatibility implements SchemaCompatibility {
       return record;
     }
 
+    /**
+     * Check whether the two schemas are incompatible such that they would prevent successfully
+     * {@link #project projecting} a key or value with the original schema into the current schema.
+     *
+     * <p>This method currently considers schemas to be compatible if and only they are
+     * {@link Schema#equals(Object) equal}. Otherwise, the schemas are deemed incompatible.
+     *
+     * @param originalSchema the original (new) schema; may not be null
+     * @param currentSchema  the current schema; may not be null
+     * @return true if the schemas are equals, or false if they are not equal
+     */
     @Override
     protected boolean check(
         Schema originalSchema,
@@ -58,8 +73,22 @@ public enum StorageSchemaCompatibility implements SchemaCompatibility {
   },
   BACKWARD,
   FORWARD {
+    /**
+     * Check whether the two schemas have incompatible versions that prevent successfully
+     * {@link #project projecting} a key or value with the original schema into the current schema.
+     *
+     * <p>This method will consider schemas compatible for projection if the original schema's
+     * {@link Schema#version() version} is less than or equal to the current schema's version.
+     * IOW, if the original schema has an <em>older</em> version than the current schema, the
+     * schemas will be incompatible.
+     *
+     * @param originalSchema the original (new) schema; may not be null
+     * @param currentSchema  the current schema; may not b enull
+     * @return true if the schema versions are not compatible for projection, or false if they are
+     *         compatible
+     */
     @Override
-    protected boolean check(
+    protected boolean checkVersions(
         Schema originalSchema,
         Schema currentSchema
     ) {
@@ -69,11 +98,28 @@ public enum StorageSchemaCompatibility implements SchemaCompatibility {
   FULL;
 
   private static final Map<String, StorageSchemaCompatibility> REVERSE = new HashMap<>();
+  private static final Set<SimpleImmutableEntry<Schema.Type, Schema.Type>> PROMOTABLES;
 
   static {
     for (StorageSchemaCompatibility compat : values()) {
       REVERSE.put(compat.name(), compat);
     }
+
+    Schema.Type[] promotableTypes = new Schema.Type[]{
+        Schema.Type.INT8,
+        Schema.Type.INT16,
+        Schema.Type.INT32,
+        Schema.Type.INT64,
+        Schema.Type.FLOAT32,
+        Schema.Type.FLOAT64
+    };
+    Set<SimpleImmutableEntry<Schema.Type, Schema.Type>> entries = new HashSet<>();
+    for (int i = 0; i < promotableTypes.length; ++i) {
+      for (int j = i; j < promotableTypes.length; ++j) {
+        entries.add(new AbstractMap.SimpleImmutableEntry<>(promotableTypes[i], promotableTypes[j]));
+      }
+    }
+    PROMOTABLES = Collections.unmodifiableSet(entries);
   }
 
   public static StorageSchemaCompatibility getCompatibility(String name) {
@@ -81,11 +127,23 @@ public enum StorageSchemaCompatibility implements SchemaCompatibility {
     return compat != null ? compat : StorageSchemaCompatibility.NONE;
   }
 
+  /**
+   * Check whether the two schemas have incompatible such that a value using the supplied value
+   * schema could not be successfully {@link #project projected} to the specified current schema.
+   *
+   * @param valueSchema   the schema of the value to be projected; may not be null
+   * @param currentSchema the current schema; may not b enull
+   * @return true if the schema versions are not compatible for projection, or false if they are
+   *         compatible
+   */
   protected boolean validateAndCheck(
       Schema valueSchema,
       Schema currentSchema
   ) {
     if (currentSchema == null && valueSchema == null) {
+      return false;
+    }
+    if (currentSchema == valueSchema) {
       return false;
     }
 
@@ -105,13 +163,156 @@ public enum StorageSchemaCompatibility implements SchemaCompatibility {
     return check(valueSchema, currentSchema);
   }
 
+  /**
+   * Check whether the two schemas are incompatible such that they would prevent successfully
+   * {@link #project projecting} a key or value with the original schema into the current schema.
+   *
+   * <p>This method currently considers schemas to be incompatible for projection when any of
+   * the following are true:
+   * <ol>
+   *   <li>The {@link Schema#type() Schema types} are different, per
+   *       {@link #checkSchemaTypes(Schema, Schema)}</li>
+   *   <li>The {@link Schema#name() Schema names} are different, per
+   *       {@link #checkSchemaNames(Schema, Schema)}</li>
+   *   <li>The {@link Schema#parameters() Schema parameters} are different, per
+   *       {@link #checkSchemaParameters(Schema, Schema)}</li>
+   *   <li>The {@link Schema#version() Schema versions} don't allow projection, per
+   *       {@link #checkSchemaTypes(Schema, Schema)}</li>
+   * </ol>
+   * In all of these cases, a record key or value using the original schema will not be able to
+   * be projected to the current schema.
+   *
+   * <p>Any of the `check*` methods can be overridden to change the individual behavior,
+   * or this method can be overridden to alter the logic described above.</p>
+   *
+   * @param originalSchema the original (new) schema; may not be null
+   * @param currentSchema  the current schema; may not be null
+   * @return true if the schema versions are not compatible for projection, or false if they are
+   *         compatible
+   */
   protected boolean check(
+      Schema originalSchema,
+      Schema currentSchema
+  ) {
+    if (checkSchemaTypes(originalSchema, currentSchema)) {
+      return true;
+    }
+    if (checkSchemaNames(originalSchema, currentSchema)) {
+      return true;
+    }
+    if (checkSchemaParameters(originalSchema, currentSchema)) {
+      return true;
+    }
+
+    return checkVersions(originalSchema, currentSchema);
+  }
+
+  /**
+   * Check whether the two schemas have incompatible versions that prevent successfully
+   * {@link #project projecting} a key or value with the original schema into the current schema.
+   *
+   * <p>This method will consider schemas compatible for projection if the original schema's
+   * {@link Schema#version() version} is less than or equal to the current schema's version.
+   * IOW, if the original schema has a <em>newer</em> version than the current schema, the schemas
+   * will be incompatible.
+   *
+   * @param originalSchema the original (new) schema; may not be null
+   * @param currentSchema  the current schema; may not b enull
+   * @return true if the schema versions are not compatible for projection, or false if they are
+   *         compatible
+   */
+  protected boolean checkVersions(
       Schema originalSchema,
       Schema currentSchema
   ) {
     return originalSchema.version().compareTo(currentSchema.version()) > 0;
   }
 
+  /**
+   * Check whether the two schemas have incompatible names that prevent successfully
+   * {@link #project projecting} a key or value with the original schema into the current schema.
+   *
+   * @param originalSchema the original (new) schema; may not be null
+   * @param currentSchema  the current schema; may not b enull
+   * @return true if the schema types are not compatible for projection, or false if they are
+   *         compatible
+   */
+  protected boolean checkSchemaTypes(
+      Schema originalSchema,
+      Schema currentSchema
+  ) {
+    return originalSchema.type() != currentSchema.type()
+        && !isPromotable(originalSchema.type(), currentSchema.type());
+  }
+
+  /**
+   * Check whether the two schemas have incompatible names that prevent successfully
+   * {@link #project projecting} a key or value with the original schema into the current schema.
+   *
+   * @param originalSchema the original (new) schema; may not be null
+   * @param currentSchema  the current schema; may not be null
+   * @return true if the schema names are not compatible for projection, or false if they are
+   *         compatible
+   */
+  protected boolean checkSchemaNames(
+      Schema originalSchema,
+      Schema currentSchema
+  ) {
+    return !Objects.equals(originalSchema.name(), currentSchema.name());
+  }
+
+  /**
+   * Check whether the two schemas have incompatible {@ink Schema#parameters() parameters} that
+   * prevent successfully {@link #project projecting} a key or value with the original schema
+   * into the current schema.
+   *
+   * @param originalSchema the original (new) schema; may not be null
+   * @param currentSchema  the current schema; may not b enull
+   * @return true if the schema parameters are not compatible for projection, or false if they are
+   *         compatible
+   */
+  protected boolean checkSchemaParameters(
+      Schema originalSchema,
+      Schema currentSchema
+  ) {
+    return !Objects.equals(originalSchema.parameters(), currentSchema.parameters());
+  }
+
+  protected boolean isPromotable(Schema.Type sourceType, Schema.Type targetType) {
+    return PROMOTABLES.contains(new AbstractMap.SimpleImmutableEntry<>(sourceType, targetType));
+  }
+
+  /**
+   * Determine whether the current key and value schemas should be changed given the current
+   * record.
+   *
+   * <p>This method will return false if the supplied record could be projected to the current
+   * schemas using {@link #project(SinkRecord, Schema, Schema)} or
+   * {@link #project(SourceRecord, Schema, Schema)}. Those methods currently require the
+   * following to be true when comparing the current key schema and record key schema (if
+   * provided) and when comparing the current value schema and record value schema
+   * (and recursively for any contained schemas within fields), which means this method returns
+   * true if any of these conditions are true.
+   *
+   * <ul>
+   *   <li>The {@link Schema#type() schema types} are equivalent or can be promoted (e.g., are
+   *   both numeric types).</li>
+   *   <li>The {@link Schema#name() schema names} are equivalent.</li>
+   *   <li>The {@link Schema#parameters() schema parameters} are equivalent.</li>
+   *   <li>The current schema has a default if it is not {@link Schema#isOptional() optional}
+   *       but the record schema is optional.</li>
+   *   <li>For {@link Schema.Type#STRUCT} schemas, each field in the current schema either
+   *   corresponds to an existing field in the record schema, or that field in the current schema
+   *   is optional or has a default value.</li>
+   * </ul>
+   *
+   * @param record             the next record; may not be null
+   * @param currentKeySchema   the current key schema; may be null
+   * @param currentValueSchema the current value schema; may be null
+   * @return true if the key or value schema in the supplied record has changed such that it cannot
+   *         be projected to the current key schema and value schema, or false if the record can
+   *         be projected
+   */
   public boolean shouldChangeSchema(
       ConnectRecord<?> record,
       Schema currentKeySchema,

--- a/core/src/test/java/io/confluent/connect/storage/schema/StorageSchemaCompatibilityTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/schema/StorageSchemaCompatibilityTest.java
@@ -1,0 +1,432 @@
+/*
+ * Copyright [2018 - 2018] Confluent Inc.
+ */
+
+package io.confluent.connect.storage.schema;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class StorageSchemaCompatibilityTest {
+
+  private final StorageSchemaCompatibility none = StorageSchemaCompatibility.NONE;
+  private final StorageSchemaCompatibility backward = StorageSchemaCompatibility.BACKWARD;
+  private final StorageSchemaCompatibility forward = StorageSchemaCompatibility.FORWARD;
+  private final StorageSchemaCompatibility full = StorageSchemaCompatibility.FULL;
+
+  private static SchemaBuilder buildStringSchema(String name, int version) {
+    return SchemaBuilder.string()
+                        .version(version)
+                        .name(name);
+  }
+
+  private static SchemaBuilder buildIntSchema(String name, int version) {
+    return SchemaBuilder.int32()
+                        .version(version)
+                        .name(name);
+  }
+
+  private static final Schema SCHEMA_A =
+      buildIntSchema("a", 2).build();
+  private static final Schema SCHEMA_A_COPY =
+      buildIntSchema("a", 2).build();
+  private static final Schema SCHEMA_A_RENAMED =
+      buildIntSchema("b", 2).build();
+  private static final Schema SCHEMA_A_OPTIONAL =
+      buildIntSchema("a", 2).optional().build();
+  private static final Schema SCHEMA_A_OLDER_VERSION =
+      buildIntSchema("a", 1).build();
+  private static final Schema SCHEMA_A_NEWER_VERSION =
+      buildIntSchema("a", 3).build();
+  private static final Schema SCHEMA_A_PARAMETERED =
+      buildIntSchema("a", 2).parameter("x", "y").build();
+  private static final Schema SCHEMA_A_RETYPED =
+      buildStringSchema("a", 1).build();
+  private static final Schema SCHEMA_A_WITH_DOC =
+      buildIntSchema("a", 2).doc("doc").build();
+
+  private static SchemaBuilder buildStructSchema(String name, int version) {
+    return SchemaBuilder.struct()
+                        .name(name)
+                        .version(version)
+                        .field("b", Schema.BOOLEAN_SCHEMA)
+                        .field("i", Schema.INT32_SCHEMA)
+                        .field("d", Schema.FLOAT64_SCHEMA)
+                        .field("s", Schema.OPTIONAL_STRING_SCHEMA)
+                        .field(
+                            "x",
+                            SchemaBuilder.struct()
+                                         .field("inner1", Schema.BOOLEAN_SCHEMA)
+                                         .build()
+                        );
+  }
+
+  private static final Schema SCHEMA_B =
+      buildStructSchema("b", 2).build();
+  private static final Schema SCHEMA_B_COPY =
+      buildStructSchema("b", 2).build();
+  private static final Schema SCHEMA_B_RENAMED =
+      buildStructSchema("c", 2).build();
+  private static final Schema SCHEMA_B_OPTIONAL =
+      buildStructSchema("b", 2).optional().build();
+  private static final Schema SCHEMA_B_OLDER_VERSION =
+      buildStructSchema("b", 1).build();
+  private static final Schema SCHEMA_B_NEWER_VERSION =
+      buildStructSchema("b", 3).build();
+  private static final Schema SCHEMA_B_PARAMETERED =
+      buildStructSchema("b", 2).parameter("x", "y").build();
+  private static final Schema SCHEMA_B_RETYPED =
+      buildStringSchema("b", 2).build();
+  private static final Schema SCHEMA_B_WITH_DOC =
+      buildStructSchema("b", 2).doc("doc").build();
+  private static final Schema SCHEMA_B_EXTRA_REQUIRED_FIELD =
+      buildStructSchema("b", 2).field("extra", Schema.STRING_SCHEMA).build();
+  private static final Schema SCHEMA_B_EXTRA_OPTIONAL_FIELD =
+      buildStructSchema("b", 2).field("extra", Schema.OPTIONAL_STRING_SCHEMA).build();
+
+
+  @Test
+  public void noneCompatibilityShouldConsiderSameVersionsAsUnchanged() {
+    assertUnchanged(none, SCHEMA_A, SCHEMA_A_COPY);
+    assertUnchanged(none, SCHEMA_B, SCHEMA_B_COPY);
+  }
+
+  @Test
+  public void noneCompatibilityShouldConsiderDifferentVersionsAsChanged() {
+    assertChanged(none, SCHEMA_A, SCHEMA_A_NEWER_VERSION);
+    assertChanged(none, SCHEMA_A, SCHEMA_A_OLDER_VERSION);
+    assertChanged(none, SCHEMA_B, SCHEMA_B_OLDER_VERSION);
+    assertChanged(none, SCHEMA_B, SCHEMA_B_PARAMETERED);
+  }
+
+  @Test
+  public void noneCompatibilityShouldConsiderAnyDifferencesAsChanged() {
+    assertChanged(none, SCHEMA_A, SCHEMA_A_RENAMED);
+    assertChanged(none, SCHEMA_A, SCHEMA_A_RETYPED);
+    assertChanged(none, SCHEMA_A, SCHEMA_A_PARAMETERED);
+    assertChanged(none, SCHEMA_A, SCHEMA_A_WITH_DOC);
+    assertChanged(none, SCHEMA_A, SCHEMA_A_OPTIONAL);
+
+    assertChanged(none, SCHEMA_B, SCHEMA_B_RENAMED);
+    assertChanged(none, SCHEMA_B, SCHEMA_B_RETYPED);
+    assertChanged(none, SCHEMA_B, SCHEMA_B_PARAMETERED);
+    assertChanged(none, SCHEMA_B, SCHEMA_B_WITH_DOC);
+    assertChanged(none, SCHEMA_B, SCHEMA_B_OPTIONAL);
+    assertChanged(none, SCHEMA_B, SCHEMA_B_EXTRA_REQUIRED_FIELD);
+    assertChanged(none, SCHEMA_B, SCHEMA_B_EXTRA_OPTIONAL_FIELD);
+
+    assertUnchanged(none, SCHEMA_A, SCHEMA_A);
+    assertUnchanged(none, SCHEMA_A, SCHEMA_A_COPY);
+    assertUnchanged(none, SCHEMA_B, SCHEMA_B);
+    assertUnchanged(none, SCHEMA_B, SCHEMA_B_COPY);
+  }
+
+  @Test
+  public void backwardCompatibilityShouldConsiderOlderSchemaVersionsAsChanged() {
+    assertChanged(backward, SCHEMA_A, SCHEMA_A_OLDER_VERSION);
+    assertChanged(backward, SCHEMA_B, SCHEMA_B_OLDER_VERSION);
+  }
+
+  @Test
+  public void backwardCompatibilityShouldConsiderSameOrNewerSchemaVersionsAsUnchanged() {
+    assertUnchanged(backward, SCHEMA_A, SCHEMA_A_COPY);
+    assertUnchanged(backward, SCHEMA_B, SCHEMA_B_COPY);
+    assertUnchanged(backward, SCHEMA_A, SCHEMA_A_NEWER_VERSION);
+    assertUnchanged(backward, SCHEMA_B, SCHEMA_B_NEWER_VERSION);
+  }
+
+  @Test
+  public void forwardCompatibilityShouldConsiderNewerSchemaVersionsAsChanged() {
+    assertChanged(forward, SCHEMA_A, SCHEMA_A_NEWER_VERSION);
+    assertChanged(forward, SCHEMA_B, SCHEMA_B_NEWER_VERSION);
+  }
+
+  @Test
+  public void forwardCompatibilityShouldConsiderSameOrOlderSchemaVersionsAsUnchanged() {
+    assertUnchanged(forward, SCHEMA_A, SCHEMA_A_COPY);
+    assertUnchanged(forward, SCHEMA_B, SCHEMA_B_COPY);
+    assertUnchanged(forward, SCHEMA_A, SCHEMA_A_OLDER_VERSION);
+    assertUnchanged(forward, SCHEMA_B, SCHEMA_B_OLDER_VERSION);
+  }
+
+  @Test
+  public void fullCompatibilityShouldConsiderOlderSchemaVersionsAsChanged() {
+    assertChanged(full, SCHEMA_A, SCHEMA_A_OLDER_VERSION);
+    assertChanged(full, SCHEMA_B, SCHEMA_B_OLDER_VERSION);
+  }
+
+  @Test
+  public void fullCompatibilityShouldConsiderSameOrNewerSchemaVersionsAsUnchanged() {
+    assertUnchanged(full, SCHEMA_A, SCHEMA_A_COPY);
+    assertUnchanged(full, SCHEMA_B, SCHEMA_B_COPY);
+    assertUnchanged(full, SCHEMA_A, SCHEMA_A_NEWER_VERSION);
+    assertUnchanged(full, SCHEMA_B, SCHEMA_B_NEWER_VERSION);
+  }
+
+  @Test
+  public void allCompatibilitiesShouldConsiderSameOrEqualSchemasAsUnchanged() {
+    assertUnchanged(none, SCHEMA_A, SCHEMA_A);
+    assertUnchanged(none, SCHEMA_A, SCHEMA_A_COPY);
+    assertUnchanged(none, SCHEMA_B, SCHEMA_B);
+    assertUnchanged(none, SCHEMA_B, SCHEMA_B_COPY);
+
+    assertUnchanged(backward, SCHEMA_A, SCHEMA_A);
+    assertUnchanged(backward, SCHEMA_A, SCHEMA_A_COPY);
+    assertUnchanged(backward, SCHEMA_B, SCHEMA_B);
+    assertUnchanged(backward, SCHEMA_B, SCHEMA_B_COPY);
+
+    assertUnchanged(forward, SCHEMA_A, SCHEMA_A);
+    assertUnchanged(forward, SCHEMA_A, SCHEMA_A_COPY);
+    assertUnchanged(forward, SCHEMA_B, SCHEMA_B);
+    assertUnchanged(forward, SCHEMA_B, SCHEMA_B_COPY);
+
+    assertUnchanged(full, SCHEMA_A, SCHEMA_A);
+    assertUnchanged(full, SCHEMA_A, SCHEMA_A_COPY);
+    assertUnchanged(full, SCHEMA_B, SCHEMA_B);
+    assertUnchanged(full, SCHEMA_B, SCHEMA_B_COPY);
+  }
+
+  @Test
+  public void allCompatibilitiesShouldConsiderDifferentSchemaNamesAsChanged() {
+    assertChanged(none, SCHEMA_A, SCHEMA_A_RENAMED);
+    assertChanged(backward, SCHEMA_A, SCHEMA_A_RENAMED);
+    assertChanged(forward, SCHEMA_A, SCHEMA_A_RENAMED);
+    assertChanged(full, SCHEMA_A, SCHEMA_A_RENAMED);
+
+    assertChanged(none, SCHEMA_B, SCHEMA_B_RENAMED);
+    assertChanged(backward, SCHEMA_B, SCHEMA_B_RENAMED);
+    assertChanged(forward, SCHEMA_B, SCHEMA_B_RENAMED);
+    assertChanged(full, SCHEMA_B, SCHEMA_B_RENAMED);
+  }
+
+  @Test
+  public void allCompatibilitiesShouldConsiderDifferentSchemaTypesAsChanged() {
+    assertChanged(none, SCHEMA_A, SCHEMA_A_RETYPED);
+    assertChanged(backward, SCHEMA_A, SCHEMA_A_RETYPED);
+    assertChanged(forward, SCHEMA_A, SCHEMA_A_RETYPED);
+    assertChanged(full, SCHEMA_A, SCHEMA_A_RETYPED);
+
+    assertChanged(none, SCHEMA_B, SCHEMA_B_RETYPED);
+    assertChanged(backward, SCHEMA_B, SCHEMA_B_RETYPED);
+    assertChanged(forward, SCHEMA_B, SCHEMA_B_RETYPED);
+    assertChanged(full, SCHEMA_B, SCHEMA_B_RETYPED);
+  }
+
+  @Test
+  public void allCompatibilitiesShouldConsiderDifferentSchemaParametersAsChanged() {
+    assertChanged(none, SCHEMA_A, SCHEMA_A_PARAMETERED);
+    assertChanged(backward, SCHEMA_A, SCHEMA_A_PARAMETERED);
+    assertChanged(forward, SCHEMA_A, SCHEMA_A_PARAMETERED);
+    assertChanged(full, SCHEMA_A, SCHEMA_A_PARAMETERED);
+
+    assertChanged(none, SCHEMA_B, SCHEMA_B_PARAMETERED);
+    assertChanged(backward, SCHEMA_B, SCHEMA_B_PARAMETERED);
+    assertChanged(forward, SCHEMA_B, SCHEMA_B_PARAMETERED);
+    assertChanged(full, SCHEMA_B, SCHEMA_B_PARAMETERED);
+  }
+
+  @Test
+  public void backwardCompatibilityShouldConsiderDifferentSchemaDocsAsUnchanged() {
+    assertUnchanged(backward, SCHEMA_A, SCHEMA_A_WITH_DOC);
+    assertUnchanged(backward, SCHEMA_B, SCHEMA_B_WITH_DOC);
+  }
+
+  @Test
+  public void forwardCompatibilityShouldConsiderDifferentSchemaDocsAsUnchanged() {
+    assertUnchanged(forward, SCHEMA_A, SCHEMA_A_WITH_DOC);
+    assertUnchanged(forward, SCHEMA_B, SCHEMA_B_WITH_DOC);
+  }
+
+  @Test
+  public void fullCompatibilityShouldConsiderDifferentSchemaDocsAsUnchanged() {
+    assertUnchanged(full, SCHEMA_A, SCHEMA_A_WITH_DOC);
+    assertUnchanged(full, SCHEMA_B, SCHEMA_B_WITH_DOC);
+  }
+
+  @Test
+  public void backwardCompatibilityShouldConsiderDifferentSchemaOptionalityAsUnchanged() {
+    assertUnchanged(backward, SCHEMA_A, SCHEMA_A_OPTIONAL);
+    assertUnchanged(backward, SCHEMA_B, SCHEMA_B_OPTIONAL);
+  }
+
+  @Test
+  public void forwardCompatibilityShouldConsiderDifferentSchemaOptionalityAsUnchanged() {
+    assertUnchanged(forward, SCHEMA_A, SCHEMA_A_OPTIONAL);
+    assertUnchanged(forward, SCHEMA_B, SCHEMA_B_OPTIONAL);
+  }
+
+  @Test
+  public void fullCompatibilityShouldConsiderDifferentSchemaOptionalityAsUnchanged() {
+    assertUnchanged(full, SCHEMA_A, SCHEMA_A_OPTIONAL);
+    assertUnchanged(full, SCHEMA_B, SCHEMA_B_OPTIONAL);
+
+  }
+
+  @Test
+  public void backwardCompatibilityShouldConsiderDifferentFieldsAsUnchanged() {
+    assertUnchanged(backward, SCHEMA_B, SCHEMA_B_EXTRA_OPTIONAL_FIELD);
+    assertUnchanged(backward, SCHEMA_B_EXTRA_OPTIONAL_FIELD, SCHEMA_B);
+    assertUnchanged(backward, SCHEMA_B_EXTRA_REQUIRED_FIELD, SCHEMA_B);
+  }
+
+  @Test
+  public void forwardCompatibilityShouldConsiderDifferentFieldsAsUnchanged() {
+    assertUnchanged(forward, SCHEMA_B, SCHEMA_B_EXTRA_OPTIONAL_FIELD);
+    assertUnchanged(forward, SCHEMA_B_EXTRA_OPTIONAL_FIELD, SCHEMA_B);
+    assertUnchanged(forward, SCHEMA_B_EXTRA_REQUIRED_FIELD, SCHEMA_B);
+  }
+
+  @Test
+  public void fullCompatibilityShouldConsiderDifferentFieldsAsUnchanged() {
+    assertUnchanged(full, SCHEMA_B, SCHEMA_B_EXTRA_OPTIONAL_FIELD);
+    assertUnchanged(full, SCHEMA_B_EXTRA_OPTIONAL_FIELD, SCHEMA_B);
+    assertUnchanged(full, SCHEMA_B_EXTRA_REQUIRED_FIELD, SCHEMA_B);
+  }
+
+  @Test
+  public void allCompatibilitiesShouldConsiderExtraRequiredFieldsAsUnchangedButNotProjectable() {
+    // The following are considered unchanged, but we cannot project from first to second.
+    // The projection should catch this case if it happens, but SR should prevent records
+    // being written to the topic if using Avro and `forward` SR compatibility is enabled
+    assertUnchanged(backward, SCHEMA_B, SCHEMA_B_EXTRA_REQUIRED_FIELD, false);
+    assertUnchanged(forward, SCHEMA_B, SCHEMA_B_EXTRA_REQUIRED_FIELD, false);
+    assertUnchanged(full, SCHEMA_B, SCHEMA_B_EXTRA_REQUIRED_FIELD, false);
+  }
+
+  protected void assertUnchanged(
+      StorageSchemaCompatibility compatibility,
+      Schema recordSchema,
+      Schema currentSchema
+  ) {
+    assertUnchanged(compatibility, recordSchema, currentSchema, true);
+  }
+
+  protected void assertUnchanged(
+      StorageSchemaCompatibility compatibility,
+      Schema recordSchema,
+      Schema currentSchema,
+      boolean isProjectable
+  ) {
+    assertFalse(
+        "Expected " + currentSchema + " to not be change in order to project " + recordSchema,
+        compatibility.validateAndCheck(recordSchema, currentSchema)
+    );
+    assertProjectable(compatibility, recordSchema, currentSchema, isProjectable);
+  }
+
+  protected void assertChanged(
+      StorageSchemaCompatibility compatibility,
+      Schema recordSchema,
+      Schema currentSchema
+  ) {
+    assertTrue(
+        "Expected " + currentSchema + " to change in order to project " + recordSchema,
+        compatibility.validateAndCheck(recordSchema, currentSchema)
+    );
+    // we don't care whether the schema are able to be projected
+  }
+
+  protected void assertProjectable(
+      StorageSchemaCompatibility compatibility,
+      Schema recordSchema,
+      Schema currentSchema,
+      boolean isProjectable
+  ) {
+    if (isProjectable) {
+      // verify that the schema can be projected
+      compatibility.project(sinkRecordWith(recordSchema), null, currentSchema);
+      compatibility.project(sourceRecordWith(recordSchema), null, currentSchema);
+    } else {
+      try {
+        compatibility.project(sinkRecordWith(recordSchema), null, currentSchema);
+        fail(
+            "Expected " + recordSchema + " to not be able to be projected to " + currentSchema
+            );
+      } catch (ConnectException e) {
+        // expected
+      }
+      try {
+        compatibility.project(sourceRecordWith(recordSchema), null, currentSchema);
+        fail(
+            "Expected " + recordSchema + " to not be able to be projected to " + currentSchema
+            );
+      } catch (ConnectException e) {
+        // expected
+      }
+    }
+  }
+
+  protected SinkRecord sinkRecordWith(Schema valueSchema) {
+    return new SinkRecord(
+        "topic",
+        0,
+        null,
+        null,
+        valueSchema,
+        valueFor(valueSchema),
+        0
+    );
+  }
+
+  protected SourceRecord sourceRecordWith(Schema valueSchema) {
+    Map<String, ?> empty = Collections.emptyMap();
+    return new SourceRecord(
+        empty,
+        empty,
+        "topic",
+        null,
+        null,
+        valueSchema,
+        valueFor(valueSchema)
+    );
+  }
+
+  protected Object valueFor(Schema schema) {
+    switch (schema.type()) {
+      case INT8:
+        return (byte) 100;
+      case INT16:
+        return (short) 100;
+      case INT32:
+        return 100;
+      case INT64:
+        return 100L;
+      case FLOAT32:
+        return 101.1;
+      case FLOAT64:
+        return 101.2d;
+      case ARRAY:
+        return new ArrayList<>();
+      case MAP:
+        return new HashMap<>();
+      case BOOLEAN:
+        return true;
+      case BYTES:
+        return "hello".getBytes(StandardCharsets.UTF_8);
+      case STRING:
+        return "hello";
+      case STRUCT:
+        Struct struct = new Struct(schema);
+        for (Field field : schema.fields()) {
+          struct.put(field, valueFor(field.schema()));
+        }
+        return struct;
+    }
+    return null;
+  }
+
+}


### PR DESCRIPTION
Added additional checks to `StorageSchemaCompatibility.shouldChangeSchema(…)` so that this method considers not only the versions but also considers a schema as having changed when the name is changed, the types are different (but not projectable), or the parameters are changed. This makes this logic more compatible with the `project(…)` methods on the same enumeration used to project a record into the schema used in a file with lots of records.

Thus, connectors that use this will effectively rotate whenever such schema evolution occurs and projection (using Connect’s SchemaProjector) would not work successfully. Most users don’t have this kind of schema evolution, and thus would see no change in behavior. And users that do have this kind of schema evolution likely do so infrequently.

This change is still compatible with Schema Registry and Avro’s schema compatiblity behavior. In particular, Avro allows schemas to have different names and namespaces as long as the field requirements are still satisfied. So when a user is using SR and backward, forward, or full compatbility, SR and the Avro serializer will not prevent writing a record with an evolved schema. With this change, the records on a topic consumed by a connector using this class will consider the evolved schema as “changed”, and the connector will rotate its file by closing it, creating a new one, and writing the record with the new schema to the new file.

Quite a few unit tests were added to verify the StorageSchemaCompatibility behaviors, including the new behavior.

This PR backports this change to 4.0.x, since it is really a bugfix rather than an enhancement. Users that don't evolve their schemas to have different names or parameters will see no changes in behavior, as the old checks using version will still be performed. However, users that do evolve their schemas to have different names/namespaces will likely do so infrequently and thus will see the extra rotations infrequently.