### PR TITLE
CC-12005: Exclude vulnerable dependency jackson mapper asl

### DIFF
--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -55,6 +55,12 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
             <version>${hadoop.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-mapper-asl</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hive.hcatalog</groupId>
@@ -68,6 +74,10 @@
                 <exclusion>
                     <groupId>jdk.tools</groupId>
                     <artifactId>jdk.tools</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-mapper-asl</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
UPDATE: The fix was added (dependency was excluded) in gcs,azure blob and hdfs connectors. We should make a call whether this fix needs to be in storage-common
## Problem
Resolving connector CVE for jackson-mapper-asl

## Solution
straight forward exclusion of the transitive dependency, since it isn't used by the connector.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?
HDFS sink and GCS sink


## Test Strategy
Branch to be tested against Muckrake.

Understand testing for all connectors that use `kafka-connect-storage-common` for these fixes

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
