### PR TITLE
Update pom.xml to use hadoop version 3.3.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <confluent.log4j.version>1.2.17-cp8</confluent.log4j.version>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <dependency.check.version>6.1.6</dependency.check.version>
-        <hadoop.version>2.10.2</hadoop.version>
+        <hadoop.version>3.3.3</hadoop.version>
         <hive.version>2.3.9</hive.version>
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.4</httpcore.version>


### PR DESCRIPTION
Update pom.xml to use hadoop version 3.3.3 to remediate security vulnerabilities

CVE-2021-37404
CVE-2022-26612

This addresses the issue raised here:
https://github.com/confluentinc/kafka-connect-storage-cloud/issues/508

## Problem


## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
