### PR TITLE
CC-8704: Exclude jetty from hcatalog - CVE

### DIFF
--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -64,6 +64,10 @@
                     <groupId>org.apache.hive</groupId>
                     <artifactId>hive-exec</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty.aggregate</groupId>
+                    <artifactId>jetty-all</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Problem
This PR addresses a CVE caused by `jetty-all 7.6.0.v20120127`. 

## Solution
Exclude the `jetty-all` dependency that is brought in by `kafka-connect-storage-hive`, same solution as in [gcp-dataproc](https://github.com/confluentinc/kafka-connect-gcp-dataproc/blob/master/pom.xml#L353-L356) and [object-store-source](https://github.com/confluentinc/kafka-connect-object-store-source/blob/master/sink-integration-tests/pom.xml#L190-L193) connectors. 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [X] no

##### If yes, where?

## Test Strategy

Tested relevant HDFS and HDFS3 connectors: 

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [X] Unit tests
- [x] Integration tests
- [x] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 

