### PR TITLE
MINOR: Actually show and fail on warnings; fix warnings

### DIFF
--- a/hive/src/main/java/io/confluent/connect/storage/errors/HiveMetaStoreException.java
+++ b/hive/src/main/java/io/confluent/connect/storage/errors/HiveMetaStoreException.java
@@ -20,6 +20,8 @@ import org.apache.kafka.connect.errors.ConnectException;
 
 public class HiveMetaStoreException extends ConnectException {
 
+  private static final long serialVersionUID = 1L;
+
   public HiveMetaStoreException(String s) {
     super(s);
   }

--- a/partitioner/src/main/java/io/confluent/connect/storage/errors/PartitionException.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/errors/PartitionException.java
@@ -19,7 +19,9 @@ package io.confluent.connect.storage.errors;
 import org.apache.kafka.connect.errors.ConnectException;
 
 public class PartitionException extends ConnectException {
-  
+
+  private static final long serialVersionUID = 1L;
+
   public PartitionException(String s) {
     super(s);
   }

--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <inherited>true</inherited>
                 <configuration>
+                    <showWarnings>true</showWarnings>
                     <compilerArgs>
                         <arg>-Xlint:all</arg>
                         <arg>-Werror</arg>


### PR DESCRIPTION
Maven apparently by default does not show warnings, making the `-Werror` a
no-op. Once warnings are turned on, some warnings show up and the build
fails as expected with. This commit also fixes those warnings.