### PR TITLE
Add hadoop shaded guava

### DIFF
--- a/hadoop-shaded-guava/README.md
+++ b/hadoop-shaded-guava/README.md
@@ -1,0 +1,6 @@
+# Purpose of this module
+
+This module serves to replace the Vulnerable Guava 30.1.1-jre contained within the package hadoop-shaded-guava which is included by the package hadoop-common until such time that the repo upgrades their guava version (at which time this package should be removable).
+
+You can check the current state of the protobuf package in question in its repo:
+* https://github.com/apache/hadoop-thirdparty

--- a/hadoop-shaded-guava/pom.xml
+++ b/hadoop-shaded-guava/pom.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Copyright [2019 - 2019] Confluent Inc.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.confluent</groupId>
+        <artifactId>kafka-connect-storage-common-parent</artifactId>
+        <version>10.0.23-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>kafka-connect-storage-common-hadoop-shaded-guava</artifactId>
+    <name>Kafka Connect Storage Common Source's version of Apache Hadoop's third-party shaded Guava</name>
+    <packaging>jar</packaging>
+
+    <properties>
+        <shaded.prefix>org.apache.hadoop.thirdparty</shaded.prefix>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>${project.basedir}/..</directory>
+                <targetPath>META-INF</targetPath>
+                <includes>
+                    <include>licenses-binary/*</include>
+                    <include>NOTICE.txt</include>
+                    <include>NOTICE-binary</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>${project.basedir}/src/main/resources</directory>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <configuration>
+                    <createDependencyReducedPom>true</createDependencyReducedPom>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>shade-guava</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>com.google.code.findbugs:jsr305</exclude>
+                                </excludes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>org.checkerframework:checker-qual</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/LICENSE.txt</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com/google/</pattern>
+                                    <shadedPattern>${shaded.prefix}/com/google/</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org/checkerframework/</pattern>
+                                    <shadedPattern>${shaded.prefix}/org/checkerframework/</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
+                                    <resources>
+                                        <resource>NOTICE</resource>
+                                        <resource>LICENSE</resource>
+                                    </resources>
+                                </transformer>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                                    <resource>META-INF/LICENSE.txt</resource>
+                                    <file>${basedir}/../LICENSE-binary</file>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
         <module>hive</module>
         <module>htrace-core4-shaded</module>
         <module>avatica-shaded</module>
+        <module>hadoop-shaded-guava</module>
         <module>hadoop-shaded-protobuf</module>
         <module>package-kafka-connect-storage-common</module>
     </modules>


### PR DESCRIPTION
## Problem
Hadoop Common 3.2.4 has a vulnerability
Hadoop Common 3.3.6 uses hadoop shaded guava in 3.3.6 version in sftp connector use case. 
Hadoop guava also has a vulnerability and can't be used
Without hadoop guava it fails with error:
```
[ERROR] testPoll(io.confluent.connect.sftp.sink.ParquetWriterTest)  Time elapsed: 0.319 s  <<< ERROR!
01:51:59  java.lang.NoClassDefFoundError: org/apache/hadoop/thirdparty/com/google/common/collect/Interners
01:51:59  	at io.confluent.connect.sftp.sink.ParquetWriterTest.testPoll(ParquetWriterTest.java:61)
01:51:59  Caused by: java.lang.ClassNotFoundException: org.apache.hadoop.thirdparty.com.google.common.collect.Interners
01:51:59  	at io.confluent.connect.sftp.sink.ParquetWriterTest.testPoll(ParquetWriterTest.java:61)
```

## Solution
Added Hadoop-shaded guava with the latest guava version as per the common pom.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
