### PR TITLE
Upgrade netty version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <jetty.version>9.4.43.v20210629</jetty.version>
         <jline.version>2.12.1</jline.version>
         <joda.version>2.9.6</joda.version>
-        <netty.version>4.1.63.Final</netty.version>
+        <netty.version>4.1.68.Final</netty.version>
         <json.smart.version>2.4.7</json.smart.version>
         <thrift.version>0.13.0</thrift.version>
         <tomcat.version>8.5.65</tomcat.version>


### PR DESCRIPTION
## Problem
Netty dependencies of version 4.1.63 are vulnerable.

## Solution
Bump netty version to 4.1.68.
See https://github.com/confluentinc/common/pull/383
The reason why we can't just inherit `netty.version` tag from common is, the explicit `netty.version` was not available in `5.4.x`

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
