### PR TITLE
CC-1360: Enable enhanced avro schema support by default in storage sink connectors

### DIFF
--- a/core/src/main/java/io/confluent/connect/storage/StorageSinkConnectorConfig.java
+++ b/core/src/main/java/io/confluent/connect/storage/StorageSinkConnectorConfig.java
@@ -101,7 +101,7 @@ public class StorageSinkConnectorConfig extends AbstractConfig implements Compos
   public static final String SCHEMA_CACHE_SIZE_DISPLAY = "Schema Cache Size";
 
   public static final String ENHANCED_AVRO_SCHEMA_SUPPORT_CONFIG = "enhanced.avro.schema.support";
-  public static final boolean ENHANCED_AVRO_SCHEMA_SUPPORT_DEFAULT = false;
+  public static final boolean ENHANCED_AVRO_SCHEMA_SUPPORT_DEFAULT = true;
   public static final String ENHANCED_AVRO_SCHEMA_SUPPORT_DOC =
       "Enable enhanced avro schema support in AvroConverter: Enum symbol preservation and Package"
           + " Name awareness";


### PR DESCRIPTION
## Problem
Changing the default required the release of a major version

## Solution
Switch the default to enhanced avro schema support

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Only 10.0.x and beyond