### PR TITLE
SEC-1334: update confluent-log4j version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <httpclient.version>4.5.2</httpclient.version>
         <httpcore.version>4.4.4</httpcore.version>
         <jline.version>2.12.1</jline.version>
-        <confluent-log4j.version>1.2.17-cp1</confluent-log4j.version>
+        <confluent-log4j.version>1.2.17-cp2</confluent-log4j.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
## Problem

This pull request updates `confluent-log4j` from `1.2.17-cp1` to `1.2.17-cp2`. The former had a few accidental commits that made the repackaged version slightly different than the upstream `log4j`. `1.2.17-cp2` fixes the issue and applies a CVE fix (and no additional code changes) to the upstream `log4j:1.2.17`.

## Solution

Update `1.2.17-cp1` to `1.2.17-cp2`

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
