### PR TITLE
Fix time-zone aware calculation for scheduled rotation between daylight savings and standard time

### DIFF
--- a/core/src/main/java/io/confluent/connect/storage/util/DateTimeUtils.java
+++ b/core/src/main/java/io/confluent/connect/storage/util/DateTimeUtils.java
@@ -16,13 +16,11 @@
 
 package io.confluent.connect.storage.util;
 
+import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-
-import java.util.concurrent.TimeUnit;
+import org.joda.time.Duration;
 
 public class DateTimeUtils {
-
-  private static final long DAY_IN_MS = TimeUnit.DAYS.toMillis(1);
 
   /**
    * Calculates next period of periodMs after currentTimeMs
@@ -40,12 +38,15 @@ public class DateTimeUtils {
       long periodMs,
       DateTimeZone timeZone
   ) {
-    long startOfDay = timeZone.convertLocalToUTC(
-        timeZone.convertUTCToLocal(currentTimeMs) / DAY_IN_MS * DAY_IN_MS,
-        true
-    );
+    DateTime currentDT = new DateTime(currentTimeMs).withZone(timeZone);
+    DateTime startOfDayDT = currentDT.withTimeAtStartOfDay();
+    DateTime startOfNextDayDT = startOfDayDT.plusDays(1);
+    Duration currentDayDuration = new Duration(startOfDayDT, startOfNextDayDT);
+    long todayInMs = currentDayDuration.getMillis();
+
+    long startOfDay = startOfDayDT.getMillis();
     long nextPeriodOffset = ((currentTimeMs - startOfDay) / periodMs + 1) * periodMs;
-    long offset = Math.min(nextPeriodOffset, DAY_IN_MS);
+    long offset = Math.min(nextPeriodOffset, todayInMs);
     return startOfDay + offset;
   }
 }

--- a/core/src/test/java/io/confluent/connect/storage/util/DateTimeUtilsTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/util/DateTimeUtilsTest.java
@@ -58,4 +58,18 @@ public class DateTimeUtilsTest {
         DateTime time2 = new DateTime(DATE_TIME_ZONE.convertUTCToLocal(utc2));
         assertEquals(time1.toString(formatter), time2.toString(formatter));
     }
+
+    @Test
+    public void testGetNextTimeAdjustedByDayDSTSwitch() {
+        // on this DST switch day we get 25 hours in a day (DATE_TIME_ZONE time zone)
+        DateTime dstSwitchDay10pm = DateTime.parse("2019-11-03T22:00:00.000-08:00").withZone(DATE_TIME_ZONE);
+        DateTime dstSwitchDay11pm = DateTime.parse("2019-11-03T23:00:00.000-08:00").withZone(DATE_TIME_ZONE);
+        DateTime dstSwitchNextDayMidnight = DateTime.parse("2019-11-04T00:00:00.000-08:00").withZone(DATE_TIME_ZONE);
+
+        // 10pm next hour should be 11pm
+        assertEquals(dstSwitchDay11pm, calcHourPeriod(dstSwitchDay10pm).withZone(DATE_TIME_ZONE));
+
+        // 11pm next hour should be midnight of next day
+        assertEquals(dstSwitchNextDayMidnight, calcHourPeriod(dstSwitchDay11pm).withZone(DATE_TIME_ZONE));
+    }
 }


### PR DESCRIPTION
Doing time-zone aware calculation for scheduled rotation

## Problem
As stated in https://github.com/confluentinc/kafka-connect-storage-cloud/issues/375 :
When scheduled rotation is enabled, on the day of the DST changes (25 hour day), during the last hour of the day kafka connect s3 sink would be rotating files after every record, producing a lot of tiny files.

## Solution
Perform timezone aware date-time calculations.

## Test Strategy
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Ready to be merged to master and should be safe to roll-back.