### PR TITLE
Remove Jackson version pinning.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,8 +80,6 @@
         <parquet.version>1.12.3</parquet.version>
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.4</httpcore.version>
-        <jackson.version>2.13.4</jackson.version>
-        <jackson.databind.version>2.13.4.2</jackson.databind.version>
         <jackson.mapper.asl.version>1.9.14.jdk17-redhat-00001</jackson.mapper.asl.version>
         <jetty.version>9.4.43.v20210629</jetty.version>
         <jline.version>2.12.1</jline.version>


### PR DESCRIPTION
Not needed after https://github.com/confluentinc/common/pull/485.