### PR TITLE
unpin the netty dependency to sync with the updated version from common/

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,6 @@
         <jackson.mapper.asl.version>1.9.14.jdk17-redhat-00001</jackson.mapper.asl.version>
         <jetty.version>9.4.43.v20210629</jetty.version>
         <jline.version>2.12.1</jline.version>
-        <netty.version>4.1.68.Final</netty.version>
         <json.smart.version>2.4.7</json.smart.version>
         <thrift.version>0.13.0</thrift.version>
         <tomcat.version>8.5.65</tomcat.version>


### PR DESCRIPTION
## Problem
The pom file for branch 5.5.x overwrites the dependency version set in parent common pom. This results in importing and outdated  version of a dependency. 

## Solution
Remove the version definition. 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
