### PR TITLE
FMC-580: Add dependencies on JSON and Protobuf libraries

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -39,6 +39,14 @@
             <artifactId>kafka-connect-avro-converter</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-connect-json-schema-converter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-connect-protobuf-converter</artifactId>
+        </dependency>
+        <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,16 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.confluent</groupId>
+                <artifactId>kafka-connect-json-schema-converter</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.confluent</groupId>
+                <artifactId>kafka-connect-protobuf-converter</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.parquet</groupId>
                 <artifactId>parquet-column</artifactId>
                 <version>${parquet.version}</version>


### PR DESCRIPTION
In order to provide JSON and Protobuf support, we need to package json and protobuf converter jars. Adding the dependency here for usage in S3, Azure Blob Storage, Azure Datalake 2, GCP Dataproc and GCS connectors
https://confluentinc.atlassian.net/wiki/spaces/CONNECT/pages/1185056814/One-Pager+Protobuf+and+JSON+Schema+support+for+connectors+on+Confluent+Cloud