### PR TITLE
Minor: Fix build errors

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
 #!/usr/bin/env groovy
 common {
   slackChannel = '#connect-warn'
+  nodeLabel = 'docker-debian-jdk8'
   upstreamProjects = ['confluentinc/common','confluentinc/schema-registry']
   pintMerge = true
 }

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,6 @@
         <parquet.version>1.7.0</parquet.version>
         <commons-io.version>2.4</commons-io.version>
         <joda.version>2.9.6</joda.version>
-        <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <licenses.version>3.2.5-SNAPSHOT</licenses.version>
         <maven-assembly.version>2.6</maven-assembly.version>
         <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
@@ -81,7 +80,7 @@
         <repository>
             <id>confluent</id>
             <name>Confluent</name>
-            <url>${confluent.maven.repo}</url>
+            <url>https://packages.confluent.io/maven/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
## Problem

There are two issues we are fixing here - 

1. Not able to access ${confluent.maven.repo} property. 
```
[ERROR]     Non-resolvable parent POM for io.confluent:kafka-connect-storage-common-parent:10.0.17-SNAPSHOT: Could not transfer artifact io.confluent:common:pom:6.1.9 from/to confluent (${confluent.maven.repo}): Cannot access ${confluent.maven.repo} with type default using the available connector factories: BasicRepositoryConnectorFactory and 'parent.relativePath' points at wrong local POM @ line 21, column 13: Cannot access ${confluent.maven.repo} using the registered transporter factories: WagonTransporterFactory: Unsupported transport protocol -> [Help 2]
```
Fix for this is already explained in this PR - https://github.com/confluentinc/kafka-connect-elasticsearch/pull/419

2. Spotbugs error due to java version 17 - 
```
[ERROR] Failed to execute goal com.github.spotbugs:spotbugs-maven-plugin:4.0.0:spotbugs (spotbugs) on project kafka-connect-storage-common: Execution spotbugs of goal com.github.spotbugs:spotbugs-maven-plugin:4.0.0:spotbugs failed: Java returned: 1 -> [Help 1]
```


## Solution
1. Fix for ${confluent.maven.repo} property is to remove the property variable and directly use the url at configured place. 
2. Fix for spotbugs is to pin java version 8 similar to other connectors by using `docker-debian-jdk8` in jenkinsFile.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
