### PR TITLE
MINOR: Fix pom metadata in htrace shaded dependency

### DIFF
--- a/htrace-core4-shaded/pom.xml
+++ b/htrace-core4-shaded/pom.xml
@@ -59,6 +59,11 @@ language governing permissions and limitations under the License. -->
                                     <includes>
                                         <include>**</include>
                                     </includes>
+                                    <excludes>
+                                        <exclude>META-INF/services/**</exclude>
+                                        <exclude>META-INF/maven/com.fasterxml.jackson.core/**</exclude>
+                                        <exclude>org/apache/htrace/shaded/fasterxml/jackson/**</exclude>
+                                    </excludes>
                                 </filter>
                                 <filter>
                                     <!-- this filter is a workaround to the fact that maven phases
@@ -80,9 +85,6 @@ language governing permissions and limitations under the License. -->
                                         <exclude>META-INF/MANIFEST.MF</exclude>
                                         <exclude>META-INF/LICENSE</exclude>
                                         <exclude>META-INF/NOTICE</exclude>
-                                        <exclude>META-INF/services/**</exclude>
-                                        <exclude>META-INF/maven/com.fasterxml.jackson.core/**</exclude>
-                                        <exclude>org/apache/htrace/shaded/fasterxml/jackson/**</exclude>
                                     </excludes>
                                 </filter>
                             </filters>


### PR DESCRIPTION
## Problem
Pom files of the old jackson version where preserved in htrace-core4, which confuses the CVE scanner. 
The actual files are correct

## Solution
Adjust the exclusions correctly

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
10.0.x and newer