### PR TITLE
MINOR: Fix versions of modules added after the creation of 10.0.x branch

### DIFF
--- a/avatica-shaded/pom.xml
+++ b/avatica-shaded/pom.xml
@@ -16,7 +16,7 @@ language governing permissions and limitations under the License. -->
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>10.0.0-SNAPSHOT</version>
+        <version>10.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kafka-connect-storage-common-avatica-shaded</artifactId>

--- a/htrace-core4-shaded/pom.xml
+++ b/htrace-core4-shaded/pom.xml
@@ -16,7 +16,7 @@ language governing permissions and limitations under the License. -->
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>10.0.0-SNAPSHOT</version>
+        <version>10.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kafka-connect-storage-common-htrace-core4-shaded</artifactId>


### PR DESCRIPTION
## Problem
The new modules were introduced after the creation of 10.0.x and were merged on that branch. 
Their version needs to be adjusted manually on the `master` branch.

## Solution
Set version `10.1.0-SNAPSHOT` on `master` for the new modules

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Only `master`