### PR TITLE
CCMSG-1906: Adress CVEs for ant, jsp, groovy, derby, netty and orc. 

### DIFF
--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -108,12 +108,16 @@
                 </exclusion>
                 <!-- Ant and jsp-api removed due to CVEs -->
                 <exclusion>
+                    <groupId>org.apache.ant</groupId>
+                    <artifactId>ant</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>ant</groupId>
                     <artifactId>ant</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.mortbay.jetty</groupId>
-                    <artifactId>jsp-api-2.1</artifactId>
+                    <artifactId>jsp-2.1</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -32,14 +32,6 @@
         <kryo.version>2.22</kryo.version>
         <xml-apis.version>1.4.01</xml-apis.version>
         <jamon.runtime.version>2.4.1</jamon.runtime.version>
-        <!--
-        Note: The following three properties are used to change the version of the
-        respective dependencies within hive. They are changed from the ones inherited from
-        hive for fixing CVEs.
-        -->
-        <groovy.override.version>2.4.21</groovy.override.version>
-        <derby.override.version>10.14.1.0</derby.override.version>
-        <orc-core.override.version>1.4.3</orc-core.override.version>
     </properties>
 
     <dependencies>
@@ -190,25 +182,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.codehaus.groovy</groupId>
-                <artifactId>groovy-all</artifactId>
-                <version>${groovy.override.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.derby</groupId>
-                <artifactId>derby</artifactId>
-                <version>${derby.override.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.orc</groupId>
-                <artifactId>orc-core</artifactId>
-                <version>${orc-core.override.version}</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
 </project>

--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -32,6 +32,14 @@
         <kryo.version>2.22</kryo.version>
         <xml-apis.version>1.4.01</xml-apis.version>
         <jamon.runtime.version>2.4.1</jamon.runtime.version>
+        <!--
+        Note: The following three properties are used to change the version of the
+        respective dependencies within hive. They are changed from the ones inherited from
+        hive for fixing CVEs.
+        -->
+        <groovy.override.version>2.4.21</groovy.override.version>
+        <derby.override.version>10.14.1.0</derby.override.version>
+        <orc-core.override.version>1.4.3</orc-core.override.version>
     </properties>
 
     <dependencies>
@@ -106,6 +114,15 @@
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-core</artifactId>
                 </exclusion>
+                <!-- Ant and jsp-api removed due to CVEs -->
+                <exclusion>
+                    <groupId>ant</groupId>
+                    <artifactId>ant</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>jsp-api-2.1</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <!-- Explicitly include working version of xml-apis -->
@@ -173,4 +190,25 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-all</artifactId>
+                <version>${groovy.override.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.derby</groupId>
+                <artifactId>derby</artifactId>
+                <version>${derby.override.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.orc</groupId>
+                <artifactId>orc-core</artifactId>
+                <version>${orc-core.override.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -85,12 +85,20 @@
         <joda.version>2.9.6</joda.version>
         <kafka.connect.storage.common.version>11.1.0-SNAPSHOT</kafka.connect.storage.common.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
-        <netty.version>4.1.68.Final</netty.version>
+        <netty.version>4.1.71.Final</netty.version>
         <parquet.version>1.11.1</parquet.version>
         <json.smart.version>2.4.7</json.smart.version>
         <thrift.version>0.13.0</thrift.version>
         <tomcat.version>8.5.65</tomcat.version>
         <protobuf.version>3.19.4</protobuf.version>
+        <!--
+        Note: The following three properties are used to change the version of the
+        respective dependencies within hive. They are changed from the ones inherited from
+        hive for fixing CVEs.
+        -->
+        <groovy.override.version>2.4.21</groovy.override.version>
+        <derby.override.version>10.14.1.0</derby.override.version>
+        <orc-core.override.version>1.4.3</orc-core.override.version>
     </properties>
 
     <repositories>
@@ -276,6 +284,21 @@
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>
                 <version>${protobuf.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-all</artifactId>
+                <version>${groovy.override.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.derby</groupId>
+                <artifactId>derby</artifactId>
+                <version>${derby.override.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.orc</groupId>
+                <artifactId>orc-core</artifactId>
+                <version>${orc-core.override.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Problem
List of CVE that this PR addresses. 
https://confluentinc.atlassian.net/browse/CCMSG-1900
https://confluentinc.atlassian.net/browse/CCMSG-1894
https://confluentinc.atlassian.net/browse/CCMSG-1896
https://confluentinc.atlassian.net/browse/CCMSG-1901
https://confluentinc.atlassian.net/browse/CCMSG-1904
https://confluentinc.atlassian.net/browse/CCMSG-1908
https://confluentinc.atlassian.net/browse/CCMSG-1910
https://confluentinc.atlassian.net/browse/CCMSG-1912


## Solution
Since all of these dependencies are brought in through hive we have to override those dependencies through dependency management. Some of the dependencies can be removed.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy
Tested this locally by installing the maven artefact and using it in hdfs sink connector. All test tests pass with the updated dependencies, except one for kerberos auth, which fails to properly set up auth locally. 

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
