### PR TITLE
CC-147: logical types support for HiveSchemaConverter

### DIFF
--- a/hive/src/main/java/io/confluent/connect/storage/hive/HiveConfig.java
+++ b/hive/src/main/java/io/confluent/connect/storage/hive/HiveConfig.java
@@ -69,6 +69,16 @@ public class HiveConfig extends AbstractConfig implements ComposableConfig {
   public static final String SCHEMA_COMPATIBILITY_DEFAULT = "NONE";
   public static final String SCHEMA_COMPATIBILITY_DISPLAY = "Schema Compatibility";
 
+  //Logical type handling group
+  public static final String HIVE_LOGICAL_TYPES_ENABLED_CONFIG = "hive.logical.types.enabled";
+  public static final String HIVE_LOGICAL_TYPES_ENABLED_DOC = "Whether enable hive logical types:"
+      + "DECIMAL, DATE, INTERVAL, TIMESTAMP."
+      + "Please be noted that some of the logical types are not available "
+      + "in earlier versions of Hive. Better to disable hive logical type"
+      + "if using these earlier versions";
+  public static final boolean HIVE_LOGICAL_TYPES_ENABLED_DEFAULT = false;
+  public static final String HIVE_LOGICAL_TYPES_ENABLED_DISPLAY = "Enable Hive Logical Types";
+
   // CHECKSTYLE:OFF
   public static final ConfigDef.Recommender hiveIntegrationDependentsRecommender =
       new BooleanParentRecommender(HIVE_INTEGRATION_CONFIG);
@@ -173,6 +183,25 @@ public class HiveConfig extends AbstractConfig implements ComposableConfig {
           Width.SHORT,
           SCHEMA_COMPATIBILITY_DISPLAY,
           schemaCompatibilityRecommender
+      );
+    }
+
+    {
+      // Define Logical type handling configuration group
+      final String group = "Logical type handling";
+      int orderInGroup = 0;
+
+      // Define Logical type handling configuration group
+      CONFIG_DEF.define(
+          HIVE_LOGICAL_TYPES_ENABLED_CONFIG,
+          Type.BOOLEAN,
+          HIVE_LOGICAL_TYPES_ENABLED_DEFAULT,
+          Importance.MEDIUM,
+          HIVE_LOGICAL_TYPES_ENABLED_DOC,
+          group,
+          ++orderInGroup,
+          Width.SHORT,
+          HIVE_LOGICAL_TYPES_ENABLED_DISPLAY
       );
     }
   }

--- a/hive/src/main/java/io/confluent/connect/storage/hive/HiveConfig.java
+++ b/hive/src/main/java/io/confluent/connect/storage/hive/HiveConfig.java
@@ -71,12 +71,15 @@ public class HiveConfig extends AbstractConfig implements ComposableConfig {
 
   //Logical type handling group
   public static final String HIVE_LOGICAL_TYPES_ENABLED_CONFIG = "hive.logical.types.enabled";
-  public static final String HIVE_LOGICAL_TYPES_ENABLED_DOC = "Whether enable hive logical types:"
-      + "DECIMAL, DATE, INTERVAL, TIMESTAMP."
-      + "Please be noted that some of the logical types are not available "
-      + "in earlier versions of Hive. Better to disable hive logical type"
-      + "if using these earlier versions";
-  public static final boolean HIVE_LOGICAL_TYPES_ENABLED_DEFAULT = false;
+  public static final String HIVE_LOGICAL_TYPES_ENABLED_DOC = "Whether to enable logical "
+      + "type conversion: \n"
+      + "Connect Decimal -> Hive DECIMAL \n "
+      + "Connect Date -> Hive DATE \n "
+      + "Connect Timestamp -> Hive TIMESTAMP \n"
+      + "Connect Time is not supported with current implementation of Hive Serde."
+      + "Beware that the 3 logical types above are not compatible with "
+      + "some older versions of Hive.";
+  public static final boolean HIVE_LOGICAL_TYPES_ENABLED_DEFAULT = true;
   public static final String HIVE_LOGICAL_TYPES_ENABLED_DISPLAY = "Enable Hive Logical Types";
 
   // CHECKSTYLE:OFF

--- a/hive/src/main/java/io/confluent/connect/storage/hive/HiveConfig.java
+++ b/hive/src/main/java/io/confluent/connect/storage/hive/HiveConfig.java
@@ -69,19 +69,6 @@ public class HiveConfig extends AbstractConfig implements ComposableConfig {
   public static final String SCHEMA_COMPATIBILITY_DEFAULT = "NONE";
   public static final String SCHEMA_COMPATIBILITY_DISPLAY = "Schema Compatibility";
 
-  //Logical type handling group
-  public static final String HIVE_LOGICAL_TYPES_ENABLED_CONFIG = "hive.logical.types.enabled";
-  public static final String HIVE_LOGICAL_TYPES_ENABLED_DOC = "Whether to enable logical "
-      + "type conversion: \n"
-      + "Connect Decimal -> Hive DECIMAL \n "
-      + "Connect Date -> Hive DATE \n "
-      + "Connect Timestamp -> Hive TIMESTAMP \n"
-      + "Connect Time is not supported with current implementation of Hive Serde."
-      + "Beware that the 3 logical types above are not compatible with "
-      + "some older versions of Hive.";
-  public static final boolean HIVE_LOGICAL_TYPES_ENABLED_DEFAULT = true;
-  public static final String HIVE_LOGICAL_TYPES_ENABLED_DISPLAY = "Enable Hive Logical Types";
-
   // CHECKSTYLE:OFF
   public static final ConfigDef.Recommender hiveIntegrationDependentsRecommender =
       new BooleanParentRecommender(HIVE_INTEGRATION_CONFIG);
@@ -186,25 +173,6 @@ public class HiveConfig extends AbstractConfig implements ComposableConfig {
           Width.SHORT,
           SCHEMA_COMPATIBILITY_DISPLAY,
           schemaCompatibilityRecommender
-      );
-    }
-
-    {
-      // Define Logical type handling configuration group
-      final String group = "Logical type handling";
-      int orderInGroup = 0;
-
-      // Define Logical type handling configuration group
-      CONFIG_DEF.define(
-          HIVE_LOGICAL_TYPES_ENABLED_CONFIG,
-          Type.BOOLEAN,
-          HIVE_LOGICAL_TYPES_ENABLED_DEFAULT,
-          Importance.MEDIUM,
-          HIVE_LOGICAL_TYPES_ENABLED_DOC,
-          group,
-          ++orderInGroup,
-          Width.SHORT,
-          HIVE_LOGICAL_TYPES_ENABLED_DISPLAY
       );
     }
   }

