### PR TITLE
CC-27453: [aws-maven plugin] Changes to support IAM Roles instead of …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,13 @@
         </repository>
     </repositories>
 
+    <pluginRepositories>
+        <pluginRepository>
+            <id>confluent</id>
+            <url>https://packages.confluent.io/maven/</url>
+        </pluginRepository>
+    </pluginRepositories>
+
     <dependencyManagement>
         <dependencies>
             <!--children-->
@@ -369,11 +376,12 @@
         </plugins>
         <extensions>
             <extension>
-                <groupId>org.springframework.build</groupId>
+                <groupId>io.confluent</groupId>
                 <artifactId>aws-maven</artifactId>
-                <version>5.0.0.RELEASE</version>
+                <version>1.0.0</version>
             </extension>
         </extensions>
+
     </build>
     <distributionManagement>
         <repository>


### PR DESCRIPTION
## Problem

To comply with DevProd guidelines, we need to replace the aws-maven package across all open-source connect packages/connectors. The aws-maven ([repo](https://github.com/spring-attic/aws-maven)) plugin is deprecated and only supports IAM users, which rely on static credentials and are less secure. This plugin currently requires AWS keys for releasing a connector, which we aim to avoid.

NOTE: Currently, aws-maven is used to upload artifacts on S3 buckets.

## Solution
Replace it with plugin which supports IAM Roles instead of IAM Users.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
