### PR TITLE
[RCCA-5984] Updating commons parent version, to fetch 6.1.4 version of kafka-conn…

### DIFF
--- a/avatica-shaded/src/main/java/io/confluent/connect/storage/PlaceHolder.java
+++ b/avatica-shaded/src/main/java/io/confluent/connect/storage/PlaceHolder.java
@@ -16,13 +16,17 @@
 package io.confluent.connect.storage;
 
 /**
- *    This class is added as a workaround to maven. Attempting to run both verify and install phases
- *    with maven fails if there's no source code in the project (the produced jar is empty).  
- *    @see <a href="http://mail-archives.apache.org/mod_mbox/maven-users/201608.mbox/%3c20160805151905.500d5c45@copperhead.int.arc7.info%3e">mvn clean verify deploy causes jar plugin to execute twice</a>
- * <p>This fact subsequently fails the attempt to re-shade the dependencies without adding new code.
- *    The workaround is to introduce this class here, with the intention to remove it during shading
- *    by configuring a filter for maven-shade-plugin.
- * </p>
+ * This class is added as a workaround to maven. Attempting to run both verify and install phases
+ * with maven fails if there's no source code in the project (the produced jar is empty).
+ *
+ * @see <a href="http://mail-archives.apache.org/mod_mbox/maven-users/201608.mbox/%3c20160805151905.500d5c45@copperhead.int.arc7.info%3e">mvn
+ *      clean verify deploy causes jar plugin to execute twice</a>
+ *
+ *      <p>
+ *      This fact subsequently fails the attempt to re-shade the dependencies without adding new
+ *      code. The workaround is to introduce this class here, with the intention to remove it during
+ *      shading by configuring a filter for maven-shade-plugin.
+ *      </p>
  */
 public class PlaceHolder {
 }

