### PR TITLE
MINOR: pin jamon dependency to fix build errors

### DIFF
--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -95,6 +95,10 @@
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.jamon</groupId>
+                    <artifactId>jamon-runtime</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <!-- Explicitly include working version of xml-apis -->
@@ -133,6 +137,11 @@
             <groupId>org.apache.avro</groupId>
             <artifactId>avro-mapred</artifactId>
             <version>${avro.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jamon</groupId>
+            <artifactId>jamon-runtime</artifactId>
+            <version>2.4.1</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -31,6 +31,7 @@
         <commons.lang3.version>3.1</commons.lang3.version>
         <kryo.version>2.22</kryo.version>
         <xml-apis.version>1.4.01</xml-apis.version>
+        <jamon.runtime.version>2.4.1</jamon.runtime.version>
     </properties>
 
     <dependencies>
@@ -141,7 +142,7 @@
         <dependency>
             <groupId>org.jamon</groupId>
             <artifactId>jamon-runtime</artifactId>
-            <version>2.4.1</version>
+            <version>${jamon.runtime.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Signed-off-by: Lev Zemlyanov <lev@confluent.io>

## Problem
jamon runtime is causing build errors for some storage connectors i.e [HDFS](https://github.com/confluentinc/kafka-connect-hdfs/tree/10.0.x)

due to https://www.jfrog.com/jira/browse/RTFACT-16033, suppressing consistency checks is not an option

## Solution
pin this dependency and release a new version of storage common

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
pinned the snapshot version to HDFS and made sure it built and ran all of the hive tests correctly

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
release `v10.0.2` for the storage connectors to use