### PR TITLE
MINOR: Keep zookeeper as transitive dependency inherited from common parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,6 @@
         <parquet.version>1.11.0</parquet.version>
         <thrift.version>0.9.3</thrift.version>
         <tomcat.version>8.5.65</tomcat.version>
-        <zookeeper.version>3.7.0</zookeeper.version>
     </properties>
 
     <repositories>
@@ -217,11 +216,6 @@
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-core</artifactId>
                 <version>${tomcat.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.zookeeper</groupId>
-                <artifactId>zookeeper</artifactId>
-                <version>${zookeeper.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.jackson</groupId>


### PR DESCRIPTION
## Problem
When the versions of zk differ from Kafka tests and common, tests break

## Solution
Keep getting ZK as transitive dependency at the version that is defined in https://github.com/confluentinc/common/blob/master/pom.xml#L94

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
