### PR TITLE
CCMSG-2370: Remove logging struct in exception 

### DIFF
--- a/core/src/main/java/io/confluent/connect/storage/util/DataUtils.java
+++ b/core/src/main/java/io/confluent/connect/storage/util/DataUtils.java
@@ -41,14 +41,13 @@ public class DataUtils {
       return field;
     } else {
       throw new DataException(String.format(
-            "Argument not a Struct or Map. Cannot get field '%s' from %s.",
-            fieldName,
-            structOrMap
+            "Argument not a Struct or Map. Cannot get field '%s'.",
+            fieldName
       ));
     }
     if (field == null) {
       throw new DataException(
-            String.format("The field '%s' does not exist in %s.", fieldName, structOrMap));
+            String.format("The field '%s' does not exist.", fieldName));
     }
     return field;
   }
@@ -65,7 +64,7 @@ public class DataUtils {
       return innermost;
     } catch (DataException e) {
       throw new DataException(
-            String.format("The field '%s' does not exist in %s.", fieldName, structOrMap),
+            String.format("The field '%s' does not exist.", fieldName),
             e
       );
     }

--- a/core/src/test/java/io/confluent/connect/storage/util/DataUtilsTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/util/DataUtilsTest.java
@@ -203,7 +203,7 @@ public class DataUtilsTest extends StorageSinkTestBase {
       DataUtils.getNestedFieldValue(map, fieldName);
     });
     assertThat(e.getMessage(),
-        startsWith(String.format("The field '%s' does not exist in", fieldName)));
+        startsWith(String.format("The field '%s' does not exist", fieldName)));
   }
 
   @Test
@@ -218,7 +218,7 @@ public class DataUtilsTest extends StorageSinkTestBase {
       DataUtils.getNestedFieldValue(map, topField + "." + fieldName);
     });
     assertThat(e.getMessage(),
-        startsWith(String.format("The field '%s.%s' does not exist in", topField, fieldName)));
+        startsWith(String.format("The field '%s.%s' does not exist", topField, fieldName)));
   }
 
   @Test


### PR DESCRIPTION
## Problem
A data exception if thrown can include struct information which contain user data. This is a security concern.

## Solution
Remove struct from the exception logging. 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
