### PR TITLE
CC-13532: Pin storage common version in parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
     </modules>
 
     <properties>
+        <kafka.connect.storage.common.version>10.0.2</kafka.connect.storage.common.version>
         <commons-io.version>2.4</commons-io.version>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <hadoop.version>2.10.1</hadoop.version>
@@ -94,27 +95,27 @@
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-connect-storage-common</artifactId>
-                <version>${project.version}</version>
+                <version>${kafka.connect.storage.common.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-connect-storage-core</artifactId>
-                <version>${project.version}</version>
+                <version>${kafka.connect.storage.common.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-connect-storage-format</artifactId>
-                <version>${project.version}</version>
+                <version>${kafka.connect.storage.common.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-connect-storage-partitioner</artifactId>
-                <version>${project.version}</version>
+                <version>${kafka.connect.storage.common.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-connect-storage-wal</artifactId>
-                <version>${project.version}</version>
+                <version>${kafka.connect.storage.common.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.confluent</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     </modules>
 
     <properties>
-        <kafka.connect.storage.common.version>10.0.2</kafka.connect.storage.common.version>
+        <kafka.connect.storage.common.version>10.0.3-SNAPSHOT</kafka.connect.storage.common.version>
         <commons-io.version>2.4</commons-io.version>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <hadoop.version>2.10.1</hadoop.version>


### PR DESCRIPTION
## Problem
Currently the parent pom uses `${project.version}` for the submodules `kafka-connect-storage-common`, `kafka-connect-storage-core`, `kafka-connect-storage-format`, `kafka-connect-storage-partitioner`, `kafka-connect-storage-wal`. 

This becomes an issue when building connectors that use this parent, as the `${project.version}` in a parent pom refers to the version of the child, not the parent. The value gets re-interpreted by maven every time on a build and refers to the version of the project built at that moment, not the version of the parent. This has resulted in connector build job errors as `SNAPSHOT` dependencies are not allowed. 

```
01:01:13  [ERROR] Failed to execute goal org.apache.maven.plugins:maven-release-plugin:2.5.3:prepare (default-cli) on project kafka-connect-storage-cloud: 
Can't release project due to non released dependencies :
01:01:13  [ERROR]     io.confluent:kafka-connect-storage-common:jar:10.0.0-SNAPSHOT:compile
01:01:13  [ERROR]     io.confluent:kafka-connect-storage-core:jar:10.0.0-SNAPSHOT:compile
01:01:13  [ERROR]     io.confluent:kafka-connect-storage-format:jar:10.0.0-SNAPSHOT:compile
01:01:13  [ERROR]     io.confluent:kafka-connect-storage-partitioner:jar:10.0.0-SNAPSHOT:compile
01:01:13  [ERROR] in project 'kafka-connect-storage-cloud' (io.confluent:kafka-connect-storage-cloud:pom:10.0.0-SNAPSHOT)
```
[In this example](https://github.com/confluentinc/kafka-connect-hdfs/pull/529/files) we also had to replace the `SNAPSHOT` version with a non-snapshot one for the build job to pass. 
## Solution

[Current workaround](https://github.com/confluentinc/kafka-connect-hdfs/commit/5ce49b67379ab63b548b650a4a0908ad547af6ec) defines the version in the connector pom. Instead of overwriting this version property in each child repo, we should define the version in the parent. This will also allow us to remove the version pinned in the inherited connector poms and remove the `<version>` tags of the dependencies there for a cleaner configuration.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [X] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [X] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Backporting to `10.0.x` as CP connectors were de-coupled starting that version. 