### PR TITLE
CCMSG-1654: fix parent in hadoop shaded

### DIFF
--- a/hadoop-shaded-protobuf/pom.xml
+++ b/hadoop-shaded-protobuf/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>10.1.11-SNAPSHOT</version>
+        <version>11.0.8-SNAPSHOT</version>
     </parent>
 
     <artifactId>kafka-connect-storage-common-hadoop-shaded-protobuf</artifactId>


### PR DESCRIPTION
## Problem
Parent version in Hadoop shaded is not the branch's latest snapshot version
Start getting this issue after pint merge of #244 
## Solution
updated parent version in Hadoop shaded


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
