### PR TITLE
CCMSG-1654: Add hadoop shaded protobuf module

### DIFF
--- a/hadoop-shaded-protobuf/README.md
+++ b/hadoop-shaded-protobuf/README.md
@@ -2,5 +2,5 @@
 
 This module serves to replace the DOS-vulnerable Protobuf 3.7 contained within the package hadoop-shaded-protobuf_3_7 which is included by the package hadoop-common until such time that the the repo upgrades their protobuf version (at which time this package should be removable).
 
-You can chack the current state of the protobuf package in question in its repo:
+You can check the current state of the protobuf package in question in its repo:
 * https://github.com/apache/hadoop-thirdparty

--- a/hadoop-shaded-protobuf/README.md
+++ b/hadoop-shaded-protobuf/README.md
@@ -1,0 +1,6 @@
+# Purpose of this module
+
+This module serves to replace the DOS-vulnerable Protobuf 3.7 contained within the package hadoop-shaded-protobuf_3_7 which is included by the package hadoop-common until such time that the the repo upgrades their protobuf version (at which time this package should be removable).
+
+You can chack the current state of the protobuf package in question in its repo:
+* https://github.com/apache/hadoop-thirdparty

--- a/hadoop-shaded-protobuf/pom.xml
+++ b/hadoop-shaded-protobuf/pom.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Copyright [2019 - 2019] Confluent Inc.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.confluent</groupId>
+        <artifactId>kafka-connect-storage-common-parent</artifactId>
+        <version>10.0.15-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>kafka-connect-storage-common-hadoop-shaded-protobuf</artifactId>
+    <name>Kafka Connect Storage Common Source's version of Apache Hadoop's third-party shaded Protobuf</name>
+    <packaging>jar</packaging>
+
+    <properties>
+        <shaded.prefix>org.apache.hadoop.thirdparty</shaded.prefix>
+        <protobuf.shade.prefix>${shaded.prefix}.protobuf</protobuf.shade.prefix>
+        <protobuf.version>3.21.1</protobuf.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>${protobuf.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>${project.basedir}/..</directory>
+                <targetPath>META-INF</targetPath>
+                <includes>
+                    <include>licenses-binary/*</include>
+                    <include>NOTICE.txt</include>
+                    <include>NOTICE-binary</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>${project.basedir}/src/main/resources</directory>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <configuration>
+                    <createDependencyReducedPom>true</createDependencyReducedPom>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>shade-protobuf</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.google.protobuf:protobuf-java</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>com.google.protobuf:*</artifact>
+                                    <includes>
+                                        <include>**/*</include>
+                                    </includes>
+                                </filter>
+                            </filters>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com/google/protobuf</pattern>
+                                    <shadedPattern>${protobuf.shade.prefix}</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>google/</pattern>
+                                    <shadedPattern>${shaded.prefix}.google.</shadedPattern>
+                                    <includes>
+                                        <include>**/*.proto</include>
+                                    </includes>
+                                </relocation>
+                            </relocations>
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
+                                    <resources>
+                                        <resource>NOTICE</resource>
+                                        <resource>LICENSE</resource>
+                                    </resources>
+                                </transformer>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                                    <resource>META-INF/LICENSE.txt</resource>
+                                    <file>${basedir}/../LICENSE-binary</file>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/hadoop-shaded-protobuf/pom.xml
+++ b/hadoop-shaded-protobuf/pom.xml
@@ -22,7 +22,6 @@
     <properties>
         <shaded.prefix>org.apache.hadoop.thirdparty</shaded.prefix>
         <protobuf.shade.prefix>${shaded.prefix}.protobuf</protobuf.shade.prefix>
-        <protobuf.version>3.21.1</protobuf.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
         <module>hive</module>
         <module>htrace-core4-shaded</module>
         <module>avatica-shaded</module>
+        <module>hadoop-shaded-protobuf</module>
         <module>package-kafka-connect-storage-common</module>
     </modules>
 


### PR DESCRIPTION
## Problem
Hadoop Shaded module contains protobuf-java with vulnerability and it is getting used in hdfs3 sink connector

## Solution
Added hadoop shaded module which contains latest protobuf-java without vulnerability

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?
https://github.com/confluentinc/kafka-connect-object-store-source/pull/274

## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
Tested by using local storage-common SNAPSHOT in hdfs3 sink connector in docker playground:
```
➜  connect-hdfs3-sink git:(master) ✗ TAG=5.3.8 CONNECTOR_ZIP=/Users/ajain/projects/kafka-connect-hdfs3/target/components/packages/confluentinc-kafka-connect-hdfs3-1.1.14-SNAPSHOT.zip  ./hdfs3-sink.sh
23:38:42 ℹ️ 🚀 Using specified CP version 5.3.8
23:38:42 ℹ️ 👷🛠 Re-building Docker image vdesabou/kafka-docker-playground-connect:5.3.8 to include confluentinc/kafka-connect-hdfs3:latest
[+] Building 43.8s (6/6) FINISHED                                                                                                                                           
 => [internal] load build definition from Dockerfile                                                                                                                   0.0s
 => => transferring dockerfile: 174B                                                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                                        0.0s
 => [internal] load metadata for docker.io/vdesabou/kafka-docker-playground-connect:5.3.8                                                                              0.0s
 => CACHED [1/2] FROM docker.io/vdesabou/kafka-docker-playground-connect:5.3.8                                                                                         0.0s
 => [2/2] RUN confluent-hub install --no-prompt confluentinc/kafka-connect-hdfs3:latest                                                                               42.2s
 => exporting to image                                                                                                                                                 1.5s
 => => exporting layers                                                                                                                                                1.4s
 => => writing image sha256:9c08439a3e0c21fc34875747f228bdf46f6b64062fc5664fde4ad334de7b262d                                                                           0.0s 
 => => naming to docker.io/vdesabou/kafka-docker-playground-connect:5.3.8                                                                                              0.0s 
                                                                                                                                                                            
Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them                                                                        
23:39:29 ℹ️ 🎯 CONNECTOR_ZIP is set with /Users/ajain/projects/kafka-connect-hdfs3/target/components/packages/confluentinc-kafka-connect-hdfs3-1.1.14-SNAPSHOT.zip
23:39:29 ℹ️ 👷 Building Docker image vdesabou/kafka-docker-playground-connect:CP-5.3.8-confluentinc-kafka-connect-hdfs3-1.1.14-SNAPSHOT.zip
[+] Building 14.1s (8/8) FINISHED                                                                                                                                           
 => [internal] load build definition from Dockerfile                                                                                                                   0.0s
 => => transferring dockerfile: 273B                                                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                                        0.0s
 => [internal] load metadata for docker.io/vdesabou/kafka-docker-playground-connect:5.3.8                                                                              0.0s
 => [internal] load build context                                                                                                                                      4.2s
 => => transferring context: 179.23MB                                                                                                                                  4.1s
 => [1/3] FROM docker.io/vdesabou/kafka-docker-playground-connect:5.3.8                                                                                                0.2s
 => [2/3] COPY --chown=root:root confluentinc-kafka-connect-hdfs3-1.1.14-SNAPSHOT.zip /tmp                                                                             0.7s
 => [3/3] RUN confluent-hub install --no-prompt /tmp/confluentinc-kafka-connect-hdfs3-1.1.14-SNAPSHOT.zip                                                              7.9s
 => exporting to image                                                                                                                                                 1.1s 
 => => exporting layers                                                                                                                                                1.1s 
 => => writing image sha256:1586f01ecc58d007e845aa971512c6e4e5d115958a0186d142ed57ca4fb69a5b                                                                           0.0s 
 => => naming to docker.io/vdesabou/kafka-docker-playground-connect:CP-5.3.8-confluentinc-kafka-connect-hdfs3-1.1.14-SNAPSHOT.zip                                      0.0s 
                                                                                                                                                                            
Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them                                                                        
23:39:47 ℹ️ 🛑 Grafana is disabled
namenode uses an image, skipping
hive-metastore-postgresql uses an image, skipping
broker uses an image, skipping
datanode uses an image, skipping
hive-server uses an image, skipping
presto-coordinator uses an image, skipping
zookeeper uses an image, skipping
nodemanager uses an image, skipping
schema-registry uses an image, skipping
resourcemanager uses an image, skipping
hive-metastore uses an image, skipping
historyserver uses an image, skipping
connect uses an image, skipping
Stopping ksqldb-cli                ... done
Stopping ksqldb-server             ... done
Stopping control-center            ... done
Stopping connect                   ... done
Stopping schema-registry           ... done
Stopping zookeeper                 ... done
Stopping broker                    ... done
Stopping historyserver             ... done
Stopping hive-metastore-postgresql ... done
Stopping datanode                  ... done
Stopping resourcemanager           ... done
Stopping hive-metastore            ... done
Stopping presto-coordinator        ... done
Stopping namenode                  ... done
Stopping nodemanager               ... done
Stopping hive-server               ... done
Removing ksqldb-cli                ... done
Removing ksqldb-server             ... done
Removing control-center            ... done
Removing connect                   ... done
Removing schema-registry           ... done
Removing zookeeper                 ... done
Removing broker                    ... done
Removing historyserver             ... done
Removing hive-metastore-postgresql ... done
Removing datanode                  ... done
Removing resourcemanager           ... done
Removing hive-metastore            ... done
Removing presto-coordinator        ... done
Removing namenode                  ... done
Removing nodemanager               ... done
Removing hive-server               ... done
Removing network mynetwork
Removing volume plaintext_datanode
Removing volume plaintext_namenode
Removing volume plaintext_hadoop_historyserver
Creating network "mynetwork" with the default driver
Creating volume "plaintext_datanode" with default driver
Creating volume "plaintext_namenode" with default driver
Creating volume "plaintext_hadoop_historyserver" with default driver
Creating hive-metastore-postgresql ... done
Creating resourcemanager           ... done
Creating zookeeper                 ... done
Creating historyserver             ... done
Creating presto-coordinator        ... done
Creating datanode                  ... done
Creating broker                    ... done
Creating hive-server               ... done
Creating nodemanager               ... done
Creating namenode                  ... done
Creating hive-metastore            ... done
Creating schema-registry           ... done
Creating connect                   ... done
Creating ksqldb-server             ... done
Creating control-center            ... done
Creating ksqldb-cli                ... done
23:40:28 ℹ️ 📝 To see the actual properties file, use ../../scripts/get-properties.sh <container>
23:40:28 ℹ️ ✨ If you modify a docker-compose file and want to re-create the container(s), run ../../scripts/recreate-containers.sh or use this command:
23:40:28 ℹ️ ✨ source ../../scripts/utils.sh && docker-compose -f ../../environment/plaintext/docker-compose.yml -f /Users/ajain/projects/kafka-docker-playground/connect/connect-hdfs3-sink/docker-compose.plaintext.yml --profile control-center --profile ksqldb   up -d
23:40:29 ℹ️ ⌛ Waiting up to 480 seconds for connect to start
23:41:32 ℹ️ 🚦 connect is started!
23:41:32 ℹ️ 🔧 You can use ksqlDB with CLI using:
23:41:32 ℹ️ docker exec -i ksqldb-cli ksql http://ksqldb-server:8088
23:41:32 ℹ️ 📊 JMX metrics are available locally on those ports:
23:41:32 ℹ️     - zookeeper       : 9999
23:41:32 ℹ️     - broker          : 10000
23:41:32 ℹ️     - schema-registry : 10001
23:41:32 ℹ️     - connect         : 10002
23:41:32 ℹ️     - ksqldb-server   : 10003
WARNING: HADOOP_PREFIX has been replaced by HADOOP_HOME. Using value of HADOOP_PREFIX.
23:41:45 ℹ️ Creating HDFS Sink connector with Hive integration
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2235  100   924  100  1311    904   1282  0:00:01  0:00:01 --:--:--  2189
{
  "name": "hdfs3-sink",
  "config": {
    "connector.class": "io.confluent.connect.hdfs3.Hdfs3SinkConnector",
    "tasks.max": "1",
    "topics": "test_hdfs",
    "store.url": "hdfs://namenode:9000",
    "flush.size": "3",
    "hadoop.conf.dir": "/etc/hadoop/",
    "partitioner.class": "io.confluent.connect.storage.partitioner.FieldPartitioner",
    "partition.field.name": "f1",
    "rotate.interval.ms": "120000",
    "hadoop.home": "/opt/hadoop-3.1.3/share/hadoop/common",
    "logs.dir": "/tmp",
    "hive.integration": "true",
    "hive.metastore.uris": "thrift://hive-metastore:9083",
    "hive.database": "testhive",
    "confluent.license": "",
    "confluent.topic.bootstrap.servers": "broker:9092",
    "confluent.topic.replication.factor": "1",
    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
    "value.converter": "io.confluent.connect.avro.AvroConverter",
    "value.converter.schema.registry.url": "http://schema-registry:8081",
    "schema.compatibility": "BACKWARD",
    "name": "hdfs3-sink"
  },
  "tasks": [],
  "type": "sink"
}
23:41:46 ℹ️ Sending messages to topic test_hdfs
23:41:59 ℹ️ Listing content of /topics/test_hdfs in HDFS
WARNING: HADOOP_PREFIX has been replaced by HADOOP_HOME. Using value of HADOOP_PREFIX.
Found 10 items
drwxr-xr-x   - root supergroup          0 2022-06-14 18:11 /topics/test_hdfs/f1=value1
drwxr-xr-x   - root supergroup          0 2022-06-14 18:11 /topics/test_hdfs/f1=value10
drwxr-xr-x   - root supergroup          0 2022-06-14 18:11 /topics/test_hdfs/f1=value2
drwxr-xr-x   - root supergroup          0 2022-06-14 18:11 /topics/test_hdfs/f1=value3
drwxr-xr-x   - root supergroup          0 2022-06-14 18:11 /topics/test_hdfs/f1=value4
drwxr-xr-x   - root supergroup          0 2022-06-14 18:11 /topics/test_hdfs/f1=value5
drwxr-xr-x   - root supergroup          0 2022-06-14 18:11 /topics/test_hdfs/f1=value6
drwxr-xr-x   - root supergroup          0 2022-06-14 18:11 /topics/test_hdfs/f1=value7
drwxr-xr-x   - root supergroup          0 2022-06-14 18:11 /topics/test_hdfs/f1=value8
drwxr-xr-x   - root supergroup          0 2022-06-14 18:11 /topics/test_hdfs/f1=value9
23:42:01 ℹ️ Getting one of the avro files locally and displaying content with avro-tools
WARNING: HADOOP_PREFIX has been replaced by HADOOP_HOME. Using value of HADOOP_PREFIX.
2022-06-14 18:12:03,488 INFO sasl.SaslDataTransferClient: SASL encryption trust check: localHostTrusted = false, remoteHostTrusted = false
log4j:WARN No appenders could be found for logger (org.apache.hadoop.metrics2.lib.MutableMetricsFactory).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
{"f1":"value1"}
23:43:06 ℹ️ Check data with beeline
WARNING: HADOOP_PREFIX has been replaced by HADOOP_HOME. Using value of HADOOP_PREFIX.
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/opt/hive/lib/log4j-slf4j-impl-2.10.0.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/opt/hadoop-3.1.2/share/hadoop/common/lib/slf4j-log4j12-1.7.25.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.apache.logging.slf4j.Log4jLoggerFactory]
Beeline version 3.1.2 by Apache Hive
beeline> !connect jdbc:hive2://hive-server:10000/testhive
Connecting to jdbc:hive2://hive-server:10000/testhive
Enter username for jdbc:hive2://hive-server:10000/testhive: hive
Enter password for jdbc:hive2://hive-server:10000/testhive: ****
Connected to: Apache Hive (version 3.1.2)
Driver: Hive JDBC (version 3.1.2)
Transaction isolation: TRANSACTION_REPEATABLE_READ
0: jdbc:hive2://hive-server:10000/testhive> show create table test_hdfs;
INFO  : Compiling command(queryId=root_20220614181310_006cd1b6-d968-4d7d-933d-9366ffcc4fac): show create table test_hdfs
INFO  : Concurrency mode is disabled, not creating a lock manager
INFO  : Semantic Analysis Completed (retrial = false)
INFO  : Returning Hive schema: Schema(fieldSchemas:[FieldSchema(name:createtab_stmt, type:string, comment:from deserializer)], properties:null)
INFO  : Completed compiling command(queryId=root_20220614181310_006cd1b6-d968-4d7d-933d-9366ffcc4fac); Time taken: 326.062 seconds
INFO  : Concurrency mode is disabled, not creating a lock manager
INFO  : Executing command(queryId=root_20220614181310_006cd1b6-d968-4d7d-933d-9366ffcc4fac): show create table test_hdfs
INFO  : Starting task [Stage-0:DDL] in serial mode
INFO  : Completed executing command(queryId=root_20220614181310_006cd1b6-d968-4d7d-933d-9366ffcc4fac); Time taken: 0.529 seconds
INFO  : OK
INFO  : Concurrency mode is disabled, not creating a lock manager
+----------------------------------------------------+
|                   createtab_stmt                   |
+----------------------------------------------------+
| CREATE EXTERNAL TABLE `test_hdfs`(                 |
| )                                                  |
| PARTITIONED BY (                                   |
|   `f1` string COMMENT '')                          |
| ROW FORMAT SERDE                                   |
|   'org.apache.hadoop.hive.serde2.avro.AvroSerDe'   |
| STORED AS INPUTFORMAT                              |
|   'org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat'  |
| OUTPUTFORMAT                                       |
|   'org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat' |
| LOCATION                                           |
|   'hdfs://namenode:9000/topics/test_hdfs'          |
| TBLPROPERTIES (                                    |
|   'avro.schema.literal'='{"type":"record","name":"ConnectDefault","namespace":"io.confluent.connect.avro","fields":[]}',  |
|   'bucketing_version'='2',                         |
|   'transient_lastDdlTime'='1655230314')            |
+----------------------------------------------------+
16 rows selected (327.479 seconds)
0: jdbc:hive2://hive-server:10000/testhive> select * from test_hdfs;
INFO  : Compiling command(queryId=root_20220614181837_06b9537a-2922-46f4-9808-40314821265c): select * from test_hdfs
INFO  : Concurrency mode is disabled, not creating a lock manager
INFO  : Semantic Analysis Completed (retrial = false)
INFO  : Returning Hive schema: Schema(fieldSchemas:[FieldSchema(name:test_hdfs.f1, type:string, comment:null)], properties:null)
INFO  : Completed compiling command(queryId=root_20220614181837_06b9537a-2922-46f4-9808-40314821265c); Time taken: 4.209 seconds
INFO  : Concurrency mode is disabled, not creating a lock manager
INFO  : Executing command(queryId=root_20220614181837_06b9537a-2922-46f4-9808-40314821265c): select * from test_hdfs
INFO  : Completed executing command(queryId=root_20220614181837_06b9537a-2922-46f4-9808-40314821265c); Time taken: 0.004 seconds
INFO  : OK
INFO  : Concurrency mode is disabled, not creating a lock manager
+---------------+
| test_hdfs.f1  |
+---------------+
| value1        |
| value2        |
| value3        |
| value4        |
| value5        |
| value6        |
| value7        |
| value8        |
| value9        |
+---------------+
9 rows selected (5.171 seconds)
0: jdbc:hive2://hive-server:10000/testhive> Closing: 0: jdbc:hive2://hive-server:10000/testhive
| value1        |

```
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
