### PR TITLE
CC-9779: PartitionerConfig should perform basic timezone validation

### DIFF
--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/PartitionerConfig.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/PartitionerConfig.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 
 import io.confluent.connect.storage.common.ComposableConfig;
+import org.joda.time.DateTimeZone;
 
 public class PartitionerConfig extends AbstractConfig implements ComposableConfig {
 
@@ -182,6 +183,7 @@ public class PartitionerConfig extends AbstractConfig implements ComposableConfi
       configDef.define(TIMEZONE_CONFIG,
           Type.STRING,
           TIMEZONE_DEFAULT,
+          new TimezoneValidator(),
           Importance.MEDIUM,
           TIMEZONE_DOC,
           group,
@@ -272,6 +274,29 @@ public class PartitionerConfig extends AbstractConfig implements ComposableConfi
         ce.initCause(e);
         throw ce;
       }
+    }
+  }
+
+  public static class TimezoneValidator implements ConfigDef.Validator {
+    @Override
+    public void ensureValid(String name, Object timezone) {
+      String timezoneStr = ((String) timezone).trim();
+      if (!timezoneStr.isEmpty()) {
+        try {
+          DateTimeZone.forID(timezoneStr);
+        } catch (IllegalArgumentException e) {
+          throw new ConfigException(
+              name,
+              timezone,
+              e.getMessage()
+          );
+        }
+      }
+    }
+
+    @Override
+    public String toString() {
+      return "Any timezone accepted by: " + DateTimeZone.class;
     }
   }
 

--- a/partitioner/src/test/java/io/confluent/connect/storage/partitioner/PartitionerConfigTest.java
+++ b/partitioner/src/test/java/io/confluent/connect/storage/partitioner/PartitionerConfigTest.java
@@ -1,0 +1,42 @@
+package io.confluent.connect.storage.partitioner;
+
+import static org.junit.Assert.assertEquals;
+
+import io.confluent.connect.storage.StorageSinkTestBase;
+import io.confluent.connect.storage.common.GenericRecommender;
+import org.apache.kafka.common.config.ConfigException;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PartitionerConfigTest extends StorageSinkTestBase {
+
+  @Before
+  public void setup() {
+    properties = super.createProps();
+  }
+
+  @Test(expected = ConfigException.class)
+  public void testInvalidTimezoneThrowsException() {
+    properties.put(PartitionerConfig.TIMEZONE_CONFIG, "LLL");
+    new PartitionerConfig(PartitionerConfig.newConfigDef(new GenericRecommender()), properties);
+  }
+
+  @Test
+  public void testValidTimezoneAccepted() {
+    properties.put(PartitionerConfig.TIMEZONE_CONFIG, "CET");
+    new PartitionerConfig(PartitionerConfig.newConfigDef(new GenericRecommender()), properties);
+  }
+
+  @Test
+  public void testTimezoneValidatedExceptionMessage() {
+    properties.put(PartitionerConfig.TIMEZONE_CONFIG, "LLL");
+    String expectedError = String.format("Invalid value LLL for configuration %s: "
+        + "The datetime zone id 'LLL' is not recognised", PartitionerConfig.TIMEZONE_CONFIG);
+    try {
+      new PartitionerConfig(PartitionerConfig.newConfigDef(new GenericRecommender()), properties);
+    } catch (ConfigException e){
+      assertEquals(expectedError, e.getMessage());
+    }
+  }
+
+}


### PR DESCRIPTION
## Problem
The `timezone` configuration is not being validated when the `TimeBasedPartitioner` is not set. This results in a runtime error when the `rotate.schedule.interval.ms` is used and an invalid or no `timezone` value is set. [Parent ticket](https://confluentinc.atlassian.net/browse/CC-8815) 

## Solution
Validate the `timezone` configuration whenever set.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [X] yes
- [ ] no

##### If yes, where?
Secondary checks that depend on the timezone configuration should be added to all connectors that need them. For example in the S3 sink we expect the `timezone` configuration to be set when `rotate.schedule.interval.ms` is used. 

## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [X] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
