### PR TITLE
Revert "[6.0] CC-3543: Update Hadoop and Hive versions (#123)"

### DIFF
--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -32,7 +32,6 @@
     <properties>
         <commons.lang3.version>3.1</commons.lang3.version>
         <kryo.version>2.22</kryo.version>
-        <xml-apis.version>1.4.01</xml-apis.version>
     </properties>
 
     <dependencies>
@@ -65,17 +64,7 @@
                     <groupId>org.apache.hive</groupId>
                     <artifactId>hive-exec</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>jdk.tools</groupId>
-                    <artifactId>jdk.tools</artifactId>
-                </exclusion>
             </exclusions>
-        </dependency>
-        <!-- Explicitly include working version of xml-apis -->
-        <dependency>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
-            <version>${xml-apis.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hive</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -67,8 +67,8 @@
         <commons-io.version>2.4</commons-io.version>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <confluent.version>6.0.0-SNAPSHOT</confluent.version>
-        <hadoop.version>2.10.0</hadoop.version>
-        <hive.version>2.3.6</hive.version>
+        <hadoop.version>2.7.3</hadoop.version>
+        <hive.version>1.2.2</hive.version>
         <joda.version>2.9.6</joda.version>
         <licenses.version>6.0.0-SNAPSHOT</licenses.version>
         <parquet.version>1.10.1</parquet.version>
@@ -174,7 +174,7 @@
                 <configuration>
                     <showWarnings>true</showWarnings>
                     <compilerArgs>
-                        <arg>-Xlint:-processing</arg>
+                        <arg>-Xlint:all</arg>
                         <arg>-Werror</arg>
                     </compilerArgs>
                 </configuration>


### PR DESCRIPTION
This reverts commit 286b9b80e0fbac7ef98e6c01eba26e20c853491c.

This change has been causing downstream build failures with the HDFS connector, which are in turn blocking some of our other downstream builds. We should revert these changes for now and only merge them back after verifying that they work with the HDFS connector.