### PR TITLE
Expose `scrub.invalid.names` config to scrub invalid schema names

### DIFF
--- a/core/src/main/java/io/confluent/connect/storage/StorageSinkConnectorConfig.java
+++ b/core/src/main/java/io/confluent/connect/storage/StorageSinkConnectorConfig.java
@@ -100,6 +100,11 @@ public class StorageSinkConnectorConfig extends AbstractConfig implements Compos
   public static final int SCHEMA_CACHE_SIZE_DEFAULT = 1000;
   public static final String SCHEMA_CACHE_SIZE_DISPLAY = "Schema Cache Size";
 
+  public static final String SCRUB_INVALID_NAMES_CONFIG = AvroDataConfig.SCRUB_INVALID_NAMES_CONFIG;
+  public static final String SCRUB_INVALID_NAMES_DOC = "Enable scrubbing of invalid schema names";
+  public static final String SCRUB_INVALID_NAMES_DEFAULT = false;
+  public static final String SCRUB_INVALID_NAMES_DISPLAY = "Scrub Invalid Schema Names";
+
   public static final String ENHANCED_AVRO_SCHEMA_SUPPORT_CONFIG = "enhanced.avro.schema.support";
   public static final boolean ENHANCED_AVRO_SCHEMA_SUPPORT_DEFAULT = true;
   public static final String ENHANCED_AVRO_SCHEMA_SUPPORT_DOC =
@@ -241,6 +246,18 @@ public class StorageSinkConnectorConfig extends AbstractConfig implements Compos
           ++orderInGroup,
           Width.SHORT,
           CONNECT_META_DATA_DISPLAY
+      );
+
+      configDef.define(
+          SCRUB_INVALID_NAMES_CONFIG,
+          Type.BOOLEAN,
+          SCRUB_INVALID_NAMES_DEFAULT,
+          Importance.LOW,
+          SCRUB_INVALID_NAMES_DOC,
+          group,
+          ++orderInGroup,
+          Width.SHORT,
+          SCRUB_INVALID_NAMES_DISPLAY
       );
 
       configDef.define(
@@ -409,6 +426,7 @@ public class StorageSinkConnectorConfig extends AbstractConfig implements Compos
     props.put(SCHEMA_CACHE_SIZE_CONFIG, get(SCHEMA_CACHE_SIZE_CONFIG));
     props.put(ENHANCED_AVRO_SCHEMA_SUPPORT_CONFIG, get(ENHANCED_AVRO_SCHEMA_SUPPORT_CONFIG));
     props.put(CONNECT_META_DATA_CONFIG, get(CONNECT_META_DATA_CONFIG));
+    props.put(SCRUB_INVALID_NAMES_CONFIG, get(SCRUB_INVALID_NAMES_CONFIG));
     return new AvroDataConfig(props);
   }
 }


### PR DESCRIPTION
## Problem
https://github.com/confluentinc/schema-registry/pull/1873 introduced the option to scrub invalid schema names, but the storage connectors can't take advantage of it as it's not an exposed config.

## Solution

Expose the option to be configured. A lucrative alternative here would be instead to have a passthrough, say `formatter.avro.*` which let through all of `AvroDataConfig` options instead of exposing them one by one. 


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [X] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [X] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
