### PR TITLE
Bump `netty.version` to `4.1.108.Final`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <joda.version>2.9.6</joda.version>
         <kafka.connect.storage.common.version>11.0.29-SNAPSHOT</kafka.connect.storage.common.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
-        <netty.version>4.1.107.Final</netty.version>
+        <netty.version>4.1.108.Final</netty.version>
         <parquet.version>1.11.2</parquet.version>
         <json.smart.version>2.4.10</json.smart.version>
         <thrift.version>0.13.0</thrift.version>


### PR DESCRIPTION
## Problem
Bump netty-version to fix CVEs in child repositories.

## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
