### PR TITLE
CCLOG-2401: Parse logical types correctly for hive schemas. 

### DIFF
--- a/hive/src/main/java/io/confluent/connect/storage/hive/HiveSchemaConverter.java
+++ b/hive/src/main/java/io/confluent/connect/storage/hive/HiveSchemaConverter.java
@@ -19,6 +19,7 @@ import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
@@ -28,6 +29,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.kafka.connect.data.Timestamp;
 import org.apache.kafka.connect.errors.ConnectException;
 
 public class HiveSchemaConverter {
@@ -133,22 +135,27 @@ public class HiveSchemaConverter {
       return convertPrimitive(schema);
     }
 
-    if (Decimal.LOGICAL_NAME.equals(schema.name())) {
-      String scale = schema.parameters().get(Decimal.SCALE_FIELD);
-      String precision = schema.parameters().get(CONNECT_AVRO_DECIMAL_PRECISION_PROP);
-      if (precision != null && Integer.parseInt(precision) > HIVE_DECIMAL_PRECISION_MAX) {
-        throw new ConnectException(
-            String.format("Illegal precision %s : Hive allows at most %d precision.",
-                precision,
-                HIVE_DECIMAL_PRECISION_MAX)
-        );
-      }
-      // Let precision always be HIVE_DECIMAL_PRECISION_MAX. Hive serde will try the best
-      // to fit decimal data into decimal schema. If the data is too long even for
-      // the maximum precision, hive will throw serde exception. No data loss risk.
-      return new DecimalTypeInfo(HIVE_DECIMAL_PRECISION_MAX, Integer.parseInt(scale));
-    } else {
-      return convertPrimitive(schema);
+    switch (schema.name()) {
+      case Decimal.LOGICAL_NAME:
+        String scale = schema.parameters().get(Decimal.SCALE_FIELD);
+        String precision = schema.parameters().get(CONNECT_AVRO_DECIMAL_PRECISION_PROP);
+        if (precision != null && Integer.parseInt(precision) > HIVE_DECIMAL_PRECISION_MAX) {
+          throw new ConnectException(
+              String.format("Illegal precision %s : Hive allows at most %d precision.",
+                  precision,
+                  HIVE_DECIMAL_PRECISION_MAX)
+          );
+        }
+        // Let precision always be HIVE_DECIMAL_PRECISION_MAX. Hive serde will try the best
+        // to fit decimal data into decimal schema. If the data is too long even for
+        // the maximum precision, hive will throw serde exception. No data loss risk.
+        return new DecimalTypeInfo(HIVE_DECIMAL_PRECISION_MAX, Integer.parseInt(scale));
+      case Date.LOGICAL_NAME:
+        return TypeInfoFactory.dateTypeInfo;
+      case Timestamp.LOGICAL_NAME:
+        return TypeInfoFactory.timestampTypeInfo;
+      default:
+        return convertPrimitive(schema);
     }
   }
 }

--- a/hive/src/test/java/io/confluent/connect/storage/hive/HiveSchemaConverterTest.java
+++ b/hive/src/test/java/io/confluent/connect/storage/hive/HiveSchemaConverterTest.java
@@ -21,16 +21,22 @@ public class HiveSchemaConverterTest {
     // The only decimal type supported by Hive with parquet is decimal,
     // All other types should be parsed as primitive.
     Schema dateSchema = SchemaBuilder.int32().name(Date.LOGICAL_NAME).build();
-    assertEquals(TypeInfoFactory.intTypeInfo,
+    assertEquals(TypeInfoFactory.dateTypeInfo,
         HiveSchemaConverter.convertPrimitiveMaybeLogical(dateSchema));
+
 
     // logical type time is not supported by Hive serde, convert it to Hive INT
     Schema timeSchema = SchemaBuilder.int32().name(Time.LOGICAL_NAME).build();
     assertEquals(TypeInfoFactory.intTypeInfo,
         HiveSchemaConverter.convertPrimitiveMaybeLogical(timeSchema));
 
-    Schema timestampSchema = SchemaBuilder.int64().name(Timestamp.LOGICAL_NAME).build();
+    // time when represented in microseconds is long
+    Schema timeSchema64 = SchemaBuilder.int64().name(Time.LOGICAL_NAME).build();
     assertEquals(TypeInfoFactory.longTypeInfo,
+        HiveSchemaConverter.convertPrimitiveMaybeLogical(timeSchema64));
+
+    Schema timestampSchema = SchemaBuilder.int64().name(Timestamp.LOGICAL_NAME).build();
+    assertEquals(TypeInfoFactory.timestampTypeInfo,
         HiveSchemaConverter.convertPrimitiveMaybeLogical(timestampSchema));
   }
 


### PR DESCRIPTION
## Problem
Some logical connect data types are not correctly inferred to their hive counterpart. These include Date and Timestamp datatypes which are inferred as `int` and `long` previously. However in the `orc` writer these are inserted as Timestamp and Dates respectively which causes data with such datatypes to fail when queried in hive. Time logical type can also either be `int` or `long`. 

There is also a bug in the recursive parsing logic where if logical types are not handled if nested inside a struct, array or map. This is because in case of struct the `convertPrimitiveMaybeLogical` is never reached as the recursive calls always goes to the not logical convert method. 

## Solution
Assign the correct hive data types for the logical connect types. The hive logical conversion is not used currently in any of the downstream hdfs connectors which use this package. The current orc writer does not correctly infer logical types hence there should not be any backwards compatibility issues. Regardless this will be released as a minor version bump. 

The recursive logic is fixed and some tests are added. 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
