### PR TITLE
remove parquet-jackson dependency causing CVEs

### DIFF
--- a/format/pom.xml
+++ b/format/pom.xml
@@ -29,6 +29,12 @@
     <packaging>jar</packaging>
     <name>kafka-connect-storage-format</name>
 
+    <properties>
+        <jackson.groupId>com.fasterxml.jackson.core</jackson.groupId>
+        <jackson.package>com.fasterxml.jackson</jackson.package>
+        <shade.prefix>shaded.parquet</shade.prefix>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.confluent</groupId>
@@ -41,6 +47,12 @@
         <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-avro</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.parquet</groupId>
+                    <artifactId>parquet-jackson</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -48,4 +60,46 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <minimizeJar>false</minimizeJar>
+                            <createSourcesJar>false</createSourcesJar>
+                            <artifactSet>
+                                <includes>
+                                    <include>${jackson.groupId}:*</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>${jackson.groupId}:*</artifact>
+                                    <includes>
+                                        <include>**</include>
+                                    </includes>
+                                </filter>
+                            </filters>
+                            <relocations>
+                                <relocation>
+                                    <pattern>${jackson.package}</pattern>
+                                    <shadedPattern>${shade.prefix}.${jackson.package}</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -54,6 +54,12 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
             <version>${hadoop.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.htrace</groupId>
+                    <artifactId>htrace-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hive.hcatalog</groupId>

--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -54,12 +54,6 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
             <version>${hadoop.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.htrace</groupId>
-                    <artifactId>htrace-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hive.hcatalog</groupId>


### PR DESCRIPTION
Signed-off-by: Lev Zemlyanov <lev@confluent.io>

## Problem
`parquet-avro` pulls in `parquet-jackson` which is a shaded jackson library that pulls in many CVEs in a lot of our storage connectors

## Solution
exclude `parquet-jackson` and shade a clean jackson version using the same strategy
https://repo1.maven.org/maven2/org/apache/parquet/parquet-jackson/1.11.0/parquet-jackson-1.11.0.pom

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?
this should address `parquet-jackson` in all storage connectors

## Test Strategy
made sure parquet files were successfully written using the S3 connector

ran system tests for [S3](https://jenkins.confluent.io/job/system-test-confluent-platform-branch-builder/4102/) and [HDFS](https://jenkins.confluent.io/job/system-test-confluent-platform-branch-builder/4105/)

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [x] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
backport to `5.4.x` where CVEs were caught