### PR TITLE
CCMSG-1072: stop excluding necessary jackson-mapper-asl dependency

### DIFF
--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -60,10 +60,6 @@
                     <artifactId>commons-collections</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.codehaus.jackson</groupId>
-                    <artifactId>jackson-mapper-asl</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>
@@ -89,10 +85,6 @@
                 <exclusion>
                   <groupId>org.apache.hive</groupId>
                   <artifactId>hive-exec</artifactId>
-                </exclusion>
-                <exclusion>
-                  <groupId>org.codehaus.jackson</groupId>
-                  <artifactId>jackson-mapper-asl</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.eclipse.jetty.aggregate</groupId>


### PR DESCRIPTION
Signed-off-by: Lev Zemlyanov <lev@confluent.io>

## Problem
https://github.com/confluentinc/kafka-connect-storage-common/pull/138 introduced an issue where the HDFS connector needs this dependency and fails if it is not present

```
[2021-05-05 15:32:36,071] ERROR WorkerSinkTask{xxx} Task threw an uncaught and unrecoverable exception (org.apache.kafka.connect.runtime.WorkerTask:187)
com.google.common.util.concurrent.ExecutionError: java.lang.NoClassDefFoundError: org/codehaus/jackson/map/ObjectMapper
    at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2261)
    at com.google.common.cache.LocalCache.get(LocalCache.java:4000)
    at com.google.common.cache.LocalCache$LocalManualCache.get(LocalCache.java:4789)
    at org.apache.hadoop.hdfs.KeyProviderCache.get(KeyProviderCache.java:76)
    at org.apache.hadoop.hdfs.DFSClient.getKeyProvider(DFSClient.java:2975)
    at org.apache.hadoop.hdfs.DFSClient.createWrappedInputStream(DFSClient.java:1012)
    at org.apache.hadoop.hdfs.DistributedFileSystem$4.doCall(DistributedFileSystem.java:329)
    at org.apache.hadoop.hdfs.DistributedFileSystem$4.doCall(DistributedFileSystem.java:324)
    at org.apache.hadoop.fs.FileSystemLinkResolver.resolve(FileSystemLinkResolver.java:81)
    at org.apache.hadoop.hdfs.DistributedFileSystem.open(DistributedFileSystem.java:324)
    at io.confluent.connect.hdfs.wal.WALFile$Reader.openFile(WALFile.java:589)
    at io.confluent.connect.hdfs.wal.WALFile$Reader.<init>(WALFile.java:470)
    at io.confluent.connect.hdfs.wal.WALFile$Writer.<init>(WALFile.java:164)
    at io.confluent.connect.hdfs.wal.WALFile.createWriter(WALFile.java:78)
    at io.confluent.connect.hdfs.wal.FSWAL.acquireLease(FSWAL.java:82)
    at io.confluent.connect.hdfs.wal.FSWAL.apply(FSWAL.java:133)
    at io.confluent.connect.hdfs.TopicPartitionWriter.applyWAL(TopicPartitionWriter.java:700)
    at io.confluent.connect.hdfs.TopicPartitionWriter.recover(TopicPartitionWriter.java:259)
    at io.confluent.connect.hdfs.DataWriter.recover(DataWriter.java:403)
    at io.confluent.connect.hdfs.DataWriter.open(DataWriter.java:470)
    at io.confluent.connect.hdfs.HdfsSinkTask.open(HdfsSinkTask.java:162)
    at org.apache.kafka.connect.runtime.WorkerSinkTask.openPartitions(WorkerSinkTask.java:594)
    at org.apache.kafka.connect.runtime.WorkerSinkTask.access$1100(WorkerSinkTask.java:70)
    at org.apache.kafka.connect.runtime.WorkerSinkTask$HandleRebalance.onPartitionsAssigned(WorkerSinkTask.java:659)
    at org.apache.kafka.clients.consumer.internals.ConsumerCoordinator.invokePartitionsAssigned(ConsumerCoordinator.java:278)
    at org.apache.kafka.clients.consumer.internals.ConsumerCoordinator.onJoinComplete(ConsumerCoordinator.java:419)
    at org.apache.kafka.clients.consumer.internals.AbstractCoordinator.joinGroupIfNeeded(AbstractCoordinator.java:439)
    at org.apache.kafka.clients.consumer.internals.AbstractCoordinator.ensureActiveGroup(AbstractCoordinator.java:358)
    at org.apache.kafka.clients.consumer.internals.ConsumerCoordinator.poll(ConsumerCoordinator.java:497)
    at org.apache.kafka.clients.consumer.KafkaConsumer.updateAssignmentMetadataIfNeeded(KafkaConsumer.java:1274)
    at org.apache.kafka.clients.consumer.KafkaConsumer.poll(KafkaConsumer.java:1236)
    at org.apache.kafka.clients.consumer.KafkaConsumer.poll(KafkaConsumer.java:1216)
    at org.apache.kafka.connect.runtime.WorkerSinkTask.pollConsumer(WorkerSinkTask.java:448)
    at org.apache.kafka.connect.runtime.WorkerSinkTask.poll(WorkerSinkTask.java:321)
    at org.apache.kafka.connect.runtime.WorkerSinkTask.iteration(WorkerSinkTask.java:229)
    at org.apache.kafka.connect.runtime.WorkerSinkTask.execute(WorkerSinkTask.java:201)
    at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:185)
    at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:235)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
    at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.NoClassDefFoundError: org/codehaus/jackson/map/ObjectMapper
    at org.apache.hadoop.crypto.key.kms.KMSClientProvider.<clinit>(KMSClientProvider.java:127)
    at org.apache.hadoop.crypto.key.kms.KMSClientProvider$Factory.createProvider(KMSClientProvider.java:321)
    at org.apache.hadoop.crypto.key.KeyProviderFactory.get(KeyProviderFactory.java:96)
    at org.apache.hadoop.util.KMSUtil.createKeyProviderFromUri(KMSUtil.java:63)
    at org.apache.hadoop.hdfs.KeyProviderCache$2.call(KeyProviderCache.java:79)
    at org.apache.hadoop.hdfs.KeyProviderCache$2.call(KeyProviderCache.java:76)
    at com.google.common.cache.LocalCache$LocalManualCache$1.load(LocalCache.java:4792)
    at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3599)
    at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2379)
    at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2342)
    at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2257)
    ... 42 more
Caused by: java.lang.ClassNotFoundException: org.codehaus.jackson.map.ObjectMapper
    at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
    at org.apache.kafka.connect.runtime.isolation.PluginClassLoader.loadClass(PluginClassLoader.java:104)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
    ... 53 more
```

## Solution
remove the exclusion
[the right version is already pinned in the main pom file](https://github.com/confluentinc/kafka-connect-storage-common/blob/10.0.x/pom.xml#L224-L228) to `v1.9.3` the latest available

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
tested with HDFS locally

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
backport to `10.0.x` where this was introduced