### PR TITLE
CCMSG-2388: Bump protobuf.version to 3.19.6 to resolve CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <thrift.version>0.13.0</thrift.version>
         <tomcat.version>8.5.65</tomcat.version>
         <slf4j-reload4j.version>1.7.36</slf4j-reload4j.version>
-        <protobuf.version>3.19.4</protobuf.version>
+        <protobuf.version>3.19.6</protobuf.version>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>6.1.6</version>
+        <version>6.1.9</version>
     </parent>
 
     <artifactId>kafka-connect-storage-common-parent</artifactId>
@@ -92,7 +92,6 @@
         <thrift.version>0.13.0</thrift.version>
         <tomcat.version>8.5.65</tomcat.version>
         <slf4j-reload4j.version>1.7.36</slf4j-reload4j.version>
-        <protobuf.version>3.19.6</protobuf.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
## Problem
- https://confluentinc.atlassian.net/browse/CCMSG-2388
- Protobuf version 3.19.4 has vulnerabilities.

## Solution
- Bring updated protobuf dependency from parent pom. 

Reference - https://github.com/confluentinc/kafka-connect-elasticsearch/pull/419
<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
