### PR TITLE
MINOR: Pin version for dependency check plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,9 @@
         <commons.codec.version>1.15</commons.codec.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
         <jackson.databind.version>2.10.5.1</jackson.databind.version>
+        <!-- temporary fix by pinning the version until we upgrade to a version of common that contains this or newer version.
+            See https://github.com/confluentinc/common/pull/332 for details -->
+        <dependency.check.version>6.1.6</dependency.check.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
## Problem
Same issue as in: confluentinc/common#332
But the connector depends on a released version of common since version 10.0.x

## Solution
Overwrite the property.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
