### PR TITLE
WAL: created FilePathOffset class, and added extractLatestOffsetFromWAL to interface

### DIFF
--- a/wal/src/main/java/io/confluent/connect/storage/wal/FilePathOffset.java
+++ b/wal/src/main/java/io/confluent/connect/storage/wal/FilePathOffset.java
@@ -24,16 +24,16 @@ package io.confluent.connect.storage.wal;
  */
 public class FilePathOffset {
 
-  public final long extractedOffset;
+  public final long offset;
   public final String filePath;
 
-  public FilePathOffset(long extractedOffset, String filePath) {
-    this.extractedOffset = extractedOffset;
+  public FilePathOffset(long offset, String filePath) {
+    this.offset = offset;
     this.filePath = filePath;
   }
 
   public long getOffset() {
-    return extractedOffset;
+    return offset;
   }
 
   public String getFilePath() {
@@ -43,7 +43,7 @@ public class FilePathOffset {
   @Override
   public String toString() {
     return "FilePathOffset{"
-        + "extractedOffset=" + extractedOffset
+        + "extractedOffset=" + offset
         + ", filePath='" + filePath + '\''
         + '}';
   }

--- a/wal/src/main/java/io/confluent/connect/storage/wal/FilePathOffset.java
+++ b/wal/src/main/java/io/confluent/connect/storage/wal/FilePathOffset.java
@@ -24,8 +24,8 @@ package io.confluent.connect.storage.wal;
  */
 public class FilePathOffset {
 
-  public final long offset;
-  public final String filePath;
+  private final long offset;
+  private final String filePath;
 
   public FilePathOffset(long offset, String filePath) {
     this.offset = offset;

--- a/wal/src/main/java/io/confluent/connect/storage/wal/FilePathOffset.java
+++ b/wal/src/main/java/io/confluent/connect/storage/wal/FilePathOffset.java
@@ -1,0 +1,35 @@
+package io.confluent.connect.storage.wal;
+
+/**
+ * A class to keep track of an offset and filepath pair.
+ *
+ * <p>The offset may be extracted from the filepath in the same function. Extracting the offset from
+ * the file path involves O(n) time complexity. This class can be used to link the extracted offset
+ * to the filepath to avoid the re-computation of extracting the offset.</p>
+ */
+public class FilePathOffset {
+
+  public final long extractedOffset;
+  public final String filePath;
+
+  public FilePathOffset(long extractedOffset, String filePath) {
+    this.extractedOffset = extractedOffset;
+    this.filePath = filePath;
+  }
+
+  public long getOffset() {
+    return extractedOffset;
+  }
+
+  public String getFilePath() {
+    return filePath;
+  }
+
+  @Override
+  public String toString() {
+    return "FilePathOffset{" +
+        "extractedOffset=" + extractedOffset +
+        ", filePath='" + filePath + '\'' +
+        '}';
+  }
+}

--- a/wal/src/main/java/io/confluent/connect/storage/wal/FilePathOffset.java
+++ b/wal/src/main/java/io/confluent/connect/storage/wal/FilePathOffset.java
@@ -43,7 +43,7 @@ public class FilePathOffset {
   @Override
   public String toString() {
     return "FilePathOffset{"
-        + "extractedOffset=" + offset
+        + "offset=" + offset
         + ", filePath='" + filePath + '\''
         + '}';
   }

--- a/wal/src/main/java/io/confluent/connect/storage/wal/FilePathOffset.java
+++ b/wal/src/main/java/io/confluent/connect/storage/wal/FilePathOffset.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.connect.storage.wal;
 
 /**
@@ -27,9 +42,9 @@ public class FilePathOffset {
 
   @Override
   public String toString() {
-    return "FilePathOffset{" +
-        "extractedOffset=" + extractedOffset +
-        ", filePath='" + filePath + '\'' +
-        '}';
+    return "FilePathOffset{"
+        + "extractedOffset=" + extractedOffset
+        + ", filePath='" + filePath + '\''
+        + '}';
   }
 }

--- a/wal/src/main/java/io/confluent/connect/storage/wal/WAL.java
+++ b/wal/src/main/java/io/confluent/connect/storage/wal/WAL.java
@@ -35,5 +35,5 @@ public interface WAL {
 
   String getLogFile();
 
-  FilePathOffset extractLatestOffsetFromWAL();
+  FilePathOffset extractLatestOffset();
 }

--- a/wal/src/main/java/io/confluent/connect/storage/wal/WAL.java
+++ b/wal/src/main/java/io/confluent/connect/storage/wal/WAL.java
@@ -34,4 +34,6 @@ public interface WAL {
   void close() throws ConnectException;
 
   String getLogFile();
+
+  FilePathOffset extractLatestOffsetFromWAL();
 }


### PR DESCRIPTION
## Problem
The `WAL` interface does lacks a function to support extracting latest offsets from `WAL` files. 

## Solution
Add a function to support extracting offsets from `WAL` files and a class to keep track of the returned offset-path value pair. 


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [X] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Targeting `10.0.x` for new release. 