### PR TITLE
Update netty to 4.1.86 to to address CVE-2022-41915 and put in line with Kafka version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <jackson.mapper.asl.version>1.9.14.jdk17-redhat-00001</jackson.mapper.asl.version>
         <jetty.version>9.4.43.v20210629</jetty.version>
         <jline.version>2.12.1</jline.version>
-        <netty.version>4.1.68.Final</netty.version>
+        <netty.version>4.1.86.Final</netty.version>
 	<json.smart.version>2.4.7</json.smart.version>
         <thrift.version>0.13.0</thrift.version>
         <tomcat.version>8.5.65</tomcat.version>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,8 @@
         <jackson.mapper.asl.version>1.9.14.jdk17-redhat-00001</jackson.mapper.asl.version>
         <jetty.version>9.4.43.v20210629</jetty.version>
         <jline.version>2.12.1</jline.version>
-        <json.smart.version>2.4.7</json.smart.version>
+        <netty.version>4.1.68.Final</netty.version>
+	<json.smart.version>2.4.7</json.smart.version>
         <thrift.version>0.13.0</thrift.version>
         <tomcat.version>8.5.65</tomcat.version>
         <slf4j-reload4j.version>1.7.36</slf4j-reload4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,6 @@
         <jackson.mapper.asl.version>1.9.14.jdk17-redhat-00001</jackson.mapper.asl.version>
         <jetty.version>9.4.43.v20210629</jetty.version>
         <jline.version>2.12.1</jline.version>
-        <netty.version>4.1.68.Final</netty.version>
         <json.smart.version>2.4.7</json.smart.version>
         <thrift.version>0.13.0</thrift.version>
         <tomcat.version>8.5.65</tomcat.version>


### PR DESCRIPTION
## Problem
The netty dependency is out of date and should be updated to resolve CVE-2022-41915 in the connectors that use this common parent

## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
