### PR TITLE
MINOR: Fix build requiring an implementation of errantRecordReporter

### DIFF
--- a/core/src/main/java/io/confluent/connect/storage/StorageSinkTestBase.java
+++ b/core/src/main/java/io/confluent/connect/storage/StorageSinkTestBase.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.ErrantRecordReporter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.junit.After;
@@ -248,6 +249,11 @@ public class StorageSinkTestBase {
 
     @Override
     public void requestCommit() {}
+
+    @Override
+    public ErrantRecordReporter errantRecordReporter() {
+      throw new UnsupportedOperationException("ErrantRecordReporter is undefined for this class");
+    }
   }
 
 }


### PR DESCRIPTION
This is a preliminary implementation that signals that the new method is not supported yet. 