### PR TITLE
CC-27029 Bump joda-time version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <jackson.mapper.asl.version>1.9.14.jdk17-redhat-00001</jackson.mapper.asl.version>
         <jetty.version>9.4.53.v20231009</jetty.version>
         <jline.version>2.12.1</jline.version>
-        <joda.version>2.9.6</joda.version>
+        <joda.version>2.10.1</joda.version>
         <kafka.connect.storage.common.version>11.2.15-SNAPSHOT</kafka.connect.storage.common.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
         <netty.version>4.1.108.Final</netty.version>


### PR DESCRIPTION
## Problem
joda-time version 2.9.6 does not handle the daylight savings for some timezones and was formatting the time incorrectly. 
Example, for America/Santiago timezone, the timezone was formatted incorrectly when the day light savings ended

RCCA-19503

## Solution
Fix the dependency to v2.10.1 which has the fix for same.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
