### PR TITLE
Update pom to exclude org/apache/http from the shaded JAR.

### DIFF
--- a/avatica-shaded/pom.xml
+++ b/avatica-shaded/pom.xml
@@ -64,9 +64,8 @@ language governing permissions and limitations under the License. -->
                                         <exclude>META-INF/services/com.fasterxml.jackson.core*</exclude>
                                         <exclude>META-INF/maven/com.fasterxml.jackson.core/**</exclude>
                                         <exclude>com/fasterxml/jackson/**</exclude>
-                                        <exclude>META-INF/services/org.apache.httpcomponents*</exclude>
                                         <exclude>META-INF/maven/org.apache.httpcomponents/**</exclude>
-                                        <exclude>org/apache/httpcomponents/**</exclude>
+                                        <exclude>org/apache/calcite/avatica/org/apache/http/**</exclude>
                                     </excludes>
                                 </filter>
                                 <filter>


### PR DESCRIPTION
## Problem

Looks like we have two sets of classes in `org.apache.http` package: one of the correct version(`4.5.13`) and one of the old version(`4.5.2`).

```
mvn clean package
...
unzip kafka-connect-storage-common-avatica-shaded-10.0.4-SNAPSHOT.jar -d kafka-connect-storage-common-avatica-shaded-10.0.4-SNAPSHOT
...
cd kafka-connect-storage-common-avatica-shaded-10.0.4-SNAPSHOT
...
find . -name "HttpClient.class"
./org/apache/calcite/avatica/org/apache/http/client/HttpClient.class
./org/apache/http/client/HttpClient.class
...
cat org/apache/http/client/version.properties|grep release
info.release   = 4.5.13
...
cat org/apache/calcite/avatica/org/apache/http/client/version.properties|grep release
info.release   = 4.5.2
```



## Solution
Exclude the `org/apache/httpcomponents/**` package from the shaded JAR.


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
