### PR TITLE
CC-31173: Bump netty.version to 4.1.115.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <joda.version>2.10.1</joda.version>
         <kafka.connect.storage.common.version>11.2.21-SNAPSHOT</kafka.connect.storage.common.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
-        <netty.version>4.1.108.Final</netty.version>
+        <netty.version>4.1.115.Final</netty.version>
         <parquet.version>1.11.2</parquet.version>
         <json.smart.version>2.4.10</json.smart.version>
         <thrift.version>0.13.0</thrift.version>


### PR DESCRIPTION
## Problem
Update `netty.version` to 4.1.115.Final to fix CVE

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [X] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [X] Unit tests
- [X] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
