### PR TITLE
Bump parquet version to remove jackson-mapper-asl dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <hive.version>1.2.2</hive.version>
         <joda.version>2.9.6</joda.version>
         <licenses.version>5.3.3-SNAPSHOT</licenses.version>
-        <parquet.version>1.10.1</parquet.version>
+        <parquet.version>1.11.0</parquet.version>
         <httpclient.version>4.5.2</httpclient.version>
         <httpcore.version>4.4.4</httpcore.version>
         <jline.version>2.12.1</jline.version>


### PR DESCRIPTION
`jackson-mapper-asl` has CVE issue as described in CC-8170. The library is still pulled in by Hive even after this commit, but at least impact is minimized to those using Hive integration.

Muckrake tests passing runs:
https://jenkins.confluent.io/job/system-test-confluent-platform-branch-builder/3502/
https://jenkins.confluent.io/job/system-test-confluent-platform-branch-builder/3503/