### PR TITLE
Added azure-storage-blob-shaded.

### DIFF
--- a/azure-storage-blob-shaded/pom.xml
+++ b/azure-storage-blob-shaded/pom.xml
@@ -72,6 +72,8 @@ language governing permissions and limitations under the License. -->
                                     <include>io.netty:*</include>
                                     <include>io.projectreactor.netty:*</include>
                                     <include>io.projectreactor:*</include>
+                                    <include>org.codehaus.woodstox:*</include>
+                                    <include>com.fasterxml.woodstox:*</include>
                                 </includes>
                             </artifactSet>
                             <filters>
@@ -111,6 +113,14 @@ language governing permissions and limitations under the License. -->
                                 <relocation>
                                     <pattern>org.reactivestreams</pattern>
                                     <shadedPattern>org.reactivestreams.shaded</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.codehaus.woodstox</pattern>
+                                    <shadedPattern>org.codehaus.woodstox.shaded</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml.woodstox</pattern>
+                                    <shadedPattern>com.fasterxml.woodstox.shaded</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>

--- a/azure-storage-blob-shaded/pom.xml
+++ b/azure-storage-blob-shaded/pom.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor
+license agreements. See the NOTICE file distributed with this work for additional
+information regarding copyright ownership. The ASF licenses this file to
+You under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of
+the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required
+by applicable law or agreed to in writing, software distributed under the
+License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.confluent</groupId>
+        <artifactId>kafka-connect-storage-common-parent</artifactId>
+        <version>10.3.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>azure-storage-blob-shaded</artifactId>
+    <packaging>jar</packaging>
+    <name>azure-storage-blob-shaded</name>
+
+    <description>azure-storage-blob shaded to replace dependencies that are shipped with Kafka</description>
+    <inceptionYear>2021</inceptionYear>
+
+    <properties>
+        <azure-storage.version>12.11.1</azure-storage.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.azure:*</include>
+                                    <include>org.reactivestreams:*</include>
+                                    <include>com.fasterxml.jackson*:*</include>
+                                    <include>io.netty:*</include>
+                                    <include>io.projectreactor.netty:*</include>
+                                    <include>io.projectreactor:*</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <!-- this filter is a workaround to the fact that maven phases
+                                    can't run twice without adding new code to the produced jar
+                                    (by producing an empty jar). It's used to remove the placeholder
+                                    class io.confluent.connect.storage.PlaceHolder.class
+                                     -->
+                                    <artifact>io.confluent:*</artifact>
+                                    <excludes>
+                                        <exlude>**</exlude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.azure</pattern>
+                                    <shadedPattern>com.azure.shaded</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>io.netty</pattern>
+                                    <shadedPattern>io.netty.shaded</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>io.projectreactor</pattern>
+                                    <shadedPattern>io.projectreactor.shaded</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>reactor</pattern>
+                                    <shadedPattern>reactor.shaded</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson</pattern>
+                                    <shadedPattern>com.fasterxml.jackson.shaded</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.reactivestreams</pattern>
+                                    <shadedPattern>org.reactivestreams.shaded</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-storage-blob</artifactId>
+            <version>${azure-storage.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/azure-storage-blob-shaded/pom.xml
+++ b/azure-storage-blob-shaded/pom.xml
@@ -72,7 +72,7 @@ language governing permissions and limitations under the License. -->
                                     <include>io.netty:*</include>
                                     <include>io.projectreactor.netty:*</include>
                                     <include>io.projectreactor:*</include>
-                                    <include>org.codehaus.woodstox:*</include>
+                                    <include>org.codehaus*:*</include>
                                     <include>com.fasterxml.woodstox:*</include>
                                 </includes>
                             </artifactSet>
@@ -115,8 +115,8 @@ language governing permissions and limitations under the License. -->
                                     <shadedPattern>org.reactivestreams.shaded</shadedPattern>
                                 </relocation>
                                 <relocation>
-                                    <pattern>org.codehaus.woodstox</pattern>
-                                    <shadedPattern>org.codehaus.woodstox.shaded</shadedPattern>
+                                    <pattern>org.codehaus</pattern>
+                                    <shadedPattern>org.codehaus.shaded</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>com.fasterxml.woodstox</pattern>

--- a/azure-storage-blob-shaded/pom.xml
+++ b/azure-storage-blob-shaded/pom.xml
@@ -46,6 +46,24 @@ language governing permissions and limitations under the License. -->
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <transformers>
+                                <!--
+                                There are provider-configuration files in META-INF/services:
+                                - com.azure.shaded.core.http.HttpClientProvider
+                                - com.fasterxml.jackson.shaded.core.ObjectCodec
+                                - reactor.shaded.blockhound.integration.BlockHoundIntegration
+                                - com.fasterxml.jackson.shaded.core.JsonFactory
+                                - com.fasterxml.jackson.shaded.databind.Module
+                                Since we are doing relocation for above classes, these files has to be relocated accordingly.
+                                Without this change:
+                                $ cat com.azure.core.http.HttpClientProvider
+                                com.azure.core.http.netty.NettyAsyncHttpClientProvider
+                                With this change:
+                                $ cat com.azure.shaded.core.http.HttpClientProvider
+                                com.azure.shaded.core.http.netty.NettyAsyncHttpClientProvider
+                                -->
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
                             <artifactSet>
                                 <includes>
                                     <include>com.azure:*</include>

--- a/azure-storage-blob-shaded/src/main/java/io/confluent/connect/storage/PlaceHolder.java
+++ b/azure-storage-blob-shaded/src/main/java/io/confluent/connect/storage/PlaceHolder.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.storage;
+
+
+/**
+ * This class is added as a workaround to maven. Attempting to run both verify and install phases
+ * with maven fails if there's no source code in the project (the produced jar is empty).
+ *
+ * @see <a href="http://mail-archives.apache.org/mod_mbox/maven-users/201608.mbox/%3c20160805151905.500d5c45@copperhead.int.arc7.info%3e">mvn
+ * clean verify deploy causes jar plugin to execute twice</a>
+ * <p>This fact subsequently fails the attempt to re-shade the dependencies without adding new
+ * code.
+ * The workaround is to introduce this class here, with the intention to remove it during shading by
+ * configuring a filter for maven-shade-plugin.
+ * </p>
+ */
+public class PlaceHolder {
+
+
+}


### PR DESCRIPTION
## Problem
Azure Blob Storage Source Connector uses and ships with `com.azure.azure-storage-blob` dependency.
But, if the classpath has the older versions of this dependency - the connector will fail because of conflicting versions.

After bringing up the connector using the [Docker playground](https://github.com/vdesabou/kafka-docker-playground/tree/master/connect/connect-azure-blob-storage-source), I see that Worker's classpath has 2 versions of this JAR:
```
[main] INFO org.apache.kafka.common.utils.AppInfoParser - Kafka startTimeMs: 1635903919086
  jvm.classpath = .../usr/share/java/confluent-security/connect/azure-storage-blob-12.5.0.jar:.../:/usr/share/java/kafka/azure-storage-blob-12.6.0.jar:.../usr/bin/../share/java/kafka/azure-storage-blob-12.6.0.jar:
```



## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
