### PR TITLE
MINOR: Align versions in parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     </modules>
 
     <properties>
-        <kafka.connect.storage.common.version>10.0.3-SNAPSHOT</kafka.connect.storage.common.version>
+        <kafka.connect.storage.common.version>10.1.0-SNAPSHOT</kafka.connect.storage.common.version>
         <commons-io.version>2.4</commons-io.version>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <hadoop.version>2.10.1</hadoop.version>


### PR DESCRIPTION
## Problem
In the parent pom, `version` and `kafka.connect.storage.common.version` are misaligned. 

## Solution
Update `kafka.connect.storage.common.version` to `10.1.0-SNAPSHOT` .

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [X] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Fixing on `master` 