### PR TITLE
CCMSG-1737: Remove pinning of jackson from avatica shaded

### DIFF
--- a/avatica-shaded/pom.xml
+++ b/avatica-shaded/pom.xml
@@ -28,7 +28,6 @@ language governing permissions and limitations under the License. -->
 
     <properties>
         <avatica.version>1.8.0</avatica.version>
-        <jackson.version>2.10.5</jackson.version>
     </properties>
 
     <build>


### PR DESCRIPTION
## Problem
This pin is outdated. Morever, we are updating something in the parent level now so let's use that.

Original basis for the pin was just a usage of something recent at the time, before we could get a current version fromelsewhere.
https://github.com/confluentinc/kafka-connect-storage-common/pull/159/files#r516434514

We are already using a different jackson version in the hdfs connector without issue 
https://github.com/confluentinc/kafka-connect-hdfs/blob/10.1.x/pom.xml#L205
So this pin doesn't serve anything anymore other than to give us CVE tickets.

## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
