### PR TITLE
Extend config of RecordTimestampExtractor with date-time format pattern

### DIFF
--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/PartitionerConfig.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/PartitionerConfig.java
@@ -103,6 +103,12 @@ public class PartitionerConfig extends AbstractConfig implements ComposableConfi
   public static final String TIMESTAMP_FIELD_NAME_DEFAULT = "timestamp";
   public static final String TIMESTAMP_FIELD_NAME_DISPLAY = "Record Field for Timestamp Extractor";
 
+  public static final String TIMESTAMP_FIELD_FORMAT_PATTERN_CONFIG = "timestamp.field.format";
+  public static final String TIMESTAMP_FIELD_FORMAT_PATTERN_DOC = "The datetime format pattern of record "
+          + "field used as timestamp by RecordTimestampExtractor. If empty (which is default) "
+          + "ISODateTimeFormat.dateTimeParser() is used";
+  public static final String TIMESTAMP_FIELD_FORMAT_PATTERN_DEFAULT = "";
+  public static final String TIMESTAMP_FIELD_FORMAT_PATTERN_DISPLAY = "Datetime format pattern for RecordTimestampExtractor";
   /**
    * Create a new configuration definition.
    *
@@ -211,6 +217,16 @@ public class PartitionerConfig extends AbstractConfig implements ComposableConfi
           ++orderInGroup,
           Width.LONG,
           TIMESTAMP_FIELD_NAME_DISPLAY);
+
+      configDef.define(TIMESTAMP_FIELD_FORMAT_PATTERN_CONFIG,
+              Type.STRING,
+              TIMESTAMP_FIELD_FORMAT_PATTERN_DEFAULT,
+              Importance.MEDIUM,
+              TIMESTAMP_FIELD_FORMAT_PATTERN_DOC,
+              group,
+              ++orderInGroup,
+              Width.LONG,
+              TIMESTAMP_FIELD_FORMAT_PATTERN_DISPLAY);
     }
 
     return configDef;

--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/TimeBasedPartitioner.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/TimeBasedPartitioner.java
@@ -273,7 +273,8 @@ public class TimeBasedPartitioner<T> extends DefaultPartitioner<T> {
     @Override
     public void configure(Map<String, Object> config) {
       fieldName = (String) config.get(PartitionerConfig.TIMESTAMP_FIELD_NAME_CONFIG);
-      dateTime = ISODateTimeFormat.dateTimeParser();
+      String formatPattern = (String) config.get(PartitionerConfig.TIMESTAMP_FIELD_FORMAT_PATTERN_CONFIG);
+      dateTime = formatPattern.isEmpty() ? ISODateTimeFormat.dateTimeParser() : DateTimeFormat.forPattern(formatPattern);
     }
 
     @Override


### PR DESCRIPTION
## Problem
Partitioning by String field is possible only if this field contains data in only one specific format. There is no easy way to override RecordFieldTimestampExtractor with custom datetime formatter. 
## Solution
This PR introduceses new configuration field with format pattern. 
Default value of this new configuration is empty String, cause there is no coressponding pattern to DatetimeFormatter beeing used currently - it is only possible to set this programmticaly.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
