### PR TITLE
update jetty version to match kafka-rest, pin additional jetty libraries

### DIFF
--- a/avatica-shaded/pom.xml
+++ b/avatica-shaded/pom.xml
@@ -154,15 +154,4 @@ language governing permissions and limitations under the License. -->
             <version>${protobuf.version}</version>
         </dependency>
     </dependencies>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>com.google.protobuf</groupId>
-                <artifactId>protobuf-java</artifactId>
-                <version>${protobuf.version}</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <jackson.version>2.14.2</jackson.version>
         <jackson.databind.version>2.14.2</jackson.databind.version>
         <jackson.mapper.asl.version>1.9.14.jdk17-redhat-00001</jackson.mapper.asl.version>
-        <jetty.version>9.4.43.v20210629</jetty.version>
+        <jetty.version>9.4.48.v20220622</jetty.version>
         <jline.version>2.12.1</jline.version>
         <joda.version>2.9.6</joda.version>
         <kafka.connect.storage.common.version>10.0.21-SNAPSHOT</kafka.connect.storage.common.version>
@@ -255,12 +255,37 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-client</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-io</artifactId>
                 <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-server</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-servlet</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-servlets</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-util</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-webapp</artifactId>
                 <version>${jetty.version}</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
         <hive.version>2.3.9</hive.version>
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.4</httpcore.version>
+        <!-- jackson is defined in common, might be worthwhile to update common then remove this pins here -->
         <jackson.version>2.14.2</jackson.version>
         <jackson.databind.version>2.14.2</jackson.databind.version>
         <jackson.mapper.asl.version>1.9.14.jdk17-redhat-00001</jackson.mapper.asl.version>
@@ -86,6 +87,7 @@
         <joda.version>2.9.6</joda.version>
         <kafka.connect.storage.common.version>10.0.21-SNAPSHOT</kafka.connect.storage.common.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
+        <!-- netty is defined in common, might be worthwhile to update common then remove this pins here -->
         <netty.version>4.1.86.Final</netty.version>
         <parquet.version>1.11.2</parquet.version>
         <json.smart.version>2.4.7</json.smart.version>


### PR DESCRIPTION
## Problem
Parent pom defines outdated version of jetty that could lead to bringing outdated, vulnerable dependencies by connectors using kafka-connect-storage pom

## Solution
Bump version of the dependency, specify dependencies in the dependencyManagement to instruct artifacts built using this pom to use the updated versions.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
