### PR TITLE
CC-13056: address http and jackson CVEs

### DIFF
--- a/avatica-shaded/pom.xml
+++ b/avatica-shaded/pom.xml
@@ -51,6 +51,7 @@ language governing permissions and limitations under the License. -->
                                 <includes>
                                     <include>org.apache.calcite.avatica:*</include>
                                     <include>com.fasterxml.jackson.core:*</include>
+                                    <include>org.apache.httpcomponents</include>
                                 </includes>
                             </artifactSet>
                             <filters>
@@ -63,6 +64,9 @@ language governing permissions and limitations under the License. -->
                                         <exclude>META-INF/services/com.fasterxml.jackson.core*</exclude>
                                         <exclude>META-INF/maven/com.fasterxml.jackson.core/**</exclude>
                                         <exclude>com/fasterxml/jackson/**</exclude>
+                                        <exclude>META-INF/services/org.apache.httpcomponents*</exclude>
+                                        <exclude>META-INF/maven/org.apache.httpcomponents/**</exclude>
+                                        <exclude>org/apache/httpcomponents/**</exclude>
                                     </excludes>
                                 </filter>
                                 <filter>
@@ -78,6 +82,17 @@ language governing permissions and limitations under the License. -->
                                 </filter>
                                 <filter>
                                     <artifact>com.fasterxml.jackson.core:*</artifact>
+                                    <includes>
+                                        <include>**</include>
+                                    </includes>
+                                    <excludes>
+                                        <exclude>META-INF/MANIFEST.MF</exclude>
+                                        <exclude>META-INF/LICENSE</exclude>
+                                        <exclude>META-INF/NOTICE</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>org.apache.httpcomponents:httpclient</artifact>
                                     <includes>
                                         <include>**</include>
                                     </includes>

--- a/avatica-shaded/pom.xml
+++ b/avatica-shaded/pom.xml
@@ -109,7 +109,12 @@ language governing permissions and limitations under the License. -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.databind.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${httpclient.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/htrace-core4-shaded/pom.xml
+++ b/htrace-core4-shaded/pom.xml
@@ -115,7 +115,7 @@ language governing permissions and limitations under the License. -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.databind.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>6.0.0</version>
+        <version>6.0.1</version>
     </parent>
 
     <artifactId>kafka-connect-storage-common-parent</artifactId>
@@ -71,12 +71,13 @@
         <hive.version>2.3.7</hive.version>
         <joda.version>2.9.6</joda.version>
         <parquet.version>1.11.1</parquet.version>
-        <httpclient.version>4.5.2</httpclient.version>
+        <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.4</httpcore.version>
         <jline.version>2.12.1</jline.version>
         <confluent-log4j.version>1.2.17-cp2</confluent-log4j.version>
         <commons.codec.version>1.15</commons.codec.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
+        <jackson.databind.version>2.10.5.1</jackson.databind.version>
     </properties>
 
     <repositories>
@@ -155,6 +156,11 @@
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
                 <version>${commons.codec.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.databind.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Signed-off-by: Lev Zemlyanov <lev@confluent.io>

## Problem
there are still multiple CVEs (jackson-databind and http-components)

## Solution
bump common parent and the CVEs versions to clean ones (twistlock shows clean)

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
bug fix version bumps so harmless
built a local version and tried it downstream with HDFS and everything passed

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
`10.0.x` where the CVEs are reported