### PR TITLE
remove usage of deprecated mockito-all

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -47,8 +47,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>${mockito-all.version}</version>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
mockito-all was removed in mockito 2.x
