### PR TITLE
CCMSG-2275: Update commons-io to resolve CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 
     <properties>
         <avro.version>1.10.2</avro.version>
-        <commons-io.version>2.7</commons-io.version>
+        <commons-io.version>2.8.0</commons-io.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
         <commons.codec.version>1.15</commons.codec.version>
         <commons.compress.version>1.21</commons.compress.version>


### PR DESCRIPTION
https://confluentinc.atlassian.net/browse/CCMSG-2275

According to the release notes for 2.8.0 it is fully compatible with 2.7 so this bump should not cause a breaking change. 
https://github.com/apache/commons-io/blob/master/RELEASE-NOTES.txt
<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
