### PR TITLE
Bump up hadoop version to 2.10.2.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <confluent.log4j.version>1.2.17-cp2</confluent.log4j.version>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <confluent.version>5.4.10-SNAPSHOT</confluent.version>
-        <hadoop.version>2.10.1</hadoop.version>
+        <hadoop.version>2.10.2</hadoop.version>
         <hive.version>1.2.2</hive.version>
         <joda.version>2.9.6</joda.version>
         <licenses.version>5.4.10-SNAPSHOT</licenses.version>


### PR DESCRIPTION
https://confluentinc.atlassian.net/browse/CCMSG-2042


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy
Tested this upgrade on kafka-connect-s3 where the hadoop dependency is being inherited as is. This was done by installing it locally and then running the tests in s3. 

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
