### PR TITLE
CC-13001: Remove avro-converter dependency and add avro-data dependency

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -36,7 +36,7 @@
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
-            <artifactId>kafka-connect-avro-converter</artifactId>
+            <artifactId>kafka-connect-avro-data</artifactId>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>

--- a/format/pom.xml
+++ b/format/pom.xml
@@ -38,7 +38,7 @@
     <dependencies>
         <dependency>
             <groupId>io.confluent</groupId>
-            <artifactId>kafka-connect-avro-converter</artifactId>
+            <artifactId>kafka-connect-avro-data</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.parquet</groupId>

--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -47,7 +47,7 @@
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
-            <artifactId>kafka-connect-avro-converter</artifactId>
+            <artifactId>kafka-connect-avro-data</artifactId>
             <version>${confluent.version}</version>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -117,8 +117,8 @@
             </dependency>
             <dependency>
                 <groupId>io.confluent</groupId>
-                <artifactId>kafka-connect-avro-converter</artifactId>
-                <version>${project.version}</version>
+                <artifactId>kafka-connect-avro-data</artifactId>
+                <version>${confluent.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.parquet</groupId>


### PR DESCRIPTION
## Problem
The current cc-docker image has kafka-connect-avro-converter in multiple places:

/usr/share/java/connectors/plugins/converters

/opt/confluent/libs

S3 sink, ADLS2, GCP functions, Azure functions, Dataproc sink, Azure blob storage, GCS sink connectors.

It’s problematic to have the same library in multiple locations, and we need to worry about version consistency. We want to have this library in /usr/share/java/connectors/plugins/converters only, and treat it as another plugin.


## Solution
Now that we have the `avro-data` dependency available, remove `avro-converter` dependency from downstream blob connectors https://confluentinc.atlassian.net/browse/CC-7169

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes ADLS Gen2 Sink, Azure Blob Sink, GCS Sink, S3 Sink
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:

Tested with IT's in Azure Blob Storage https://github.com/confluentinc/kafka-connect-azure-blob-storage/pull/125
- [ ] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
