### PR TITLE
MINOR: exclude jetty-all to address CVE

### DIFF
--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -79,6 +79,10 @@
                     <artifactId>hive-exec</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.eclipse.jetty.aggregate</groupId>
+                    <artifactId>jetty-all</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>


### PR DESCRIPTION
Signed-off-by: Lev Zemlyanov <lev@confluent.io>

## Problem
`jetty-all` is a CVE that is getting pulled into HDFS

## Solution
exclude it

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy
tested against HDFS

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
backport to `5.2.x` where the CVE needs to be fixed