### PR TITLE
Migration: Jenkins -> Semaphore

### DIFF
--- a/.semaphore/project.yml
+++ b/.semaphore/project.yml
@@ -1,0 +1,43 @@
+# This file is managed by ServiceBot plugin - Semaphore. The content in this file is created using a common
+# template and configurations in service.yml.
+# Modifications in this file will be overwritten by generated content in the nightly run.
+# For more information, please refer to the page:
+# https://confluentinc.atlassian.net/wiki/spaces/Foundations/pages/2871296194/Add+SemaphoreCI
+apiVersion: v1alpha
+kind: Project
+metadata:
+  name: kafka-connect-storage-common
+  description: ""
+spec:
+  visibility: private
+  repository:
+    url: git@github.com:confluentinc/kafka-connect-storage-common.git
+    run_on:
+    - branches
+    - pull_requests
+    pipeline_file: .semaphore/semaphore.yml
+    integration_type: github_app
+    status:
+      pipeline_files:
+      - path: .semaphore/semaphore.yml
+        level: pipeline
+    whitelist:
+      branches:
+      - master
+      - main
+      - /^\d+\.\d+\.x$/
+      - /^gh-readonly-queue.*/
+  custom_permissions: true
+  debug_permissions:
+  - empty
+  - default_branch
+  - non_default_branch
+  - pull_request
+  - forked_pull_request
+  - tag
+  attach_permissions:
+  - default_branch
+  - non_default_branch
+  - pull_request
+  - forked_pull_request
+  - tag

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -59,7 +59,6 @@ blocks:
             - mvn -Dcloud -Pjenkins -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode -DaltDeploymentRepository=confluent-codeartifact-internal::default::https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/maven/maven-snapshots/
               -DrepositoryId=confluent-codeartifact-internal deploy -DskipTests
 
-
 after_pipeline:
   task:
     agent:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,79 @@
+# This file is managed by ServiceBot plugin - Semaphore. The content in this file is created using a common
+# template and configurations in service.yml.
+# Any modifications made to ths file will be overwritten by the generated content in nightly runs.
+# For more information, please refer to the page:
+# https://confluentinc.atlassian.net/wiki/spaces/Foundations/pages/2871296194/Add+SemaphoreCI
+version: v1.0
+name: build-test-release
+agent:
+  machine:
+    type: s1-prod-ubuntu20-04-amd64-1
+
+fail_fast:
+  cancel:
+    when: "true"
+
+execution_time_limit:
+  hours: 1
+
+queue:
+  - when: "branch != 'master' and branch !~ '[0-9]+\\.[0-9]+\\.x'"
+    processing: parallel
+
+global_job_config:
+  prologue:
+    commands:
+      - checkout
+      - sem-version java 8
+      - . cache-maven restore
+
+blocks:
+  - name: Test
+    dependencies: []
+    run:
+      # don't run the tests on non-functional changes...
+      when: "change_in('/', {exclude: ['/.deployed-versions/', '.github/']})"
+    task:
+      jobs:
+        - name: Test
+          commands:
+            - pip install confluent-release-tools -q
+            - . sem-pint
+            - mvn -Dcloud -Pjenkins -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress clean verify install dependency:analyze validate
+            - . cve-scan
+            - . cache-maven store
+      epilogue:
+        always:
+          commands:
+            - . publish-test-results
+            - artifact push workflow target/test-results
+
+  - name: Release
+    dependencies: ["Test"]
+    run:
+      when: "branch = 'master' or branch =~ '[0-9]+\\.[0-9]+\\.x'"
+    task:
+      jobs:
+        - name: Release
+          commands:
+            - mvn -Dcloud -Pjenkins -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode -DaltDeploymentRepository=confluent-codeartifact-internal::default::https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/maven/maven-snapshots/
+              -DrepositoryId=confluent-codeartifact-internal deploy -DskipTests
+
+
+after_pipeline:
+  task:
+    agent:
+      machine:
+        type: s1-prod-ubuntu20-04-arm64-0
+    jobs:
+      - name: Metrics
+        commands:
+          - emit-ci-metrics -p -a test-results
+      - name: Publish Test Results
+        commands:
+          - test-results gen-pipeline-report
+      - name: SonarQube
+        commands:
+          - checkout
+          - sem-version java 11
+          - emit-sonarqube-data -a test-results

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,5 +5,4 @@ common {
   upstreamProjects = ['confluentinc/common','confluentinc/schema-registry']
   pintMerge = true
   downStreamValidate = false
-  mvnSkipDeploy = true
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,4 +5,5 @@ common {
   upstreamProjects = ['confluentinc/common','confluentinc/schema-registry']
   pintMerge = true
   downStreamValidate = false
+  mvnSkipDeploy = true
 }

--- a/service.yml
+++ b/service.yml
@@ -1,6 +1,6 @@
 name: kafka-connect-storage-common
 lang: java
-lang_version: unknown
+lang_version: 8
 git:
   enable: true
 codeowners:
@@ -9,3 +9,6 @@ semaphore:
   enable: true
   pipeline_type: cp
   cve_scan: true
+  extra_deploy_args: "-Dcloud -Pjenkins"
+  extra_build_args: "-Dcloud -Pjenkins"
+  run_pint_merge: true

--- a/service.yml
+++ b/service.yml
@@ -1,0 +1,11 @@
+name: kafka-connect-storage-common
+lang: java
+lang_version: unknown
+git:
+  enable: true
+codeowners:
+  enable: true
+semaphore:
+  enable: true
+  pipeline_type: cp
+  cve_scan: true

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,8 @@
+### service-bot sonarqube plugin managed file
+sonar.coverage.exclusions=**/test/**/*,**/tests/**/*,**/mock/**/*,**/mocks/**/*,**/*mock*,**/*test*
+sonar.coverage.jacoco.xmlReportPaths=**/jacoco.xml
+sonar.exclusions=**/*.pb.*,**/mk-include/**/*
+sonar.java.binaries=.
+sonar.language=java
+sonar.projectKey=kafka-connect-storage-common
+sonar.sources=.


### PR DESCRIPTION
### Action required after merging
Cherry-pick the changes to the lowest valid .x branch and open a PR.
Then [pint merge](https://jenkins.confluent.io/job/tools-autotasks/job/tools-autotasks/job/apply-pint-merge/build?delay=0sec) the changes from that .x branch.

### Changes
1) Disables the deploy in the Jenkinsfile.
2) Adds the service-bot config (service.yml) and semaphore files generated by service-bot

### Why are we migrating?
[Read the background and motivation](https://confluentinc.atlassian.net/wiki/spaces/TOOLS/pages/3033867557/CI+System+Migration+Jenkins-+Semaphore#Background-and-Motivation)  
Please merge this PR ASAP because we plan on shutting down Jenkins by the end of the year.