### PR TITLE
CC-11532: TimeBasedPartitioner to extract timestamp from a string literal as unixtime or ISO-8601-formatted date.

### DIFF
--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/TimeBasedPartitioner.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/TimeBasedPartitioner.java
@@ -48,7 +48,8 @@ public class TimeBasedPartitioner<T> extends DefaultPartitioner<T> {
 
   private static final String SCHEMA_GENERATOR_CLASS =
       "io.confluent.connect.storage.hive.schema.TimeBasedSchemaGenerator";
-  static Pattern NUMERIC_TIMESTAMP_PATTERN = Pattern.compile("^-?[0-9]{1,19}$");
+  private static final Pattern NUMERIC_TIMESTAMP_PATTERN = Pattern.compile("^-?[0-9]{1,19}$");
+
 
   // Duration of a partition in milliseconds.
   private long partitionDurationMs;

--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/TimeBasedPartitioner.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/TimeBasedPartitioner.java
@@ -324,7 +324,7 @@ public class TimeBasedPartitioner<T> extends DefaultPartitioner<T> {
       }
     }
 
-    private Long extractTimestampFromString(Object timestampValue) {
+    private Long extractTimestampFromString(String timestampValue) {
       String timestampValueStr = (String) timestampValue;
       try {
         return Long.valueOf(timestampValueStr);

--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/TimeBasedPartitioner.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/TimeBasedPartitioner.java
@@ -48,7 +48,7 @@ public class TimeBasedPartitioner<T> extends DefaultPartitioner<T> {
 
   private static final String SCHEMA_GENERATOR_CLASS =
       "io.confluent.connect.storage.hive.schema.TimeBasedSchemaGenerator";
-  static Pattern NUMERIC_TIMESTAMP_PATTERN = Pattern.compile("^[0-9]{13}$");
+  static Pattern NUMERIC_TIMESTAMP_PATTERN = Pattern.compile("^-?[0-9]{1,19}$");
 
   // Duration of a partition in milliseconds.
   private long partitionDurationMs;

--- a/partitioner/src/test/java/io/confluent/connect/storage/partitioner/TimeBasedPartitionerTest.java
+++ b/partitioner/src/test/java/io/confluent/connect/storage/partitioner/TimeBasedPartitionerTest.java
@@ -580,9 +580,7 @@ public class TimeBasedPartitionerTest extends StorageSinkTestBase {
     validateEncodedPartition(encodedPartition);
   }
 
-  @Test
-  public void testRecordFieldTimeAsMillisStringExtractorRecord() {
-    long millis = DATE_TIME.getMillis();
+  private void validateTimestampAsMillisRecordExtracted(long millis) {
     String timeStr = String.valueOf(millis);
     String timeFieldName = "timestamp";
     TimeBasedPartitioner<String> partitioner = configurePartitioner(
@@ -596,8 +594,36 @@ public class TimeBasedPartitionerTest extends StorageSinkTestBase {
   }
 
   @Test
-  public void testRecordFieldTimeAsMillisStringExtractorMap() {
-    Long millis = DATE_TIME.getMillis();
+  public void testRecordFieldTimeAsMillisMinValueStringExtractorRecord() {
+    long millis = Long.MIN_VALUE;
+    validateTimestampAsMillisRecordExtracted(millis);
+  }
+
+  @Test
+  public void testRecordFieldTimeAsMillisNegativeValueStringExtractorRecord() {
+    long millis = -1;
+    validateTimestampAsMillisRecordExtracted(millis);
+  }
+
+  @Test
+  public void testRecordFieldTimeAsMillisZeroStringExtractorRecord() {
+    long millis = 0;
+    validateTimestampAsMillisRecordExtracted(millis);
+  }
+
+  @Test
+  public void testRecordFieldTimeAsMillisStringExtractorRecord() {
+    long millis = DATE_TIME.getMillis();
+    validateTimestampAsMillisRecordExtracted(millis);
+  }
+
+  @Test
+  public void testRecordFieldTimeAsMillisMaxValueStringExtractorRecord() {
+    long millis = Long.MAX_VALUE;
+    validateTimestampAsMillisRecordExtracted(millis);
+  }
+
+  private void validateTimestampAsMillisMapExtracted(long millis) {
     String timeStr = String.valueOf(millis);
     String timeFieldName = "timestamp";
     TimeBasedPartitioner<String> partitioner = configurePartitioner(
@@ -608,6 +634,36 @@ public class TimeBasedPartitionerTest extends StorageSinkTestBase {
     SinkRecord sinkRecord = createValuedSinkRecord(mapSchema, map, millis);
     Long extractedTimestamp = partitioner.getTimestampExtractor().extract(sinkRecord);
     assertThat(extractedTimestamp, is(millis));
+  }
+
+  @Test
+  public void testRecordFieldTimeAsMillisMinValueStringExtractorMap() {
+    long millis = Long.MIN_VALUE;
+    validateTimestampAsMillisMapExtracted(millis);
+  }
+
+  @Test
+  public void testRecordFieldTimeAsMillisNegativeValueStringExtractorMap() {
+    long millis = -1;
+    validateTimestampAsMillisMapExtracted(millis);
+  }
+
+  @Test
+  public void testRecordFieldTimeAsMillisZeroStringExtractorMap() {
+    long millis = 0;
+    validateTimestampAsMillisMapExtracted(millis);
+  }
+
+  @Test
+  public void testRecordFieldTimeAsMillisStringExtractorMap() {
+    Long millis = DATE_TIME.getMillis();
+    validateTimestampAsMillisMapExtracted(millis);
+  }
+
+  @Test
+  public void testRecordFieldTimeAsMillisMaxValueStringExtractorMap() {
+    long millis = Long.MAX_VALUE;
+    validateTimestampAsMillisMapExtracted(millis);
   }
 
   @Test

--- a/partitioner/src/test/java/io/confluent/connect/storage/partitioner/TimeBasedPartitionerTest.java
+++ b/partitioner/src/test/java/io/confluent/connect/storage/partitioner/TimeBasedPartitionerTest.java
@@ -597,7 +597,8 @@ public class TimeBasedPartitionerTest extends StorageSinkTestBase {
 
   @Test
   public void testRecordFieldTimeAsMillisStringExtractorMap() {
-    String timeStr = String.valueOf(DATE_TIME.getMillis());
+    Long millis = DATE_TIME.getMillis();
+    String timeStr = String.valueOf(millis);
     String timeFieldName = "timestamp";
     TimeBasedPartitioner<String> partitioner = configurePartitioner(
         new TimeBasedPartitioner<>(), timeFieldName, null);

--- a/partitioner/src/test/java/io/confluent/connect/storage/partitioner/TimeBasedPartitionerTest.java
+++ b/partitioner/src/test/java/io/confluent/connect/storage/partitioner/TimeBasedPartitionerTest.java
@@ -601,8 +601,7 @@ public class TimeBasedPartitionerTest extends StorageSinkTestBase {
     String timeFieldName = "timestamp";
     TimeBasedPartitioner<String> partitioner = configurePartitioner(
         new TimeBasedPartitioner<>(), timeFieldName, null);
-    Schema keySchema = Schema.STRING_SCHEMA;
-    Schema mapSchema = SchemaBuilder.map(keySchema, Schema.STRING_SCHEMA);
+    Schema mapSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA);
     Map<String, Object> map = new HashMap<>();
     map.put(timeFieldName, timeStr);
     SinkRecord sinkRecord = createValuedSinkRecord(mapSchema, map, millis);

--- a/partitioner/src/test/java/io/confluent/connect/storage/partitioner/TimeBasedPartitionerTest.java
+++ b/partitioner/src/test/java/io/confluent/connect/storage/partitioner/TimeBasedPartitionerTest.java
@@ -596,7 +596,7 @@ public class TimeBasedPartitionerTest extends StorageSinkTestBase {
   }
 
   @Test
-  public void testRecordFieldTimeStringExtractorMap() {
+  public void testRecordFieldTimeAsMillisStringExtractorMap() {
     long millis = DATE_TIME.getMillis();
     String timeStr = String.valueOf(millis);
     String timeFieldName = "timestamp";

--- a/partitioner/src/test/java/io/confluent/connect/storage/partitioner/TimeBasedPartitionerTest.java
+++ b/partitioner/src/test/java/io/confluent/connect/storage/partitioner/TimeBasedPartitionerTest.java
@@ -581,7 +581,7 @@ public class TimeBasedPartitionerTest extends StorageSinkTestBase {
   }
 
   @Test
-  public void testRecordFieldTimeStringExtractorRecord() {
+  public void testRecordFieldTimeAsMillisStringExtractorRecord() {
     long millis = DATE_TIME.getMillis();
     String timeStr = String.valueOf(millis);
     String timeFieldName = "timestamp";

--- a/partitioner/src/test/java/io/confluent/connect/storage/partitioner/TimeBasedPartitionerTest.java
+++ b/partitioner/src/test/java/io/confluent/connect/storage/partitioner/TimeBasedPartitionerTest.java
@@ -31,9 +31,7 @@ import org.joda.time.ReadableInstant;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.DateTimeFormatterBuilder;
 import org.joda.time.format.ISODateTimeFormat;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.Collections;
 import java.util.Date;
@@ -48,14 +46,13 @@ import io.confluent.connect.storage.common.StorageCommonConfig;
 import io.confluent.connect.storage.errors.PartitionException;
 import io.confluent.connect.storage.util.DateTimeUtils;
 
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
 
 public class TimeBasedPartitionerTest extends StorageSinkTestBase {
 
@@ -581,6 +578,37 @@ public class TimeBasedPartitionerTest extends StorageSinkTestBase {
 
     encodedPartition = getEncodedPartition(String.format("header.%s", timeFieldName), sinkRecord);
     validateEncodedPartition(encodedPartition);
+  }
+
+  @Test
+  public void testRecordFieldTimeStringExtractorRecord() {
+    long millis = DATE_TIME.getMillis();
+    String timeStr = String.valueOf(millis);
+    String timeFieldName = "timestamp";
+    TimeBasedPartitioner<String> partitioner = configurePartitioner(
+        new TimeBasedPartitioner<>(), timeFieldName, null);
+    Schema schema = SchemaBuilder.struct().name("record")
+        .field(timeFieldName, Schema.STRING_SCHEMA);
+    Struct s = new Struct(schema).put(timeFieldName, timeStr);
+    SinkRecord sinkRecord = createValuedSinkRecord(schema, s, millis);
+    Long extractedTimestamp = partitioner.getTimestampExtractor().extract(sinkRecord);
+    assertThat(extractedTimestamp, is(millis));
+  }
+
+  @Test
+  public void testRecordFieldTimeStringExtractorMap() {
+    long millis = DATE_TIME.getMillis();
+    String timeStr = String.valueOf(millis);
+    String timeFieldName = "timestamp";
+    TimeBasedPartitioner<String> partitioner = configurePartitioner(
+        new TimeBasedPartitioner<>(), timeFieldName, null);
+    Schema keySchema = Schema.STRING_SCHEMA;
+    Schema mapSchema = SchemaBuilder.map(keySchema, Schema.STRING_SCHEMA);
+    Map<String, Object> map = new HashMap<>();
+    map.put(timeFieldName, timeStr);
+    SinkRecord sinkRecord = createValuedSinkRecord(mapSchema, map, millis);
+    Long extractedTimestamp = partitioner.getTimestampExtractor().extract(sinkRecord);
+    assertThat(extractedTimestamp, is(millis));
   }
 
   @Test

--- a/partitioner/src/test/java/io/confluent/connect/storage/partitioner/TimeBasedPartitionerTest.java
+++ b/partitioner/src/test/java/io/confluent/connect/storage/partitioner/TimeBasedPartitionerTest.java
@@ -597,8 +597,7 @@ public class TimeBasedPartitionerTest extends StorageSinkTestBase {
 
   @Test
   public void testRecordFieldTimeAsMillisStringExtractorMap() {
-    long millis = DATE_TIME.getMillis();
-    String timeStr = String.valueOf(millis);
+    String timeStr = String.valueOf(DATE_TIME.getMillis());
     String timeFieldName = "timestamp";
     TimeBasedPartitioner<String> partitioner = configurePartitioner(
         new TimeBasedPartitioner<>(), timeFieldName, null);


### PR DESCRIPTION
## Problem

Currently, if S3 sink connector is configured as follows:

```
"connector.class":"io.confluent.connect.s3.S3SinkConnector",
"timestamp.extractor":"RecordField",
"timestamp.field":"ts.field",
"partitioner.class":"io.confluent.connect.storage.partitioner.TimeBasedPartitioner",
...
```

It can handle records, where the timestamp field has a string literal with ISO-8601-formatted date:
```
{"ts.field":"2000-08-20T4:05:30.799044","value":"xyz"}
```
But fails to handle a record, where the timestamp field has a string literal with Unix time:
```
{"ts.field":"1597904371234","value":"xyz"}
```

## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
