### PR TITLE
Update parquet version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <kafka.connect.storage.common.version>11.3.0-SNAPSHOT</kafka.connect.storage.common.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
         <netty.version>4.1.86.Final</netty.version>
-        <parquet.version>1.11.2</parquet.version>
+        <parquet.version>1.13.0</parquet.version>
         <json.smart.version>2.4.7</json.smart.version>
         <thrift.version>0.13.0</thrift.version>
         <tomcat.version>8.5.65</tomcat.version>


### PR DESCRIPTION
To add zstd-jni and support zstd-jni compression easily in connectors. cf: https://github.com/apache/parquet-mr/pull/793

## Problem

Currently, to access the zstd compression. We need to add the Hadoop native library, cf: https://github.com/confluentinc/kafka-connect-storage-cloud/issues/570#issuecomment-1384326683

We could add the `zstd-jni` package by updating parquet version to ease the use of zstd codec.

## Solution

Update parquet version

## Tests

No tests have been made.
How could I test it? I have seen that in implementations such as `Kafka-connect-storage-cloud`, this lib is "provided" and all its transitive dependencies. How can I use this PR to build a new Docker image that could be used for local tests?

Is there a way to add unit tests?

I would be happy to help, but kinda lost on this repo
