### PR TITLE
CC-29502: Bumped apache avro to resolve CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     </modules>
 
     <properties>
-        <avro.version>1.10.2</avro.version>
+        <avro.version>1.11.4</avro.version>
         <commons-io.version>2.17.0</commons-io.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
         <commons.codec.version>1.15</commons.codec.version>


### PR DESCRIPTION
## Problem
CC-29502: Vulnerable dependency "org.apache.avro_avro:1.11.3" for kafka-connect-storage-cloud:master-latest

## Solution
Bump apache avro to 1.11.4

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
