### PR TITLE
MINOR: Use PartitionException instead of ConnectException when unable to extract the record timestamp in TimeBasedPartitioner

### DIFF
--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/TimeBasedPartitioner.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/TimeBasedPartitioner.java
@@ -23,6 +23,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.data.Timestamp;
 import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -170,7 +171,7 @@ public class TimeBasedPartitioner<T> extends DefaultPartitioner<T> {
           + " for record: "
           + sinkRecord;
       log.error(msg);
-      throw new ConnectException(msg);
+      throw new DataException(msg);
     }
     DateTime bucket = new DateTime(
         getPartition(partitionDurationMs, timestamp, formatter.getZone())

--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/TimeBasedPartitioner.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/TimeBasedPartitioner.java
@@ -23,7 +23,6 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.data.Timestamp;
 import org.apache.kafka.connect.errors.ConnectException;
-import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -171,7 +170,7 @@ public class TimeBasedPartitioner<T> extends DefaultPartitioner<T> {
           + " for record: "
           + sinkRecord;
       log.error(msg);
-      throw new DataException(msg);
+      throw new PartitionException(msg);
     }
     DateTime bucket = new DateTime(
         getPartition(partitionDurationMs, timestamp, formatter.getZone())


### PR DESCRIPTION
## Problem
https://github.com/confluentinc/kafka-connect-storage-common/pull/177 should go into `10.0.x`

## Solution
Port to `10.0.x`.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [X] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [X] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Target `10.0.x`