### PR TITLE
CC-15305: Upgrade transitive dependency commons-compress to 1.21

### DIFF
--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -123,11 +123,6 @@
             <version>${commons.lang3.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-compress</artifactId>
-            <version>${commons.compress.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.esotericsoftware.kryo</groupId>
             <artifactId>kryo</artifactId>
             <version>${kryo.version}</version>

--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -31,7 +31,6 @@
 
     <properties>
         <commons.lang3.version>3.1</commons.lang3.version>
-        <commons.compress.version>1.21</commons.compress.version>
         <kryo.version>2.22</kryo.version>
     </properties>
 

--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -31,6 +31,7 @@
 
     <properties>
         <commons.lang3.version>3.1</commons.lang3.version>
+        <commons.compress.version>1.21</commons.compress.version>
         <kryo.version>2.22</kryo.version>
     </properties>
 
@@ -120,6 +121,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>${commons.lang3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>${commons.compress.version}</version>
         </dependency>
         <dependency>
             <groupId>com.esotericsoftware.kryo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
         <commons-io.version>2.7</commons-io.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
         <commons.codec.version>1.15</commons.codec.version>
+        <commons.compress.version>1.21</commons.compress.version>
         <confluent.log4j.version>1.2.17-cp2</confluent.log4j.version>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <confluent.version>5.4.5-SNAPSHOT</confluent.version>
@@ -187,6 +188,11 @@
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>${commons-io.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>${commons.compress.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>


### PR DESCRIPTION
## Problem
Outdated dependency

## Solution
pin version only in the hive module

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Applies to 5.4.x or newer