### PR TITLE
CC-13830: upgrade  org.apache.httpcomponents:httpclient version to 4.5.13 to address CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <joda.version>2.9.6</joda.version>
         <licenses.version>5.0.5-SNAPSHOT</licenses.version>
         <parquet.version>1.8.2</parquet.version>
-        <httpclient.version>4.5.2</httpclient.version>
+        <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.4</httpcore.version>
         <jline.version>2.12.1</jline.version>
     </properties>


### PR DESCRIPTION
## Problem
HttpClient dependency version contains a CVE: https://nvd.nist.gov/vuln/detail/CVE-2020-13956

## Solution
Upgrade to HttpClient 4.5.13

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?


## Test Strategy
The purpose is to start a discussion for https://confluentinc.atlassian.net/browse/CC-13830.
Let's discuss whether additional tests are needed. 

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
Merge to master
<!-- If you are reverting or rolling back, is it safe? --> 
