### PR TITLE
Update commons codec to 1.15 to resolve CVE and exclude zookeeper test jar

### DIFF
--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -96,6 +96,10 @@
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-yarn-server-resourcemanager</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
         <httpcore.version>4.4.4</httpcore.version>
         <jline.version>2.12.1</jline.version>
         <confluent-log4j.version>1.2.17-cp2</confluent-log4j.version>
+        <commons.codec.version>1.15</commons.codec.version>
     </properties>
 
     <repositories>
@@ -149,6 +150,11 @@
                 <artifactId>junit</artifactId>
                 <version>${junit.version}</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>${commons.codec.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Problem
Commons codec is a CVE that applies to all the storage connectors.

## Solution
Adding here to resolve across the board

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Backporting to 5.4.x seems reasonable. Will merge forward