### PR TITLE
Pin common version to 7.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>[7.2.0, 7.3.0)</version>
+        <version>7.2.1</version>
     </parent>
 
     <artifactId>kafka-connect-storage-common-parent</artifactId>


### PR DESCRIPTION
## Problem
Adding range in version can lead to variety of `kafka.version` in common. All of which may not be available for public builds. 

## Solution
Pin parent `common` version, so the dependencies imported remain constant and does not change with time. 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
