### PR TITLE
Revert "CC-25176: Bump Hive Version"

### DIFF
--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -136,6 +136,7 @@
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-exec</artifactId>
             <version>${hive.version}</version>
+            <classifier>core</classifier>
             <exclusions>
                 <exclusion>
                     <groupId>commons-collections</groupId>
@@ -148,6 +149,10 @@
                 <exclusion>
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-core</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.apache.hadoop</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <dependency.check.version>6.1.6</dependency.check.version>
         <hadoop.version>2.10.2</hadoop.version>
-        <hive.version>4.0.0</hive.version>
+        <hive.version>2.3.9</hive.version>
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.4</httpcore.version>
         <jackson.version>2.16.1</jackson.version>


### PR DESCRIPTION
Reverts confluentinc/kafka-connect-storage-common#363

## Why
* With hive versions >= 4.0.0, the core jars are no longer built and distributed by the Apache Hive project. They now only supply a fat jar which bundles a number of other dependencies as well. (please see [HIVE-25531](https://issues.apache.org/jira/browse/HIVE-25531) for more details).
* This change has now been reverted in the master branch due to the reasons explained here: [HIVE-26220](https://issues.apache.org/jira/browse/HIVE-26220). (tl;dr, core-jars will be re-introduced in hive-exec versions >= 4.1.0)
* The extra dependencies in the fat jar introduce critical vulnerabilities in the HDFS3 connector builds, hence we will be reverting to the use of core-jars.