### PR TITLE
bumping hadoop version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <confluent.log4j.version>1.2.17-cp2</confluent.log4j.version>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <confluent.version>5.4.11-SNAPSHOT</confluent.version>
-        <hadoop.version>2.10.2</hadoop.version>
+        <hadoop.version>3.2.3</hadoop.version>
         <hive.version>1.2.2</hive.version>
         <joda.version>2.9.6</joda.version>
         <licenses.version>5.4.11-SNAPSHOT</licenses.version>


### PR DESCRIPTION
## Problem
[CCMSG-2287](https://confluentinc.atlassian.net/browse/CCMSG-2287)  - Upgrade jettison at kafka-connect-storage-cloud
[CCMSG-2293](https://confluentinc.atlassian.net/browse/CCMSG-2293) - Upgrade org.apache.hadoop:hadoop-common at kafka-connect-storage-cloud

## Solution
bumping hadoop version to 3.2.3 which in turns will bump the jettison version to 1.5.1


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [x] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
