### PR TITLE
 Improvement to have specify scaling factor for timestamp column used in partitioning by configuration

### DIFF
--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/PartitionerConfig.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/PartitionerConfig.java
@@ -101,6 +101,20 @@ public class PartitionerConfig extends AbstractConfig implements ComposableConfi
   public static final String TIMESTAMP_FIELD_NAME_DEFAULT = "timestamp";
   public static final String TIMESTAMP_FIELD_NAME_DISPLAY = "Record Field for Timestamp Extractor";
 
+  public static final String TIMESTAMP_SCALING_FACTOR_CONFIG = "timestamp.scaling.factor";
+  public static final String TIMESTAMP_SCALING_FACTOR_DOC =
+      "The scaling factor to be applied to the timestamp by the timestamp extractor.";
+  public static final long TIMESTAMP_SCALING_FACTOR_DEFAULT = 1L;
+  public static final String TIMESTAMP_SCALING_FACTOR_DISPLAY =
+      "Timestamp scaling factor for Timestamp Extractor";
+
+  public static final String TIMESTAMP_SCALING_OPERATION_CONFIG = "timestamp.scaling.operation";
+  public static final String TIMESTAMP_SCALING_OPERATION_DOC =
+      "The scaling operation to be applied to the timestamp by the timestamp extractor.";
+  public static final String TIMESTAMP_SCALING_OPERATION_DEFAULT = "Division";
+  public static final String TIMESTAMP_SCALING_OPERATION_DISPLAY =
+      "Timestamp scaling operation for Timestamp Extractor";
+
   /**
    * Create a new configuration definition.
    *
@@ -208,6 +222,26 @@ public class PartitionerConfig extends AbstractConfig implements ComposableConfi
           ++orderInGroup,
           Width.LONG,
           TIMESTAMP_FIELD_NAME_DISPLAY);
+
+      configDef.define(TIMESTAMP_SCALING_FACTOR_CONFIG,
+          Type.LONG,
+          TIMESTAMP_SCALING_FACTOR_DEFAULT,
+          Importance.MEDIUM,
+          TIMESTAMP_SCALING_FACTOR_DOC,
+          group,
+          ++orderInGroup,
+          Width.LONG,
+          TIMESTAMP_SCALING_FACTOR_DISPLAY);
+
+      configDef.define(TIMESTAMP_SCALING_OPERATION_CONFIG,
+          Type.STRING,
+          TIMESTAMP_SCALING_OPERATION_DEFAULT,
+          Importance.MEDIUM,
+          TIMESTAMP_SCALING_OPERATION_DOC,
+          group,
+          ++orderInGroup,
+          Width.LONG,
+          TIMESTAMP_SCALING_OPERATION_DISPLAY);
     }
 
     return configDef;


### PR DESCRIPTION
## Problem
#126 Improve to storage partitioning scheme to be flexible and configurable at runtime

## Solution
This provides ability to specify scaling factor for timestamp column used in partitioning by configuration

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
