### PR TITLE
RCCA-10996: Update parquet.version to 1.11.2 to fix NoClassDefFoundError

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <hive.version>1.2.2</hive.version>
         <joda.version>2.9.6</joda.version>
         <licenses.version>5.4.12-SNAPSHOT</licenses.version>
-        <parquet.version>1.12.3</parquet.version>
+        <parquet.version>1.11.2</parquet.version>
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.4</httpcore.version>
         <jackson.mapper.asl.version>1.9.14.jdk17-redhat-00001</jackson.mapper.asl.version>


### PR DESCRIPTION
## Problem
- This issue was encounter earlier as well and was fixed in this PR - https://github.com/confluentinc/kafka-connect-storage-common/pull/273 but this change got recently reverted - https://github.com/confluentinc/kafka-connect-storage-common/pull/298 and again caused the same issue. 

Error stacktrace - ```NoClassDefFoundError: org/apache/hadoop/mapreduce/lib/output/FileOutputFormat```

## Solution
- Move back to older version - v1.11.2

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy
- @pbadani is manually overriding the version in s3 connector and verifying that this fixes the issue and also ensuring no new CVEs are added - https://confluent.slack.com/archives/C04PX7REHRQ/p1676622604087989?thread_ts=1676549999.603739&cid=C04PX7REHRQ 

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