--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-avro-data</artifactId>
-            <version>${confluent.version}</version>
+            <version>${io.confluent.kafka-connect-avro-data.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-avro-data</artifactId>
-            <version>${io.confluent.kafka-connect-avro-data.version}</version>
+            <version>${confluent.version.range}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,6 @@
         <json.smart.version>2.4.7</json.smart.version>
         <thrift.version>0.13.0</thrift.version>
         <tomcat.version>8.5.65</tomcat.version>
-        <io.confluent.kafka-connect-avro-data.version>${confluent.version.range}</io.confluent.kafka-connect-avro-data.version>
     </properties>
 
     <repositories>
@@ -136,7 +135,7 @@
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-connect-avro-data</artifactId>
-                <version>${io.confluent.kafka-connect-avro-data.version}</version>
+                <version>${confluent.version.range}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.parquet</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>6.0.3</version>
+        <version>6.1.4</version>
     </parent>
 
     <artifactId>kafka-connect-storage-common-parent</artifactId>
@@ -90,6 +90,7 @@
         <json.smart.version>2.4.7</json.smart.version>
         <thrift.version>0.13.0</thrift.version>
         <tomcat.version>8.5.65</tomcat.version>
+        <io.confluent.kafka-connect-avro-data.version>${confluent.version.range}</io.confluent.kafka-connect-avro-data.version>
     </properties>
 
     <repositories>
@@ -135,7 +136,7 @@
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-connect-avro-data</artifactId>
-                <version>${confluent.version}</version>
+                <version>${io.confluent.kafka-connect-avro-data.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.parquet</groupId>


### PR DESCRIPTION
…ect-avro-data. Updated indentation to pass checkstyle plugin check.

## Problem
Customer faced an issue in kafka-connect-azure-blob-storage connector, which is resolved in the `kafka-connect-avro-data` version v6.1.4. This pr aims to bring in the v6.1.4 of `kafka-connect-avro-data` within the `kafka-connect-azure-data-lake-gen2` connector. 

Details on the issue: 
https://github.com/confluentinc/schema-registry/issues/1659
Issue with sinking protobuf data using AzureDataLake connector, with parquet output format. Happens when same message type  appears on both a repeated field and a normal field in protobuf message schema.

## Solution
Issue was fixed as part of https://github.com/confluentinc/schema-registry/pull/2026. Bringing that version v6.1.4 of `kafka-connect-avro-data` within this repo. 
Indentation changes made were to fix the checkstyle failures occurring as part of `mvn org.apache.maven.plugins:maven-checkstyle-plugin:3.1.1:check -pl :kafka-connect-storage-common-avatica-shaded` check.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?
The changes here have to be imported to kafka-connect-s3 and kafka-connect-azure-blob-storage

## Test Strategy

Before the fix, observed following error in the connector 
```
[2022-03-01 16:34:24,179] ERROR WorkerSinkTask{id=adlsConnector-0} Task threw an uncaught and unrecoverable exception. Task is being killed and will not recover until manually restarted (org.apache.kafka.connect.runtime.WorkerTask:193)
org.apache.kafka.connect.errors.ConnectException: Exiting WorkerSinkTask due to unrecoverable exception.
        at org.apache.kafka.connect.runtime.WorkerSinkTask.deliverMessages(WorkerSinkTask.java:615)
        at org.apache.kafka.connect.runtime.WorkerSinkTask.poll(WorkerSinkTask.java:330)
        at org.apache.kafka.connect.runtime.WorkerSinkTask.iteration(WorkerSinkTask.java:232)
        at org.apache.kafka.connect.runtime.WorkerSinkTask.execute(WorkerSinkTask.java:201)
        at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:191)
        at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:240)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
Caused by: org.apache.kafka.connect.errors.DataException: An optinal schema should have an Avro Union type, not STRUCT
        at io.confluent.connect.avro.AvroData.avroSchemaForUnderlyingTypeIfOptional(AvroData.java:652)
        at io.confluent.connect.avro.AvroData.fromConnectData(AvroData.java:577)
        at io.confluent.connect.avro.AvroData.fromConnectData(AvroData.java:491)
        at io.confluent.connect.avro.AvroData.fromConnectData(AvroData.java:585)
        at io.confluent.connect.avro.AvroData.fromConnectData(AvroData.java:344)
        at io.confluent.connect.avro.AvroData.fromConnectData(AvroData.java:340)
        at io.confluent.connect.azure.storage.format.parquet.ParquetRecordWriterProvider$1.write(ParquetRecordWriterProvider.java:86)
        at io.confluent.connect.azure.storage.TopicPartitionWriter.writeRecord(TopicPartitionWriter.java:381)
        at io.confluent.connect.azure.storage.TopicPartitionWriter.checkRotationOrAppend(TopicPartitionWriter.java:201)
        at io.confluent.connect.azure.storage.TopicPartitionWriter.executeState(TopicPartitionWriter.java:164)
        at io.confluent.connect.azure.storage.TopicPartitionWriter.write(TopicPartitionWriter.java:133)
        at io.confluent.connect.azure.storage.AzureStorageSinkTask.put(AzureStorageSinkTask.java:144)
        at org.apache.kafka.connect.runtime.WorkerSinkTask.deliverMessages(WorkerSinkTask.java:587)
```

After the fix: 
----------
Manually verified the kafka-connect-avro-data version:
```
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ kafka-connect-storage-core ---
[INFO] io.confluent:kafka-connect-storage-core:jar:10.0.9-SNAPSHOT
[INFO] +- io.confluent:kafka-connect-storage-common:jar:10.0.9-SNAPSHOT:compile
[INFO] +- **io.confluent:kafka-connect-avro-data:jar:6.1.4:compile**
[INFO] |  +- org.apache.avro:avro:jar:1.9.2:compile
[INFO] |  |  +- com.fasterxml.jackson.core:jackson-core:jar:2.10.5:compile
[INFO] |  |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.10.5.1:compile
[INFO] |  |  |  \- com.fasterxml.jackson.core:jackson-annotations:jar:2.10.5:compile
[INFO] |  |  \- org.apache.commons:commons-compress:jar:1.21:compile
[INFO] |  \- io.confluent:kafka-avro-serializer:jar:6.1.4:compile
[INFO] |     +- io.confluent:kafka-schema-serializer:jar:6.1.4:compile
[INFO] |     \- io.confluent:kafka-schema-registry-client:jar:6.1.4:compile
[INFO] |        +- jakarta.ws.rs:jakarta.ws.rs-api:jar:2.1.6:compile
[INFO] |        +- org.glassfish.jersey.core:jersey-common:jar:2.34:compile
```

Used the above snapshot of kafka-connect-storage-common in kafka-connect-azure-blob-storage connector to test the below. 
Used a connector with the following configuration
```json
{
  "name": "adlsConnector",
  "config": {
    "azure.datalake.gen2.account.name": "<redacted>",
    "azure.datalake.gen2.sas.key": "<redacted>",
    "azure.datalake.gen2.sas.keyname": "",
    "confluent.license": "",
    "confluent.topic.bootstrap.servers": "localhost:9092",
    "confluent.topic.replication.factor": "1",
    "connector.class": "io.confluent.connect.azure.datalake.gen2.AzureDataLakeGen2SinkConnector",
    "flush.size": "1",
    "format.class": "io.confluent.connect.azure.storage.format.parquet.ParquetFormat",
    "internal.key.converter.schemas.enable": "false",
    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
    "key.converter.schemas.enable": "false",
    "name": "adlsConnector",
    "schema.compatibility": "NONE",
    "topics": "rahulTopic",
    "topics.dir": "topics",
    "value.converter": "io.confluent.connect.protobuf.ProtobufConverter",
    "value.converter.schema.registry.url": "http://localhost:8081",
    "value.converter.schemas.enable": "false"
  },
  "tasks": [],
  "type": "sink"
}
```

Observed the following logs with the fixes in azure data lake connector 
```
[2022-03-01 17:15:51,699] INFO Starting commit and rotation for topic partition rahulTopic-0 with start offset {partition=0=0} (io.confluent.connect.azure.storage.TopicPartitionWriter:204)
[2022-03-01 17:15:52,535] INFO Files committed to Azure. Target commit offset for rahulTopic-0 is 1 (io.confluent.connect.azure.storage.TopicPartitionWriter:401)
[2022-03-01 17:16:17,423] INFO Starting commit and rotation for topic partition rahulTopic-0 with start offset {partition=0=1} (io.confluent.connect.azure.storage.TopicPartitionWriter:204)
[2022-03-01 17:16:18,134] INFO Files committed to Azure. Target commit offset for rahulTopic-0 is 2 (io.confluent.connect.azure.storage.TopicPartitionWriter:401)
[2022-03-01 17:16:27,061] INFO WorkerSinkTask{id=adlsConnector-0} Committing offsets asynchronously using sequence number 1: {rahulTopic-0=OffsetAndMetadata{offset=2, leaderEpoch=null, metadata=''}} (org.apache.kafka.connect.runtime.WorkerSinkTask:353)
```

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
