### PR TITLE
Reshade transitive dependency htrace-core4 with newer jackson to remove CVEs

### DIFF
--- a/htrace-core4-shaded/pom.xml
+++ b/htrace-core4-shaded/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor
+license agreements. See the NOTICE file distributed with this work for additional
+information regarding copyright ownership. The ASF licenses this file to
+You under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of
+the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required
+by applicable law or agreed to in writing, software distributed under the
+License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.confluent</groupId>
+        <artifactId>kafka-connect-storage-common-parent</artifactId>
+        <version>10.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>kafka-connect-storage-common-htrace-core4-shaded</artifactId>
+    <name>kafka-connect-storage-common-htrace-core4-shaded</name>
+    
+    <description>htrace-core4 shaded to replace jackson dependencies without CVEs</description>
+    <inceptionYear>2020</inceptionYear>
+
+    <properties>
+        <htrace.version>4.1.0-incubating</htrace.version>
+        <jackson.version>2.10.5</jackson.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.htrace:*</include>
+                                    <include>com.fasterxml.jackson.core:*</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>org.apache.htrace:htrace-core4</artifact>
+                                    <includes>
+                                        <include>**</include>
+                                    </includes>
+                                    <excludes>
+                                        <exclude>META-INF/MANIFEST.MF</exclude>
+                                        <exclude>META-INF/LICENSE</exclude>
+                                        <exclude>META-INF/NOTICE</exclude>
+                                        <exclude>META-INF/services/**</exclude>
+                                        <exclude>META-INF/maven/com.fasterxml.jackson.core/**</exclude>
+                                        <exclude>org/apache/htrace/shaded/fasterxml/jackson/**</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>com.fasterxml.jackson.core:*</artifact>
+                                    <includes>
+                                        <include>**</include>
+                                    </includes>
+                                </filter>
+                            </filters>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson</pattern>
+                                    <shadedPattern>org.apache.htrace.shaded.fasterxml.jackson</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.htrace</groupId>
+            <artifactId>htrace-core4</artifactId>
+            <version>${htrace.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/htrace-core4-shaded/pom.xml
+++ b/htrace-core4-shaded/pom.xml
@@ -55,6 +55,12 @@ language governing permissions and limitations under the License. -->
                                     <includes>
                                         <include>**</include>
                                     </includes>
+                                </filter>
+                                <filter>
+                                    <artifact>com.fasterxml.jackson.core:*</artifact>
+                                    <includes>
+                                        <include>**</include>
+                                    </includes>
                                     <excludes>
                                         <exclude>META-INF/MANIFEST.MF</exclude>
                                         <exclude>META-INF/LICENSE</exclude>
@@ -63,12 +69,6 @@ language governing permissions and limitations under the License. -->
                                         <exclude>META-INF/maven/com.fasterxml.jackson.core/**</exclude>
                                         <exclude>org/apache/htrace/shaded/fasterxml/jackson/**</exclude>
                                     </excludes>
-                                </filter>
-                                <filter>
-                                    <artifact>com.fasterxml.jackson.core:*</artifact>
-                                    <includes>
-                                        <include>**</include>
-                                    </includes>
                                 </filter>
                             </filters>
                             <relocations>

--- a/htrace-core4-shaded/pom.xml
+++ b/htrace-core4-shaded/pom.xml
@@ -33,6 +33,9 @@ language governing permissions and limitations under the License. -->
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.2.4</version>

--- a/htrace-core4-shaded/pom.xml
+++ b/htrace-core4-shaded/pom.xml
@@ -20,6 +20,7 @@ language governing permissions and limitations under the License. -->
     </parent>
 
     <artifactId>kafka-connect-storage-common-htrace-core4-shaded</artifactId>
+    <packaging>jar</packaging>
     <name>kafka-connect-storage-common-htrace-core4-shaded</name>
     
     <description>htrace-core4 shaded to replace jackson dependencies without CVEs</description>

--- a/htrace-core4-shaded/pom.xml
+++ b/htrace-core4-shaded/pom.xml
@@ -61,6 +61,17 @@ language governing permissions and limitations under the License. -->
                                     </includes>
                                 </filter>
                                 <filter>
+                                    <!-- this filter is a workaround to the fact that maven phases
+                                    can't run twice without adding new code to the produced jar
+                                    (by producing an empty jar). It's used to remove the placeholder
+                                    class io.confluent.connect.storage.PlaceHolder.class
+                                     -->
+                                    <artifact>io.confluent:*</artifact>
+                                    <excludes>
+                                        <exlude>**</exlude>
+                                    </excludes>
+                                </filter>
+                                <filter>
                                     <artifact>com.fasterxml.jackson.core:*</artifact>
                                     <includes>
                                         <include>**</include>

--- a/htrace-core4-shaded/src/main/java/io/confluent/connect/storage/PlaceHolder.java
+++ b/htrace-core4-shaded/src/main/java/io/confluent/connect/storage/PlaceHolder.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.storage;
+
+/**
+ * This class is added as a workaround to maven. Attempting to run both verify and install phases
+ * with maven fails if there's no source code in the project (the produced jar is empty).
+ * {@see http://mail-archives.apache.org/mod_mbox/maven-users/201608.mbox/%3c20160805151905.500d5c45@copperhead.int.arc7.info%3e}
+ * <br>
+ * This fact subsequently fails the attempt to re-shade the dependencies without adding new code.
+ * The workaround is to introduce this class here, with the intention to remove it during shading
+ * by configuring a filter for maven-shade-plugin.
+ */
+public class PlaceHolder {
+}

--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,8 @@
         <module>partitioner</module>
         <module>format</module>
         <module>hive</module>
-        <module>package-kafka-connect-storage-common</module>
         <module>htrace-core4-shaded</module>
+        <module>package-kafka-connect-storage-common</module>
     </modules>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <module>format</module>
         <module>hive</module>
         <module>package-kafka-connect-storage-common</module>
+        <module>htrace-core4-shaded</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
## Problem
The HDFS connector (Hadoop v2) depends on a few transitive dependencies that are old and are shading a version of jackson that has CVEs associated with it. 

## Solution
We are reshading this dependency by removing the old jackson version and replacing it with a newer one that does not have CVEs. HDFS connector can import this dependency and get a clean htrace-core4 package. 


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