--- a/hive/src/main/java/io/confluent/connect/storage/hive/HiveSchemaConverter.java
+++ b/hive/src/main/java/io/confluent/connect/storage/hive/HiveSchemaConverter.java
@@ -140,7 +140,7 @@ public class HiveSchemaConverter {
       case Decimal.LOGICAL_NAME:
         String scale = schema.parameters().get(Decimal.SCALE_FIELD);
         String precision = schema.parameters().get(CONNECT_AVRO_DECIMAL_PRECISION_PROP);
-        if (precision == null || Integer.valueOf(precision) <= DECIMAL_PRECISION_DEFAULT) {
+        if (precision == null || Integer.parseInt(precision) <= DECIMAL_PRECISION_DEFAULT) {
           precision = String.valueOf(DECIMAL_PRECISION_DEFAULT);
         } else {
           throw new ConnectException("Illegal precision: "

--- a/hive/src/test/java/io/confluent/connect/storage/hive/HiveSchemaConverterTest.java
+++ b/hive/src/test/java/io/confluent/connect/storage/hive/HiveSchemaConverterTest.java
@@ -23,8 +23,9 @@ public class HiveSchemaConverterTest {
     assertEquals(TypeInfoFactory.dateTypeInfo,
         HiveSchemaConverter.convertPrimitiveMaybeLogical(dateSchema));
 
+    // logical type time is not supported by Hive serde, convert it to Hive INT
     Schema timeSchema = SchemaBuilder.int32().name(Time.LOGICAL_NAME).build();
-    assertEquals(TypeInfoFactory.intervalDayTimeTypeInfo,
+    assertEquals(TypeInfoFactory.intTypeInfo,
         HiveSchemaConverter.convertPrimitiveMaybeLogical(timeSchema));
 
     Schema timestampSchema = SchemaBuilder.int64().name(Timestamp.LOGICAL_NAME).build();
@@ -36,7 +37,7 @@ public class HiveSchemaConverterTest {
   public void convertPrimitiveMaybeLogicalDecimalValidTest() {
     Map<String, String> props1 = new HashMap<>();
     String someScale = "2";
-    String validPrecision1 = "38";
+    String validPrecision1 = String.valueOf(HiveSchemaConverter.HIVE_DECIMAL_PRECISION_MAX);
     props1.put(Decimal.SCALE_FIELD, someScale);
     props1.put(HiveSchemaConverter.CONNECT_AVRO_DECIMAL_PRECISION_PROP, validPrecision1);
     Schema decimalSchema1 = SchemaBuilder.bytes()
@@ -61,7 +62,7 @@ public class HiveSchemaConverterTest {
         HiveSchemaConverter.convertPrimitiveMaybeLogical(decimalSchema1));
 
     // precision in decimalSchema2 is 10, but our schema converter will still convert it to
-    // the maximum value, 38.
+    // the maximum value, HiveSchemaConverter.HIVE_DECIMAL_PRECISION_MAX.
 
     assertEquals(new DecimalTypeInfo(Integer.parseInt(precision), Integer.parseInt(scale)),
         HiveSchemaConverter.convertPrimitiveMaybeLogical(decimalSchema2));
@@ -77,7 +78,7 @@ public class HiveSchemaConverterTest {
         .build();
 
     assertEquals(
-        new DecimalTypeInfo(HiveSchemaConverter.DECIMAL_PRECISION_DEFAULT, Integer.parseInt(someScale)),
+        new DecimalTypeInfo(HiveSchemaConverter.HIVE_DECIMAL_PRECISION_MAX, Integer.parseInt(someScale)),
         HiveSchemaConverter.convertPrimitiveMaybeLogical(decimalSchema));
   }
 
@@ -85,7 +86,7 @@ public class HiveSchemaConverterTest {
   public void convertPrimitiveMaybeLogicalDecimalInvalidPrecisionTest() {
     Map<String, String> props = new HashMap<>();
     String someScale = "2";
-    String invalidPrecision = "39";
+    String invalidPrecision = String.valueOf(HiveSchemaConverter.HIVE_DECIMAL_PRECISION_MAX + 1);
     props.put(Decimal.SCALE_FIELD, someScale);
     props.put(HiveSchemaConverter.CONNECT_AVRO_DECIMAL_PRECISION_PROP, invalidPrecision);
 
@@ -101,7 +102,7 @@ public class HiveSchemaConverterTest {
   public void convertPrimitiveMaybeLogicalNotLogicalTest() {
     Map<String, String> props = new HashMap<>();
     String someScale = "2";
-    String validPrecision = "38";
+    String validPrecision = String.valueOf(HiveSchemaConverter.HIVE_DECIMAL_PRECISION_MAX);
     props.put(Decimal.SCALE_FIELD, someScale);
     props.put(HiveSchemaConverter.CONNECT_AVRO_DECIMAL_PRECISION_PROP, validPrecision);
 

--- a/hive/src/test/java/io/confluent/connect/storage/hive/HiveSchemaConverterTest.java
+++ b/hive/src/test/java/io/confluent/connect/storage/hive/HiveSchemaConverterTest.java
@@ -1,0 +1,116 @@
+package io.confluent.connect.storage.hive;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.kafka.connect.data.Date;
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Time;
+import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.junit.Test;
+
+public class HiveSchemaConverterTest {
+  @Test
+  public void convertPrimitiveMaybeLogicalAllExceptDecimalTest() {
+
+    Schema dateSchema = SchemaBuilder.int32().name(Date.LOGICAL_NAME).build();
+    assertEquals(TypeInfoFactory.dateTypeInfo,
+        HiveSchemaConverter.convertPrimitiveMaybeLogical(dateSchema));
+
+    Schema timeSchema = SchemaBuilder.int32().name(Time.LOGICAL_NAME).build();
+    assertEquals(TypeInfoFactory.intervalDayTimeTypeInfo,
+        HiveSchemaConverter.convertPrimitiveMaybeLogical(timeSchema));
+
+    Schema timestampSchema = SchemaBuilder.int64().name(Timestamp.LOGICAL_NAME).build();
+    assertEquals(TypeInfoFactory.timestampTypeInfo,
+        HiveSchemaConverter.convertPrimitiveMaybeLogical(timestampSchema));
+  }
+
+  @Test
+  public void convertPrimitiveMaybeLogicalDecimalValidTest() {
+    Map<String, String> props1 = new HashMap<>();
+    String someScale = "2";
+    String validPrecision1 = "38";
+    props1.put(Decimal.SCALE_FIELD, someScale);
+    props1.put(HiveSchemaConverter.CONNECT_AVRO_DECIMAL_PRECISION_PROP, validPrecision1);
+    Schema decimalSchema1 = SchemaBuilder.bytes()
+        .name(Decimal.LOGICAL_NAME)
+        .parameters(props1)
+        .build();
+
+    Map<String, String> props2 = new HashMap<>();
+    String validPrecision2 = "10";
+    props2.put(Decimal.SCALE_FIELD, someScale);
+    props2.put(HiveSchemaConverter.CONNECT_AVRO_DECIMAL_PRECISION_PROP, validPrecision2);
+    Schema decimalSchema2 = SchemaBuilder.bytes()
+        .name(Decimal.LOGICAL_NAME)
+        .parameters(props2)
+        .build();
+
+    String scale = decimalSchema1.parameters().get(Decimal.SCALE_FIELD);
+    String precision = decimalSchema1.parameters()
+        .get(HiveSchemaConverter.CONNECT_AVRO_DECIMAL_PRECISION_PROP);
+
+    assertEquals(new DecimalTypeInfo(Integer.parseInt(precision), Integer.parseInt(scale)),
+        HiveSchemaConverter.convertPrimitiveMaybeLogical(decimalSchema1));
+
+    // precision in decimalSchema2 is 10, but our schema converter will still convert it to
+    // the maximum value, 38.
+
+    assertEquals(new DecimalTypeInfo(Integer.parseInt(precision), Integer.parseInt(scale)),
+        HiveSchemaConverter.convertPrimitiveMaybeLogical(decimalSchema2));
+  }
+
+  @Test
+  public void convertPrimitiveMaybeLogicalDecimalAbsentPrecisionTest() {
+    String someScale = "2";
+
+    Schema decimalSchema = SchemaBuilder.bytes()
+        .name(Decimal.LOGICAL_NAME)
+        .parameter(Decimal.SCALE_FIELD, someScale)
+        .build();
+
+    assertEquals(
+        new DecimalTypeInfo(HiveSchemaConverter.DECIMAL_PRECISION_DEFAULT, Integer.parseInt(someScale)),
+        HiveSchemaConverter.convertPrimitiveMaybeLogical(decimalSchema));
+  }
+
+  @Test(expected = ConnectException.class)
+  public void convertPrimitiveMaybeLogicalDecimalInvalidPrecisionTest() {
+    Map<String, String> props = new HashMap<>();
+    String someScale = "2";
+    String invalidPrecision = "39";
+    props.put(Decimal.SCALE_FIELD, someScale);
+    props.put(HiveSchemaConverter.CONNECT_AVRO_DECIMAL_PRECISION_PROP, invalidPrecision);
+
+    Schema decimalSchema = SchemaBuilder.bytes()
+        .name(Decimal.LOGICAL_NAME)
+        .parameters(props)
+        .build();
+
+    HiveSchemaConverter.convertPrimitiveMaybeLogical(decimalSchema);
+  }
+
+  @Test
+  public void convertPrimitiveMaybeLogicalNotLogicalTest() {
+    Map<String, String> props = new HashMap<>();
+    String someScale = "2";
+    String validPrecision = "38";
+    props.put(Decimal.SCALE_FIELD, someScale);
+    props.put(HiveSchemaConverter.CONNECT_AVRO_DECIMAL_PRECISION_PROP, validPrecision);
+
+    //without a name, not logical type
+    Schema decimalSchema = SchemaBuilder.bytes()
+        .parameters(props)
+        .build();
+
+    assertEquals(TypeInfoFactory.binaryTypeInfo,
+        HiveSchemaConverter.convertPrimitiveMaybeLogical(decimalSchema));
+  }
+}

--- a/hive/src/test/java/io/confluent/connect/storage/hive/HiveSchemaConverterTest.java
+++ b/hive/src/test/java/io/confluent/connect/storage/hive/HiveSchemaConverterTest.java
@@ -18,9 +18,10 @@ import org.junit.Test;
 public class HiveSchemaConverterTest {
   @Test
   public void convertPrimitiveMaybeLogicalAllExceptDecimalTest() {
-
+    // The only decimal type supported by Hive with parquet is decimal,
+    // All other types should be parsed as primitive.
     Schema dateSchema = SchemaBuilder.int32().name(Date.LOGICAL_NAME).build();
-    assertEquals(TypeInfoFactory.dateTypeInfo,
+    assertEquals(TypeInfoFactory.intTypeInfo,
         HiveSchemaConverter.convertPrimitiveMaybeLogical(dateSchema));
 
     // logical type time is not supported by Hive serde, convert it to Hive INT
@@ -29,7 +30,7 @@ public class HiveSchemaConverterTest {
         HiveSchemaConverter.convertPrimitiveMaybeLogical(timeSchema));
 
     Schema timestampSchema = SchemaBuilder.int64().name(Timestamp.LOGICAL_NAME).build();
-    assertEquals(TypeInfoFactory.timestampTypeInfo,
+    assertEquals(TypeInfoFactory.longTypeInfo,
         HiveSchemaConverter.convertPrimitiveMaybeLogical(timestampSchema));
   }
 


### PR DESCRIPTION
This is PR basically does what this old zombie PR does https://github.com/confluentinc/kafka-connect-storage-common/pull/101 . I made this new PR because the old one was based on the wrong branch and was targeting the wrong branch. 

Once merged, `HiveSchemaConverter` would be able to support logical types: decimal, timestamp, time and date. 