### PR TITLE
CCMSG-1133: Decouple topic name from hive table name

### DIFF
--- a/hive/src/main/java/io/confluent/connect/storage/hive/HiveUtil.java
+++ b/hive/src/main/java/io/confluent/connect/storage/hive/HiveUtil.java
@@ -28,18 +28,25 @@ import io.confluent.connect.storage.partitioner.Partitioner;
  */
 public abstract class HiveUtil {
 
-  protected String url;
+  protected final String url;
   protected final HiveMetaStore hiveMetaStore;
   protected final String delim;
 
   public HiveUtil(AbstractConfig connectorConfig, HiveMetaStore hiveMetaStore) {
-    this.url = connectorConfig.getString(StorageCommonConfig.STORE_URL_CONFIG);
+    this(connectorConfig,
+            hiveMetaStore,
+            connectorConfig.getString(StorageCommonConfig.STORE_URL_CONFIG));
+  }
+
+  public HiveUtil(AbstractConfig connectorConfig, HiveMetaStore hiveMetaStore, String url) {
     this.hiveMetaStore = hiveMetaStore;
     this.delim = connectorConfig.getString(StorageCommonConfig.DIRECTORY_DELIM_CONFIG);
+    this.url = url;
   }
 
   public abstract void createTable(String database, String tableName, Schema schema,
-                                   Partitioner<FieldSchema> partitioner);
+                                   Partitioner<FieldSchema> partitioner,
+                                   String topic);
 
   public abstract void alterSchema(String database, String tableName, Schema schema);
 

--- a/hive/src/main/java/io/confluent/connect/storage/hive/HiveUtil.java
+++ b/hive/src/main/java/io/confluent/connect/storage/hive/HiveUtil.java
@@ -33,9 +33,11 @@ public abstract class HiveUtil {
   protected final String delim;
 
   public HiveUtil(AbstractConfig connectorConfig, HiveMetaStore hiveMetaStore) {
-    this(connectorConfig,
-            hiveMetaStore,
-            connectorConfig.getString(StorageCommonConfig.STORE_URL_CONFIG));
+    this(
+      connectorConfig,
+      hiveMetaStore,
+      connectorConfig.getString(StorageCommonConfig.STORE_URL_CONFIG)
+    );
   }
 
   public HiveUtil(AbstractConfig connectorConfig, HiveMetaStore hiveMetaStore, String url) {


### PR DESCRIPTION
## Problem

We need to update the HiveUtil.createTable interface by adding the topic name so we can decouple the hive table name from the location path.

## Solution

Add an extra topic argument.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no
