### PR TITLE
CCMSG-1740: update protobuf version in avatica

### DIFF
--- a/avatica-shaded/pom.xml
+++ b/avatica-shaded/pom.xml
@@ -151,6 +151,7 @@ language governing permissions and limitations under the License. -->
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
+            <version>${protobuf.version}</version>
         </dependency>
     </dependencies>
 

--- a/avatica-shaded/pom.xml
+++ b/avatica-shaded/pom.xml
@@ -27,7 +27,7 @@ language governing permissions and limitations under the License. -->
     <inceptionYear>2020</inceptionYear>
 
     <properties>
-        <avatica.version>1.9.0</avatica.version>
+        <avatica.version>1.21.0</avatica.version>
     </properties>
 
     <build>

--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -165,6 +165,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
+            <version>${protobuf.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
## Problem
protobuf used in avatica shaded has a vulnerability.

## Solution
added protobuf version in  avatica shaded pom from main pom.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

For manual testing, created a kafka-connect-storage SNAPSHOT jar and tested hdfs sink connector (having this snapshot jar) using docker playground.

```
➜  connect-hdfs2-sink git:(master) ✗ CONNECTOR_ZIP=/Users/ajain/projects/kafka-connect-hdfs/target/components/packages/confluentinc-kafka-connect-hdfs-10.0.9-SNAPSHOT.zip ./hdfs2-sink.sh
16:38:59 ℹ️ 💫 Using default CP version 7.1.1
16:38:59 ℹ️ 🎓 set TAG environment variable to specify different version, see https://kafka-docker-playground.io/#/how-to-use?id=🎯-for-confluent-platform-cp
16:38:59 ℹ️ 👷🛠 Re-building Docker image vdesabou/kafka-docker-playground-connect:7.1.1 to include confluentinc/kafka-connect-hdfs:latest
[+] Building 58.3s (6/6) FINISHED                                                                                                                                           
 => [internal] load build definition from Dockerfile                                                                                                                   0.0s
 => => transferring dockerfile: 173B                                                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                                        0.0s
 => [internal] load metadata for docker.io/vdesabou/kafka-docker-playground-connect:7.1.1                                                                              0.0s
 => CACHED [1/2] FROM docker.io/vdesabou/kafka-docker-playground-connect:7.1.1                                                                                         0.0s
 => [2/2] RUN confluent-hub install --no-prompt confluentinc/kafka-connect-hdfs:latest                                                                                56.9s
 => exporting to image                                                                                                                                                 1.2s
 => => exporting layers                                                                                                                                                1.1s
 => => writing image sha256:4f604894338a5d9666b89b638b82a6b99ed97fe6ba25cb31745777030de4ab58                                                                           0.0s 
 => => naming to docker.io/vdesabou/kafka-docker-playground-connect:7.1.1                                                                                              0.0s 
                                                                                                                                                                            
Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them                                                                        
16:40:01 ℹ️ 🎯 CONNECTOR_ZIP is set with /Users/ajain/projects/kafka-connect-hdfs/target/components/packages/confluentinc-kafka-connect-hdfs-10.0.9-SNAPSHOT.zip
16:40:01 ℹ️ 👷 Building Docker image vdesabou/kafka-docker-playground-connect:CP-7.1.1-confluentinc-kafka-connect-hdfs-10.0.9-SNAPSHOT.zip
[+] Building 12.1s (8/8) FINISHED                                                                                                                                           
 => [internal] load build definition from Dockerfile                                                                                                                   0.0s
 => => transferring dockerfile: 277B                                                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                                        0.0s
 => [internal] load metadata for docker.io/vdesabou/kafka-docker-playground-connect:7.1.1                                                                              0.0s
 => [internal] load build context                                                                                                                                      3.9s
 => => transferring context: 158.45MB                                                                                                                                  3.8s
 => [1/3] FROM docker.io/vdesabou/kafka-docker-playground-connect:7.1.1                                                                                                0.3s
 => [2/3] COPY --chown=appuser:appuser confluentinc-kafka-connect-hdfs-10.0.9-SNAPSHOT.zip /tmp                                                                        0.6s
 => [3/3] RUN confluent-hub install --no-prompt /tmp/confluentinc-kafka-connect-hdfs-10.0.9-SNAPSHOT.zip                                                               6.6s
 => exporting to image                                                                                                                                                 0.9s
 => => exporting layers                                                                                                                                                0.9s
 => => writing image sha256:02d9fd8977cc50f2738cabd325e89517c0b2885e1299b581d05ff3bef438afd7                                                                           0.0s 
 => => naming to docker.io/vdesabou/kafka-docker-playground-connect:CP-7.1.1-confluentinc-kafka-connect-hdfs-10.0.9-SNAPSHOT.zip                                       0.0s 
                                                                                                                                                                            
Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them                                                                        
16:40:17 ℹ️ 🛑 Grafana is disabled
WARNING: Some networks were defined but are not used by any service: common-network
broker uses an image, skipping
hive-server uses an image, skipping
hive-metastore-postgresql uses an image, skipping
schema-registry uses an image, skipping
presto-coordinator uses an image, skipping
namenode uses an image, skipping
zookeeper uses an image, skipping
hive-metastore uses an image, skipping
connect uses an image, skipping
datanode uses an image, skipping
WARNING: Some networks were defined but are not used by any service: common-network
Stopping ksqldb-cli                ... done
Stopping ksqldb-server             ... done
Stopping control-center            ... done
Stopping connect                   ... done
Stopping schema-registry           ... done
Stopping broker                    ... done
Stopping namenode                  ... done
Stopping zookeeper                 ... done
Stopping datanode                  ... done
Stopping hive-metastore            ... done
Stopping hive-metastore-postgresql ... done
Stopping presto-coordinator        ... done
Stopping hive-server               ... done
Removing ksqldb-cli                ... done
Removing ksqldb-server             ... done
Removing control-center            ... done
Removing connect                   ... done
Removing schema-registry           ... done
Removing broker                    ... done
Removing namenode                  ... done
Removing zookeeper                 ... done
Removing datanode                  ... done
Removing hive-metastore            ... done
Removing hive-metastore-postgresql ... done
Removing presto-coordinator        ... done
Removing hive-server               ... done
Removing network plaintext_default
Removing volume plaintext_namenode
Removing volume plaintext_datanode
WARNING: Some networks were defined but are not used by any service: common-network
Creating network "plaintext_default" with the default driver
Creating volume "plaintext_namenode" with default driver
Creating volume "plaintext_datanode" with default driver
Creating zookeeper                 ... done
Creating datanode                  ... done
Creating presto-coordinator        ... done
Creating hive-server               ... done
Creating broker                    ... done
Creating hive-metastore-postgresql ... done
Creating hive-metastore            ... done
Creating namenode                  ... done
Creating schema-registry           ... done
Creating connect                   ... done
Creating control-center            ... done
Creating ksqldb-server             ... done
Creating ksqldb-cli                ... done
16:40:47 ℹ️ 📝 To see the actual properties file, use ../../scripts/get-properties.sh <container>
16:40:47 ℹ️ ✨ If you modify a docker-compose file and want to re-create the container(s), run ../../scripts/recreate-containers.sh or use this command:
16:40:47 ℹ️ ✨ source ../../scripts/utils.sh && docker-compose -f ../../environment/plaintext/docker-compose.yml -f /Users/ajain/projects/kafka-docker-playground/connect/connect-hdfs2-sink/docker-compose.plaintext.yml --profile control-center --profile ksqldb   up -d
16:40:47 ℹ️ ⌛ Waiting up to 480 seconds for connect to start
16:44:26 ℹ️ 🚦 connect is started!
16:44:27 ℹ️ 🔧 You can use ksqlDB with CLI using:
16:44:27 ℹ️ docker exec -i ksqldb-cli ksql http://ksqldb-server:8088
16:44:27 ℹ️ 📊 JMX metrics are available locally on those ports:
16:44:27 ℹ️     - zookeeper       : 9999
16:44:27 ℹ️     - broker          : 10000
16:44:27 ℹ️     - schema-registry : 10001
16:44:27 ℹ️     - connect         : 10002
16:44:27 ℹ️     - ksqldb-server   : 10003
16:44:41 ℹ️ Creating HDFS Sink connector
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1710  100   749  100   961   1010   1296 --:--:-- --:--:-- --:--:--  2304
{
  "name": "hdfs-sink",
  "config": {
    "connector.class": "io.confluent.connect.hdfs.HdfsSinkConnector",
    "tasks.max": "1",
    "topics": "test_hdfs",
    "store.url": "hdfs://namenode:8020",
    "flush.size": "3",
    "hadoop.conf.dir": "/etc/hadoop/",
    "partitioner.class": "io.confluent.connect.hdfs.partitioner.FieldPartitioner",
    "partition.field.name": "f1",
    "rotate.interval.ms": "120000",
    "logs.dir": "/tmp",
    "hive.integration": "true",
    "hive.metastore.uris": "thrift://hive-metastore:9083",
    "hive.database": "testhive",
    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
    "value.converter": "io.confluent.connect.avro.AvroConverter",
    "value.converter.schema.registry.url": "http://schema-registry:8081",
    "schema.compatibility": "BACKWARD",
    "name": "hdfs-sink"
  },
  "tasks": [],
  "type": "sink"
}
16:44:42 ℹ️ Sending messages to topic test_hdfs
16:45:09 ℹ️ Listing content of /topics/test_hdfs in HDFS
Found 10 items
drwxr-xr-x   - appuser supergroup          0 2022-06-08 11:15 /topics/test_hdfs/f1=value1
drwxrwxrwx   - appuser supergroup          0 2022-06-08 11:15 /topics/test_hdfs/f1=value10
drwxr-xr-x   - appuser supergroup          0 2022-06-08 11:15 /topics/test_hdfs/f1=value2
drwxr-xr-x   - appuser supergroup          0 2022-06-08 11:15 /topics/test_hdfs/f1=value3
drwxr-xr-x   - appuser supergroup          0 2022-06-08 11:15 /topics/test_hdfs/f1=value4
drwxr-xr-x   - appuser supergroup          0 2022-06-08 11:15 /topics/test_hdfs/f1=value5
drwxr-xr-x   - appuser supergroup          0 2022-06-08 11:15 /topics/test_hdfs/f1=value6
drwxr-xr-x   - appuser supergroup          0 2022-06-08 11:15 /topics/test_hdfs/f1=value7
drwxr-xr-x   - appuser supergroup          0 2022-06-08 11:15 /topics/test_hdfs/f1=value8
drwxr-xr-x   - appuser supergroup          0 2022-06-08 11:15 /topics/test_hdfs/f1=value9
16:45:21 ℹ️ Getting one of the avro files locally and displaying content with avro-tools
log4j:WARN No appenders could be found for logger (org.apache.hadoop.metrics2.lib.MutableMetricsFactory).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
{"f1":"value1"}
16:45:31 ℹ️ Check data with beeline
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/opt/hive/lib/log4j-slf4j-impl-2.6.2.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/opt/hadoop-2.7.4/share/hadoop/common/lib/slf4j-log4j12-1.7.10.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.apache.logging.slf4j.Log4jLoggerFactory]
Beeline version 2.3.2 by Apache Hive
beeline> !connect jdbc:hive2://hive-server:10000/testhive
Connecting to jdbc:hive2://hive-server:10000/testhive
Enter username for jdbc:hive2://hive-server:10000/testhive: hive
Enter password for jdbc:hive2://hive-server:10000/testhive: ****
Connected to: Apache Hive (version 2.3.2)
Driver: Hive JDBC (version 2.3.2)
Transaction isolation: TRANSACTION_REPEATABLE_READ
0: jdbc:hive2://hive-server:10000/testhive> show create table test_hdfs;
+----------------------------------------------------+
|                   createtab_stmt                   |
+----------------------------------------------------+
| CREATE EXTERNAL TABLE `test_hdfs`(                 |
| )                                                  |
| PARTITIONED BY (                                   |
|   `f1` string COMMENT '')                          |
| ROW FORMAT SERDE                                   |
|   'org.apache.hadoop.hive.serde2.avro.AvroSerDe'   |
| STORED AS INPUTFORMAT                              |
|   'org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat'  |
| OUTPUTFORMAT                                       |
|   'org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat' |
| LOCATION                                           |
|   'hdfs://namenode:8020/topics/test_hdfs'          |
| TBLPROPERTIES (                                    |
|   'avro.schema.literal'='{"type":"record","name":"ConnectDefault","namespace":"io.confluent.connect.avro","fields":[]}',  |
|   'transient_lastDdlTime'='1654686906')            |
+----------------------------------------------------+
15 rows selected (2.449 seconds)
0: jdbc:hive2://hive-server:10000/testhive> select * from test_hdfs;
+---------------+
| test_hdfs.f1  |
+---------------+
| value1        |
| value2        |
| value3        |
| value4        |
| value5        |
| value6        |
| value7        |
| value8        |
| value9        |
+---------------+
9 rows selected (4.636 seconds)
0: jdbc:hive2://hive-server:10000/testhive> Closing: 0: jdbc:hive2://hive-server:10000/testhive
| value1        |

```
## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
