### PR TITLE
MINOR: revert thrift back 0.9.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <licenses.version>5.2.5-SNAPSHOT</licenses.version>
         <netty.version>4.1.63.Final</netty.version>
         <parquet.version>1.11.0</parquet.version>
-        <thrift.version>0.14.1</thrift.version>
+        <thrift.version>0.9.3</thrift.version>
         <tomcat.version>8.5.65</tomcat.version>
         <zookeeper.version>3.7.0</zookeeper.version>
     </properties>


### PR DESCRIPTION
Signed-off-by: Lev Zemlyanov <lev@confluent.io>

## Problem
upgrading thrift is a breaking change for HDFS

## Solution
revert thrift to a working version `0.9.3`

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
tested with HDFS

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
backport to `5.2.x` where this version was pinned