### PR TITLE
CCMSG-2360 Update io.confluent:common to 7.2.4-5 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>7.2.1</version>
+        <version>7.2.4-5</version>
     </parent>
 
     <artifactId>kafka-connect-storage-common-parent</artifactId>


### PR DESCRIPTION
## Problem
Existing io.confluent_common:7.2.1 is bringing value of jackson.databind.version as 2.13.2 which is vulnerable.


## Solution
Updating the version to 7.2.4-5 which uses jackson.databind.version as 2.13.4.2

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
The resultant release version will be updated in https://github.com/confluentinc/kafka-connect-storage-cloud