### PR TITLE
Correct SR schemas cache size property name for AvroDataConfig

### DIFF
--- a/core/src/main/java/io/confluent/connect/storage/StorageSinkConnectorConfig.java
+++ b/core/src/main/java/io/confluent/connect/storage/StorageSinkConnectorConfig.java
@@ -89,6 +89,9 @@ public class StorageSinkConnectorConfig extends AbstractConfig implements Compos
       "Filename Offset Zero Pad Width";
 
   public static final String SCHEMA_CACHE_SIZE_CONFIG = "schema.cache.size";
+  // Schema Cache Config Name used by Schema Registry
+  // Ref AvroDataConfig.java in https://github.com/confluentinc/schema-registry
+  public static final String SCHEMAS_CACHE_SIZE_CONFIG = "schemas.cache.config";
   public static final String SCHEMA_CACHE_SIZE_DOC =
       "The size of the schema cache used in the Avro converter.";
   public static final int SCHEMA_CACHE_SIZE_DEFAULT = 1000;
@@ -255,7 +258,7 @@ public class StorageSinkConnectorConfig extends AbstractConfig implements Compos
 
   public AvroDataConfig avroDataConfig() {
     Map<String, Object> props = new HashMap<>();
-    props.put(SCHEMA_CACHE_SIZE_CONFIG, get(SCHEMA_CACHE_SIZE_CONFIG));
+    props.put(SCHEMAS_CACHE_SIZE_CONFIG, get(SCHEMA_CACHE_SIZE_CONFIG));
     props.put(ENHANCED_AVRO_SCHEMA_SUPPORT_CONFIG, get(ENHANCED_AVRO_SCHEMA_SUPPORT_CONFIG));
     props.put(CONNECT_META_DATA_CONFIG, get(CONNECT_META_DATA_CONFIG));
     return new AvroDataConfig(props);

--- a/core/src/main/java/io/confluent/connect/storage/StorageSinkConnectorConfig.java
+++ b/core/src/main/java/io/confluent/connect/storage/StorageSinkConnectorConfig.java
@@ -87,11 +87,8 @@ public class StorageSinkConnectorConfig extends AbstractConfig implements Compos
   public static final int FILENAME_OFFSET_ZERO_PAD_WIDTH_DEFAULT = 10;
   public static final String FILENAME_OFFSET_ZERO_PAD_WIDTH_DISPLAY =
       "Filename Offset Zero Pad Width";
-
-  public static final String SCHEMA_CACHE_SIZE_CONFIG = "schema.cache.size";
-  // Schema Cache Config Name used by Schema Registry
-  // Ref AvroDataConfig.java in https://github.com/confluentinc/schema-registry
-  public static final String SCHEMAS_CACHE_SIZE_CONFIG = "schemas.cache.config";
+  
+  public static final String SCHEMA_CACHE_SIZE_CONFIG = AvroDataConfig.SCHEMAS_CACHE_SIZE_CONFIG;
   public static final String SCHEMA_CACHE_SIZE_DOC =
       "The size of the schema cache used in the Avro converter.";
   public static final int SCHEMA_CACHE_SIZE_DEFAULT = 1000;
@@ -258,7 +255,7 @@ public class StorageSinkConnectorConfig extends AbstractConfig implements Compos
 
   public AvroDataConfig avroDataConfig() {
     Map<String, Object> props = new HashMap<>();
-    props.put(SCHEMAS_CACHE_SIZE_CONFIG, get(SCHEMA_CACHE_SIZE_CONFIG));
+    props.put(SCHEMA_CACHE_SIZE_CONFIG, get(SCHEMA_CACHE_SIZE_CONFIG));
     props.put(ENHANCED_AVRO_SCHEMA_SUPPORT_CONFIG, get(ENHANCED_AVRO_SCHEMA_SUPPORT_CONFIG));
     props.put(CONNECT_META_DATA_CONFIG, get(CONNECT_META_DATA_CONFIG));
     return new AvroDataConfig(props);


### PR DESCRIPTION
## Problem
The incident RCCA https://confluentinc.atlassian.net/browse/RCCA-1273 uncovered that certain properties were not being configured properly to be used in the connector
This additionally brought to light that in the AvroDataConfig(props) method, the property name needs to match SR's property name https://github.com/confluentinc/schema-registry/blob/778f1e5cca9ebcc2cfc1876c617afb81ed3e5ea4/avro-data/src/main/java/io/confluent/connect/avro/AvroDataConfig.java#L40

## Solution
Correct SR schemas cache size property name for AvroDataConfig


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
TODO

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
