### PR TITLE
CC-19464 | Return the reason for schema incompatibility along with the boolean result.

### DIFF
--- a/core/src/main/java/io/confluent/connect/storage/schema/SchemaCompatibilityResult.java
+++ b/core/src/main/java/io/confluent/connect/storage/schema/SchemaCompatibilityResult.java
@@ -15,20 +15,21 @@
 
 package io.confluent.connect.storage.schema;
 
-import org.apache.kafka.connect.connector.ConnectRecord;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.sink.SinkRecord;
-import org.apache.kafka.connect.source.SourceRecord;
+public final class SchemaCompatibilityResult {
+  private final boolean isInCompatible;
+  private final SchemaIncompatibilityType schemaIncompatibilityType;
 
-public interface SchemaCompatibility {
+  public SchemaCompatibilityResult(boolean isInCompatible,
+      SchemaIncompatibilityType schemaIncompatibilityType) {
+    this.isInCompatible = isInCompatible;
+    this.schemaIncompatibilityType = schemaIncompatibilityType;
+  }
 
-  SchemaCompatibilityResult shouldChangeSchema(
-      ConnectRecord<?> record,
-      Schema currentkeySchema,
-      Schema currentValueSchema
-  );
+  public boolean isInCompatible() {
+    return isInCompatible;
+  }
 
-  SinkRecord project(SinkRecord record, Schema currentKeySchema, Schema currentValueSchema);
-
-  SourceRecord project(SourceRecord record, Schema currentKeySchema, Schema currentValueSchema);
+  public SchemaIncompatibilityType getSchemaIncompatibilityType() {
+    return schemaIncompatibilityType;
+  }
 }

--- a/core/src/main/java/io/confluent/connect/storage/schema/SchemaIncompatibilityType.java
+++ b/core/src/main/java/io/confluent/connect/storage/schema/SchemaIncompatibilityType.java
@@ -15,20 +15,11 @@
 
 package io.confluent.connect.storage.schema;
 
-import org.apache.kafka.connect.connector.ConnectRecord;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.sink.SinkRecord;
-import org.apache.kafka.connect.source.SourceRecord;
-
-public interface SchemaCompatibility {
-
-  SchemaCompatibilityResult shouldChangeSchema(
-      ConnectRecord<?> record,
-      Schema currentkeySchema,
-      Schema currentValueSchema
-  );
-
-  SinkRecord project(SinkRecord record, Schema currentKeySchema, Schema currentValueSchema);
-
-  SourceRecord project(SourceRecord record, Schema currentKeySchema, Schema currentValueSchema);
+public enum SchemaIncompatibilityType {
+  DIFFERENT_SCHEMA,
+  DIFFERENT_TYPE,
+  DIFFERENT_NAME,
+  DIFFERENT_PARAMS,
+  DIFFERENT_VERSION,
+  NA
 }

--- a/core/src/test/java/io/confluent/connect/storage/schema/StorageSchemaCompatibilityTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/schema/StorageSchemaCompatibilityTest.java
@@ -28,6 +28,13 @@ public class StorageSchemaCompatibilityTest {
   private final StorageSchemaCompatibility forward = StorageSchemaCompatibility.FORWARD;
   private final StorageSchemaCompatibility full = StorageSchemaCompatibility.FULL;
 
+  private final SchemaIncompatibilityType diffSchema = SchemaIncompatibilityType.DIFFERENT_SCHEMA;
+  private final SchemaIncompatibilityType diffType = SchemaIncompatibilityType.DIFFERENT_TYPE;
+  private final SchemaIncompatibilityType diffName = SchemaIncompatibilityType.DIFFERENT_NAME;
+  private final SchemaIncompatibilityType diffParams = SchemaIncompatibilityType.DIFFERENT_PARAMS;
+  private final SchemaIncompatibilityType diffVersion = SchemaIncompatibilityType.DIFFERENT_VERSION;
+  private final SchemaIncompatibilityType na = SchemaIncompatibilityType.NA;
+
   private static SchemaBuilder buildStringSchema(String name, int version) {
     return SchemaBuilder.string()
                         .version(version)
@@ -107,27 +114,27 @@ public class StorageSchemaCompatibilityTest {
 
   @Test
   public void noneCompatibilityShouldConsiderDifferentVersionsAsChanged() {
-    assertChanged(none, SCHEMA_A, SCHEMA_A_NEWER_VERSION);
-    assertChanged(none, SCHEMA_A, SCHEMA_A_OLDER_VERSION);
-    assertChanged(none, SCHEMA_B, SCHEMA_B_OLDER_VERSION);
-    assertChanged(none, SCHEMA_B, SCHEMA_B_PARAMETERED);
+    assertChanged(none, SCHEMA_A, SCHEMA_A_NEWER_VERSION, diffSchema);
+    assertChanged(none, SCHEMA_A, SCHEMA_A_OLDER_VERSION, diffSchema);
+    assertChanged(none, SCHEMA_B, SCHEMA_B_OLDER_VERSION, diffSchema);
+    assertChanged(none, SCHEMA_B, SCHEMA_B_PARAMETERED, diffSchema);
   }
 
   @Test
   public void noneCompatibilityShouldConsiderAnyDifferencesAsChanged() {
-    assertChanged(none, SCHEMA_A, SCHEMA_A_RENAMED);
-    assertChanged(none, SCHEMA_A, SCHEMA_A_RETYPED);
-    assertChanged(none, SCHEMA_A, SCHEMA_A_PARAMETERED);
-    assertChanged(none, SCHEMA_A, SCHEMA_A_WITH_DOC);
-    assertChanged(none, SCHEMA_A, SCHEMA_A_OPTIONAL);
+    assertChanged(none, SCHEMA_A, SCHEMA_A_RENAMED, diffSchema);
+    assertChanged(none, SCHEMA_A, SCHEMA_A_RETYPED, diffSchema);
+    assertChanged(none, SCHEMA_A, SCHEMA_A_PARAMETERED, diffSchema);
+    assertChanged(none, SCHEMA_A, SCHEMA_A_WITH_DOC, diffSchema);
+    assertChanged(none, SCHEMA_A, SCHEMA_A_OPTIONAL, diffSchema);
 
-    assertChanged(none, SCHEMA_B, SCHEMA_B_RENAMED);
-    assertChanged(none, SCHEMA_B, SCHEMA_B_RETYPED);
-    assertChanged(none, SCHEMA_B, SCHEMA_B_PARAMETERED);
-    assertChanged(none, SCHEMA_B, SCHEMA_B_WITH_DOC);
-    assertChanged(none, SCHEMA_B, SCHEMA_B_OPTIONAL);
-    assertChanged(none, SCHEMA_B, SCHEMA_B_EXTRA_REQUIRED_FIELD);
-    assertChanged(none, SCHEMA_B, SCHEMA_B_EXTRA_OPTIONAL_FIELD);
+    assertChanged(none, SCHEMA_B, SCHEMA_B_RENAMED, diffSchema);
+    assertChanged(none, SCHEMA_B, SCHEMA_B_RETYPED, diffSchema);
+    assertChanged(none, SCHEMA_B, SCHEMA_B_PARAMETERED, diffSchema);
+    assertChanged(none, SCHEMA_B, SCHEMA_B_WITH_DOC, diffSchema);
+    assertChanged(none, SCHEMA_B, SCHEMA_B_OPTIONAL, diffSchema);
+    assertChanged(none, SCHEMA_B, SCHEMA_B_EXTRA_REQUIRED_FIELD, diffSchema);
+    assertChanged(none, SCHEMA_B, SCHEMA_B_EXTRA_OPTIONAL_FIELD, diffSchema);
 
     assertUnchanged(none, SCHEMA_A, SCHEMA_A);
     assertUnchanged(none, SCHEMA_A, SCHEMA_A_COPY);
@@ -137,8 +144,8 @@ public class StorageSchemaCompatibilityTest {
 
   @Test
   public void backwardCompatibilityShouldConsiderOlderSchemaVersionsAsChanged() {
-    assertChanged(backward, SCHEMA_A, SCHEMA_A_OLDER_VERSION);
-    assertChanged(backward, SCHEMA_B, SCHEMA_B_OLDER_VERSION);
+    assertChanged(backward, SCHEMA_A, SCHEMA_A_OLDER_VERSION, diffVersion);
+    assertChanged(backward, SCHEMA_B, SCHEMA_B_OLDER_VERSION, diffVersion);
   }
 
   @Test
@@ -151,8 +158,8 @@ public class StorageSchemaCompatibilityTest {
 
   @Test
   public void forwardCompatibilityShouldConsiderNewerSchemaVersionsAsChanged() {
-    assertChanged(forward, SCHEMA_A, SCHEMA_A_NEWER_VERSION);
-    assertChanged(forward, SCHEMA_B, SCHEMA_B_NEWER_VERSION);
+    assertChanged(forward, SCHEMA_A, SCHEMA_A_NEWER_VERSION, diffVersion);
+    assertChanged(forward, SCHEMA_B, SCHEMA_B_NEWER_VERSION, diffVersion);
   }
 
   @Test
@@ -165,8 +172,8 @@ public class StorageSchemaCompatibilityTest {
 
   @Test
   public void fullCompatibilityShouldConsiderOlderSchemaVersionsAsChanged() {
-    assertChanged(full, SCHEMA_A, SCHEMA_A_OLDER_VERSION);
-    assertChanged(full, SCHEMA_B, SCHEMA_B_OLDER_VERSION);
+    assertChanged(full, SCHEMA_A, SCHEMA_A_OLDER_VERSION, diffVersion);
+    assertChanged(full, SCHEMA_B, SCHEMA_B_OLDER_VERSION, diffVersion);
   }
 
   @Test
@@ -202,41 +209,41 @@ public class StorageSchemaCompatibilityTest {
 
   @Test
   public void allCompatibilitiesShouldConsiderDifferentSchemaNamesAsChanged() {
-    assertChanged(none, SCHEMA_A, SCHEMA_A_RENAMED);
-    assertChanged(backward, SCHEMA_A, SCHEMA_A_RENAMED);
-    assertChanged(forward, SCHEMA_A, SCHEMA_A_RENAMED);
-    assertChanged(full, SCHEMA_A, SCHEMA_A_RENAMED);
+    assertChanged(none, SCHEMA_A, SCHEMA_A_RENAMED, diffSchema);
+    assertChanged(backward, SCHEMA_A, SCHEMA_A_RENAMED, diffName);
+    assertChanged(forward, SCHEMA_A, SCHEMA_A_RENAMED, diffName);
+    assertChanged(full, SCHEMA_A, SCHEMA_A_RENAMED, diffName);
 
-    assertChanged(none, SCHEMA_B, SCHEMA_B_RENAMED);
-    assertChanged(backward, SCHEMA_B, SCHEMA_B_RENAMED);
-    assertChanged(forward, SCHEMA_B, SCHEMA_B_RENAMED);
-    assertChanged(full, SCHEMA_B, SCHEMA_B_RENAMED);
+    assertChanged(none, SCHEMA_B, SCHEMA_B_RENAMED, diffSchema);
+    assertChanged(backward, SCHEMA_B, SCHEMA_B_RENAMED, diffName);
+    assertChanged(forward, SCHEMA_B, SCHEMA_B_RENAMED, diffName);
+    assertChanged(full, SCHEMA_B, SCHEMA_B_RENAMED, diffName);
   }
 
   @Test
   public void allCompatibilitiesShouldConsiderDifferentSchemaTypesAsChanged() {
-    assertChanged(none, SCHEMA_A, SCHEMA_A_RETYPED);
-    assertChanged(backward, SCHEMA_A, SCHEMA_A_RETYPED);
-    assertChanged(forward, SCHEMA_A, SCHEMA_A_RETYPED);
-    assertChanged(full, SCHEMA_A, SCHEMA_A_RETYPED);
+    assertChanged(none, SCHEMA_A, SCHEMA_A_RETYPED, diffSchema);
+    assertChanged(backward, SCHEMA_A, SCHEMA_A_RETYPED, diffType);
+    assertChanged(forward, SCHEMA_A, SCHEMA_A_RETYPED, diffType);
+    assertChanged(full, SCHEMA_A, SCHEMA_A_RETYPED, diffType);
 
-    assertChanged(none, SCHEMA_B, SCHEMA_B_RETYPED);
-    assertChanged(backward, SCHEMA_B, SCHEMA_B_RETYPED);
-    assertChanged(forward, SCHEMA_B, SCHEMA_B_RETYPED);
-    assertChanged(full, SCHEMA_B, SCHEMA_B_RETYPED);
+    assertChanged(none, SCHEMA_B, SCHEMA_B_RETYPED, diffSchema);
+    assertChanged(backward, SCHEMA_B, SCHEMA_B_RETYPED, diffType);
+    assertChanged(forward, SCHEMA_B, SCHEMA_B_RETYPED, diffType);
+    assertChanged(full, SCHEMA_B, SCHEMA_B_RETYPED, diffType);
   }
 
   @Test
   public void allCompatibilitiesShouldConsiderDifferentSchemaParametersAsChanged() {
-    assertChanged(none, SCHEMA_A, SCHEMA_A_PARAMETERED);
-    assertChanged(backward, SCHEMA_A, SCHEMA_A_PARAMETERED);
-    assertChanged(forward, SCHEMA_A, SCHEMA_A_PARAMETERED);
-    assertChanged(full, SCHEMA_A, SCHEMA_A_PARAMETERED);
+    assertChanged(none, SCHEMA_A, SCHEMA_A_PARAMETERED, diffSchema);
+    assertChanged(backward, SCHEMA_A, SCHEMA_A_PARAMETERED, diffParams);
+    assertChanged(forward, SCHEMA_A, SCHEMA_A_PARAMETERED, diffParams);
+    assertChanged(full, SCHEMA_A, SCHEMA_A_PARAMETERED, diffParams);
 
-    assertChanged(none, SCHEMA_B, SCHEMA_B_PARAMETERED);
-    assertChanged(backward, SCHEMA_B, SCHEMA_B_PARAMETERED);
-    assertChanged(forward, SCHEMA_B, SCHEMA_B_PARAMETERED);
-    assertChanged(full, SCHEMA_B, SCHEMA_B_PARAMETERED);
+    assertChanged(none, SCHEMA_B, SCHEMA_B_PARAMETERED, diffSchema);
+    assertChanged(backward, SCHEMA_B, SCHEMA_B_PARAMETERED, diffParams);
+    assertChanged(forward, SCHEMA_B, SCHEMA_B_PARAMETERED, diffParams);
+    assertChanged(full, SCHEMA_B, SCHEMA_B_PARAMETERED, diffParams);
   }
 
   @Test
@@ -321,21 +328,31 @@ public class StorageSchemaCompatibilityTest {
       Schema currentSchema,
       boolean isProjectable
   ) {
+    final SchemaCompatibilityResult schemaCompatibilityResult =
+        compatibility.validateAndCheck(recordSchema, currentSchema);
     assertFalse(
         "Expected " + currentSchema + " to not be change in order to project " + recordSchema,
-        compatibility.validateAndCheck(recordSchema, currentSchema).isInCompatible()
+        schemaCompatibilityResult.isInCompatible()
     );
+    assertEquals(na, schemaCompatibilityResult.getSchemaIncompatibilityType());
     assertProjectable(compatibility, recordSchema, currentSchema, isProjectable);
   }
 
   protected void assertChanged(
       StorageSchemaCompatibility compatibility,
       Schema recordSchema,
-      Schema currentSchema
+      Schema currentSchema,
+      SchemaIncompatibilityType schemaIncompatibilityType
   ) {
+    final SchemaCompatibilityResult schemaCompatibilityResult =
+        compatibility.validateAndCheck(recordSchema, currentSchema);
     assertTrue(
         "Expected " + currentSchema + " to change in order to project " + recordSchema,
-        compatibility.validateAndCheck(recordSchema, currentSchema).isInCompatible()
+        schemaCompatibilityResult.isInCompatible()
+    );
+    assertEquals(
+        schemaIncompatibilityType,
+        schemaCompatibilityResult.getSchemaIncompatibilityType()
     );
     // we don't care whether the schema are able to be projected
   }

--- a/core/src/test/java/io/confluent/connect/storage/schema/StorageSchemaCompatibilityTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/schema/StorageSchemaCompatibilityTest.java
@@ -323,7 +323,7 @@ public class StorageSchemaCompatibilityTest {
   ) {
     assertFalse(
         "Expected " + currentSchema + " to not be change in order to project " + recordSchema,
-        compatibility.validateAndCheck(recordSchema, currentSchema)
+        compatibility.validateAndCheck(recordSchema, currentSchema).isInCompatible()
     );
     assertProjectable(compatibility, recordSchema, currentSchema, isProjectable);
   }
@@ -335,7 +335,7 @@ public class StorageSchemaCompatibilityTest {
   ) {
     assertTrue(
         "Expected " + currentSchema + " to change in order to project " + recordSchema,
-        compatibility.validateAndCheck(recordSchema, currentSchema)
+        compatibility.validateAndCheck(recordSchema, currentSchema).isInCompatible()
     );
     // we don't care whether the schema are able to be projected
   }


### PR DESCRIPTION
## Problem
Return the schema incompatibility reason so that it can be logged in downstream connectors to enhance logging.

## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
