### PR TITLE
Use record.newRecord instead of Creating new SinkRecord

### DIFF
--- a/core/src/main/java/io/confluent/connect/storage/schema/StorageSchemaCompatibility.java
+++ b/core/src/main/java/io/confluent/connect/storage/schema/StorageSchemaCompatibility.java
@@ -371,19 +371,18 @@ public enum StorageSchemaCompatibility implements SchemaCompatibility {
     );
 
     // Just reference comparison here.
-    return projected.getKey() == record.key() && projected.getValue() == record.value()
-           ? record
-           : new SinkRecord(
-               record.topic(),
-               record.kafkaPartition(),
-               currentKeySchema,
-               projected.getKey(),
-               currentValueSchema,
-               projected.getValue(),
-               record.kafkaOffset(),
-               record.timestamp(),
-               record.timestampType()
-           );
+    if (projected.getKey() == record.key() && projected.getValue() == record.value()) {
+      return record;
+    }
+
+    return record.newRecord(
+        record.topic(),
+        record.kafkaPartition(),
+        currentKeySchema,
+        projected.getKey(),
+        currentValueSchema,
+        projected.getValue(),
+        record.timestamp());
   }
 
   private static Map.Entry<Object, Object> projectInternal(


### PR DESCRIPTION
## Problem
https://confluent.slack.com/archives/C06HJ2VFQ5T
While projecting we were changing instance of record from InternalSinkRecord to SinkRecord and while reporting we were using modified records which was causing the original schema of messages to be changed while serialising again.


## Solution

Instead of creating a new object, we can use record.newRecord. Functionality wise it will same for connector and while reporting we will be able to report instance of `InternalSinkRecord'

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy
Tested the change with reproduction model https://github.com/confluentinc/kafka-docker-playground-internal/blob/5fbb61804e4a282ccd29cc77719bfc8cc14d19ed/connect-connect-aws-s3-sink/s3-sink-repro-194748-unexpected-register-of-schema.sh

After the fix, no unwanted version of schema register was found. 
<img width="1055" alt="image" src="https://github.com/confluentinc/kafka-connect-storage-common/assets/108754523/71976381-36c9-4cbd-8c0b-1a903528ae10">
<img width="735" alt="image" src="https://github.com/confluentinc/kafka-connect-storage-common/assets/108754523/332d027b-3ccb-4575-a14a-86713e8b150d">



<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
