### PR TITLE
CC-14522: resolve hadoop, jackson, thrift, log4j, commons-collection, bean-utils, netty, zookeeper, commons-codec, and httpclient CVEs

### DIFF
--- a/format/pom.xml
+++ b/format/pom.xml
@@ -29,6 +29,12 @@
     <packaging>jar</packaging>
     <name>kafka-connect-storage-format</name>
 
+    <properties>
+        <jackson.groupId>com.fasterxml.jackson.core</jackson.groupId>
+        <jackson.package>com.fasterxml.jackson</jackson.package>
+        <shade.prefix>shaded.parquet</shade.prefix>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.confluent</groupId>
@@ -45,6 +51,12 @@
         <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-avro</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.parquet</groupId>
+                    <artifactId>parquet-jackson</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -52,4 +64,46 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <minimizeJar>false</minimizeJar>
+                            <createSourcesJar>false</createSourcesJar>
+                            <artifactSet>
+                                <includes>
+                                    <include>${jackson.groupId}:*</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>${jackson.groupId}:*</artifact>
+                                    <includes>
+                                        <include>**</include>
+                                    </includes>
+                                </filter>
+                            </filters>
+                            <relocations>
+                                <relocation>
+                                    <pattern>${jackson.package}</pattern>
+                                    <shadedPattern>${shade.prefix}.${jackson.package}</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -56,6 +56,10 @@
             <version>${hadoop.version}</version>
             <exclusions>
                 <exclusion>
+                    <groupId>commons-collections</groupId>
+                    <artifactId>commons-collections</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>
@@ -86,6 +90,10 @@
             <version>${hive.version}</version>
             <classifier>core</classifier>
             <exclusions>
+                <exclusion>
+                    <groupId>commons-collections</groupId>
+                    <artifactId>commons-collections</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>commons-httpclient</groupId>
                     <artifactId>commons-httpclient</artifactId>

--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -83,6 +83,10 @@
             <classifier>core</classifier>
             <exclusions>
                 <exclusion>
+                    <groupId>commons-httpclient</groupId>
+                    <artifactId>commons-httpclient</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>

