### PR TITLE
[6.0] CC-3543: Update Hadoop and Hive versions

### DIFF
--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -32,6 +32,7 @@
     <properties>
         <commons.lang3.version>3.1</commons.lang3.version>
         <kryo.version>2.22</kryo.version>
+        <xml-apis.version>1.4.01</xml-apis.version>
     </properties>
 
     <dependencies>
@@ -65,6 +66,12 @@
                     <artifactId>hive-exec</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <!-- Explicitly include working version of xml-apis -->
+        <dependency>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
+            <version>${xml-apis.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hive</groupId>

--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -65,6 +65,10 @@
                     <groupId>org.apache.hive</groupId>
                     <artifactId>hive-exec</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <!-- Explicitly include working version of xml-apis -->

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
                 <configuration>
                     <showWarnings>true</showWarnings>
                     <compilerArgs>
-                        <arg>-Xlint:all</arg>
+                        <arg>-Xlint:-processing</arg>
                         <arg>-Werror</arg>
                     </compilerArgs>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -67,8 +67,8 @@
         <commons-io.version>2.4</commons-io.version>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <confluent.version>6.0.0-SNAPSHOT</confluent.version>
-        <hadoop.version>2.7.3</hadoop.version>
-        <hive.version>1.2.2</hive.version>
+        <hadoop.version>2.10.0</hadoop.version>
+        <hive.version>2.3.6</hive.version>
         <joda.version>2.9.6</joda.version>
         <licenses.version>6.0.0-SNAPSHOT</licenses.version>
         <parquet.version>1.10.1</parquet.version>


### PR DESCRIPTION
This commit bumps Hadoop version to 2.10.0 released 10/2019 and Hive version to 2.3.6 released 8/2019.

Muckrake system test run #3352 is passing with this change.