### PR TITLE
Add a dependency on slf4j-reload4j to used child plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,7 @@
         <json.smart.version>2.4.7</json.smart.version>
         <thrift.version>0.13.0</thrift.version>
         <tomcat.version>8.5.65</tomcat.version>
+        <slf4j-reload4j.version>1.7.36</slf4j-reload4j.version>
     </properties>
 
     <repositories>
@@ -169,6 +170,11 @@
                 <scope>test</scope>
             </dependency>
             <!-- Pinning for CVEs -->
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-reload4j</artifactId>
+                <version>${slf4j-reload4j.version}</version>
+            </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>


### PR DESCRIPTION
## Problem

`slf4j-log4j12` has vulnerabilites and is being replaced with `slf4j-reload4j`

https://confluentinc.atlassian.net/browse/CCMSG-1972

## Solution
Adding a dependency on `slf4j-reload4j` in this "parent" pom, to use in child connector plugins.


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [X] no

##### If yes, where?

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
Will be used in child connect plugins