--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -59,6 +59,10 @@
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.htrace</groupId>
+                    <artifactId>htrace-core4</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -54,6 +54,12 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
             <version>${hadoop.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hive.hcatalog</groupId>
@@ -64,6 +70,10 @@
                     <groupId>org.apache.hive</groupId>
                     <artifactId>hive-exec</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -71,6 +81,12 @@
             <artifactId>hive-exec</artifactId>
             <version>${hive.version}</version>
             <classifier>core</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/htrace-core4-shaded/pom.xml
+++ b/htrace-core4-shaded/pom.xml
@@ -16,7 +16,7 @@ language governing permissions and limitations under the License. -->
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>10.0.0-SNAPSHOT</version>
+        <version>5.2.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>kafka-connect-storage-common-htrace-core4-shaded</artifactId>
@@ -28,7 +28,6 @@ language governing permissions and limitations under the License. -->
 
     <properties>
         <htrace.version>4.1.0-incubating</htrace.version>
-        <jackson.version>2.10.5</jackson.version>
     </properties>
 
     <build>
@@ -113,7 +112,7 @@ language governing permissions and limitations under the License. -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.databind.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/htrace-core4-shaded/pom.xml
+++ b/htrace-core4-shaded/pom.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor
+license agreements. See the NOTICE file distributed with this work for additional
+information regarding copyright ownership. The ASF licenses this file to
+You under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of
+the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required
+by applicable law or agreed to in writing, software distributed under the
+License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.confluent</groupId>
+        <artifactId>kafka-connect-storage-common-parent</artifactId>
+        <version>10.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>kafka-connect-storage-common-htrace-core4-shaded</artifactId>
+    <packaging>jar</packaging>
+    <name>kafka-connect-storage-common-htrace-core4-shaded</name>
+    
+    <description>htrace-core4 shaded to replace jackson dependencies without CVEs</description>
+    <inceptionYear>2020</inceptionYear>
+
+    <properties>
+        <htrace.version>4.1.0-incubating</htrace.version>
+        <jackson.version>2.10.5</jackson.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.htrace:*</include>
+                                    <include>com.fasterxml.jackson.core:*</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>org.apache.htrace:htrace-core4</artifact>
+                                    <includes>
+                                        <include>**</include>
+                                    </includes>
+                                </filter>
+                                <filter>
+                                    <!-- this filter is a workaround to the fact that maven phases
+                                    can't run twice without adding new code to the produced jar
+                                    (by producing an empty jar). It's used to remove the placeholder
+                                    class io.confluent.connect.storage.PlaceHolder.class
+                                     -->
+                                    <artifact>io.confluent:*</artifact>
+                                    <excludes>
+                                        <exlude>**</exlude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>com.fasterxml.jackson.core:*</artifact>
+                                    <includes>
+                                        <include>**</include>
+                                    </includes>
+                                    <excludes>
+                                        <exclude>META-INF/MANIFEST.MF</exclude>
+                                        <exclude>META-INF/LICENSE</exclude>
+                                        <exclude>META-INF/NOTICE</exclude>
+                                        <exclude>META-INF/services/**</exclude>
+                                        <exclude>META-INF/maven/com.fasterxml.jackson.core/**</exclude>
+                                        <exclude>org/apache/htrace/shaded/fasterxml/jackson/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson</pattern>
+                                    <shadedPattern>org.apache.htrace.shaded.fasterxml.jackson</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.htrace</groupId>
+            <artifactId>htrace-core4</artifactId>
+            <version>${htrace.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/htrace-core4-shaded/pom.xml
+++ b/htrace-core4-shaded/pom.xml
@@ -58,6 +58,11 @@ language governing permissions and limitations under the License. -->
                                     <includes>
                                         <include>**</include>
                                     </includes>
+                                    <excludes>
+                                        <exclude>META-INF/services/**</exclude>
+                                        <exclude>META-INF/maven/com.fasterxml.jackson.core/**</exclude>
+                                        <exclude>org/apache/htrace/shaded/fasterxml/jackson/**</exclude>
+                                    </excludes>
                                 </filter>
                                 <filter>
                                     <!-- this filter is a workaround to the fact that maven phases

--- a/htrace-core4-shaded/src/main/java/io/confluent/connect/storage/PlaceHolder.java
+++ b/htrace-core4-shaded/src/main/java/io/confluent/connect/storage/PlaceHolder.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.storage;
+
+/**
+ * This class is added as a workaround to maven. Attempting to run both verify and install phases
+ * with maven fails if there's no source code in the project (the produced jar is empty).
+ * {@see http://mail-archives.apache.org/mod_mbox/maven-users/201608.mbox/%3c20160805151905.500d5c45@copperhead.int.arc7.info%3e}
+ * <br>
+ * This fact subsequently fails the attempt to re-shade the dependencies without adding new code.
+ * The workaround is to introduce this class here, with the intention to remove it during shading
+ * by configuring a filter for maven-shade-plugin.
+ */
+public class PlaceHolder {
+}

--- a/htrace-core4-shaded/src/main/java/io/confluent/connect/storage/PlaceHolder.java
+++ b/htrace-core4-shaded/src/main/java/io/confluent/connect/storage/PlaceHolder.java
@@ -24,5 +24,4 @@ package io.confluent.connect.storage;
  * The workaround is to introduce this class here, with the intention to remove it during shading
  * by configuring a filter for maven-shade-plugin.
  */
-public class PlaceHolder {
-}
+public class PlaceHolder { }

--- a/pom.xml
+++ b/pom.xml
@@ -65,13 +65,18 @@
 
     <properties>
         <commons-io.version>2.4</commons-io.version>
+        <commons.beanutils.version>1.9.4</commons.beanutils.version>
+        <commons.codec.version>1.15</commons.codec.version>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <confluent.version>5.2.5-SNAPSHOT</confluent.version>
         <hadoop.version>2.7.3</hadoop.version>
         <hive.version>1.2.2</hive.version>
+        <jackson.databind.version>2.10.5.1</jackson.databind.version>
+        <jackson.mapper.asl.version>1.9.13</jackson.mapper.asl.version>
         <joda.version>2.9.6</joda.version>
         <licenses.version>5.2.5-SNAPSHOT</licenses.version>
-        <parquet.version>1.8.2</parquet.version>
+        <netty.version>4.1.63.Final</netty.version>
+        <parquet.version>1.11.0</parquet.version>
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.4</httpcore.version>
         <jline.version>2.12.1</jline.version>
@@ -153,6 +158,32 @@
                 <artifactId>junit</artifactId>
                 <version>${junit.version}</version>
                 <scope>test</scope>
+            </dependency>
+            <!-- Pinning for CVEs -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.databind.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-beanutils</groupId>
+                <artifactId>commons-beanutils</artifactId>
+                <version>${commons.beanutils.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>${commons.codec.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-all</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.jackson</groupId>
+                <artifactId>jackson-mapper-asl</artifactId>
+                <version>${jackson.mapper.asl.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
         <jackson.version>2.10.5</jackson.version>
         <jackson.databind.version>2.10.5.1</jackson.databind.version>
         <jackson.mapper.asl.version>1.9.13</jackson.mapper.asl.version>
+        <jetty.version>9.4.40.v20210413</jetty.version>
         <jline.version>2.12.1</jline.version>
         <joda.version>2.9.6</joda.version>
         <licenses.version>5.2.5-SNAPSHOT</licenses.version>
@@ -216,6 +217,11 @@
                 <groupId>org.codehaus.jackson</groupId>
                 <artifactId>jackson-mapper-asl</artifactId>
                 <version>${jackson.mapper.asl.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-io</artifactId>
+                <version>${jetty.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <module>partitioner</module>
         <module>format</module>
         <module>hive</module>
+        <module>htrace-core4-shaded</module>
         <module>package-kafka-connect-storage-common</module>
     </modules>
 

--- a/pom.xml
+++ b/pom.xml
@@ -183,11 +183,6 @@
                 <version>${commons.codec.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.confluent</groupId>
-                <artifactId>confluent-log4j</artifactId>
-                <version>${confluent.log4j.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-all</artifactId>
                 <version>${netty.version}</version>
@@ -235,6 +230,12 @@
             <groupId>jline</groupId>
             <artifactId>jline</artifactId>
             <version>${jline.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>confluent-log4j</artifactId>
+            <version>${confluent.log4j.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -71,15 +71,16 @@
         <confluent.version>5.2.5-SNAPSHOT</confluent.version>
         <hadoop.version>2.10.1</hadoop.version>
         <hive.version>1.2.2</hive.version>
+        <httpclient.version>4.5.13</httpclient.version>
+        <httpcore.version>4.4.4</httpcore.version>
         <jackson.databind.version>2.10.5.1</jackson.databind.version>
         <jackson.mapper.asl.version>1.9.13</jackson.mapper.asl.version>
+        <jline.version>2.12.1</jline.version>
         <joda.version>2.9.6</joda.version>
         <licenses.version>5.2.5-SNAPSHOT</licenses.version>
         <netty.version>4.1.63.Final</netty.version>
         <parquet.version>1.11.0</parquet.version>
-        <httpclient.version>4.5.13</httpclient.version>
-        <httpcore.version>4.4.4</httpcore.version>
-        <jline.version>2.12.1</jline.version>
+        <thrift.version>0.14.1</thrift.version>
     </properties>
 
     <repositories>
@@ -179,6 +180,11 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-all</artifactId>
                 <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.thrift</groupId>
+                <artifactId>libthrift</artifactId>
+                <version>${thrift.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.jackson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
         <jetty.version>9.4.40.v20210413</jetty.version>
         <jline.version>2.12.1</jline.version>
         <joda.version>2.9.6</joda.version>
+        <json.smart.version>2.4.7</json.smart.version>
         <licenses.version>5.2.5-SNAPSHOT</licenses.version>
         <netty.version>4.1.63.Final</netty.version>
         <parquet.version>1.11.0</parquet.version>
@@ -197,6 +198,11 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport-native-epoll</artifactId>
                 <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.minidev</groupId>
+                <artifactId>json-smart</artifactId>
+                <version>${json.smart.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.thrift</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
     </modules>
 
     <properties>
+        <avro.version>1.10.2</avro.version>
         <commons-io.version>2.4</commons-io.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
         <commons.codec.version>1.15</commons.codec.version>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
         <commons-io.version>2.4</commons-io.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
         <commons.codec.version>1.15</commons.codec.version>
+        <confluent.log4j.version>1.2.17-cp2</confluent.log4j.version>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <confluent.version>5.2.5-SNAPSHOT</confluent.version>
         <hadoop.version>2.10.1</hadoop.version>
@@ -175,6 +176,11 @@
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
                 <version>${commons.codec.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.confluent</groupId>
+                <artifactId>confluent-log4j</artifactId>
+                <version>${confluent.log4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
         <hive.version>1.2.2</hive.version>
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.4</httpcore.version>
+        <jackson.version>2.10.5</jackson.version>
         <jackson.databind.version>2.10.5.1</jackson.databind.version>
         <jackson.mapper.asl.version>1.9.13</jackson.mapper.asl.version>
         <jline.version>2.12.1</jline.version>
@@ -189,9 +190,24 @@
                 <version>${netty.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport-native-epoll</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.thrift</groupId>
                 <artifactId>libthrift</artifactId>
                 <version>${thrift.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper</artifactId>
+                <version>3.7.0</version>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.jackson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,8 @@
         <netty.version>4.1.63.Final</netty.version>
         <parquet.version>1.11.0</parquet.version>
         <thrift.version>0.14.1</thrift.version>
+        <tomcat.version>8.5.65</tomcat.version>
+        <zookeeper.version>3.7.0</zookeeper.version>
     </properties>
 
     <repositories>
@@ -205,9 +207,14 @@
                 <version>${thrift.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
-                <version>3.7.0</version>
+                <version>${zookeeper.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.jackson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <commons.codec.version>1.15</commons.codec.version>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <confluent.version>5.2.5-SNAPSHOT</confluent.version>
-        <hadoop.version>2.7.3</hadoop.version>
+        <hadoop.version>2.10.1</hadoop.version>
         <hive.version>1.2.2</hive.version>
         <jackson.databind.version>2.10.5.1</jackson.databind.version>
         <jackson.mapper.asl.version>1.9.13</jackson.mapper.asl.version>


### PR DESCRIPTION
Signed-off-by: Lev Zemlyanov <lev@confluent.io>

## Problem
lots of CVEs leftover in 5.2.x and on

## Solution
resolve them using various methods
https://twistlock.tools.confluent-internal.io/#!/monitor/vulnerabilities/images/ci?search=storage-common:PR-185
all CVEs are resolved, the ones left are in S3 and HDFS
except for guava which i was unable to resolve because there is a backwards incompatible change that HDFS relies on
some CVEs have no resolution i.e `commons-collection`
<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?
other CP connectors (S3 + HDFS)

## Test Strategy
tested against HDFS connector locally

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
backport to `5.2.x`