### PR TITLE
CONMON-19884 CC-39482: Pin aircompressor to 2.0.3 to fix CVE-2025-67721

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
         -->
         <groovy.override.version>2.4.21</groovy.override.version>
         <derby.override.version>10.14.2.0</derby.override.version>
+        <aircompressor.version>2.0.3</aircompressor.version>
         <orc-core.override.version>1.4.3</orc-core.override.version>
     </properties>
 
@@ -297,6 +298,13 @@
                 <groupId>org.apache.orc</groupId>
                 <artifactId>orc-core</artifactId>
                 <version>${orc-core.override.version}</version>
+            </dependency>
+            <!-- pin aircompressor to fix CVE-2025-67721 (CONMON-19884)
+                 Transitive via orc-core. Remove once orc-core ships with aircompressor >= 2.0.3 -->
+            <dependency>
+                <groupId>io.airlift</groupId>
+                <artifactId>aircompressor</artifactId>
+                <version>${aircompressor.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Problem

CVE-2025-67721 (High — CVSS 8.2) is an out-of-bounds read vulnerability (CWE-125) in `io.airlift:aircompressor` < 2.0.3. The Snappy and LZ4 decompressor implementations can leak previous buffer contents when processing malformed compressed input, potentially disclosing sensitive data. The vulnerable `aircompressor-2.0.2.jar` is shipped transitively via `orc-core` and `parquet-hadoop` in downstream connectors including the S3 Sink cloud connector in the FedRAMP cc-connect image.

- Jira: [CONMON-19884](https://jira.confluentgov.com/browse/CONMON-19884)
- Advisory: [GHSA-vx9q-rhv9-3jvg](https://github.com/advisories/GHSA-vx9q-rhv9-3jvg)

## Solution

Added a `dependencyManagement` override for `io.airlift:aircompressor:2.0.3` in the parent POM (`kafka-connect-storage-common-parent`).

The vulnerable dependency flows transitively through multiple paths:
- `format` → `parquet-avro` → `parquet-hadoop` → `aircompressor`
- `orc-core-shaded-jackson` → `orc-core` → `aircompressor`
- `hive` → `orc-core` → `aircompressor`

No upstream `orc-core` (latest 2.2.2) or `parquet` release pins `aircompressor >= 2.0.3`, so an explicit override is required. Placing the pin in `kafka-connect-storage-common-parent` ensures all downstream consumers (`kafka-connect-storage-cloud`, `kafka-connect-s3-private`, etc.) inherit the fix without requiring direct pins in each consumer repo.

### Dependency tree (after fix)

```
kafka-connect-storage-format:jar:11.1.20-SNAPSHOT
   \- parquet-avro → parquet-hadoop
      \- io.airlift:aircompressor:jar:2.0.3:compile

kafka-connect-storage-hive:jar:11.1.20-SNAPSHOT
   \- orc-core
      \- io.airlift:aircompressor:jar:2.0.3:compile

kafka-connect-storage-common-package:pom:11.1.20-SNAPSHOT
   \- kafka-connect-storage-format
      \- io.airlift:aircompressor:jar:2.0.3:compile

kafka-connect-storage-common-orc-core-shaded-jackson:jar:11.1.20-SNAPSHOT
   \- orc-core
      \- io.airlift:aircompressor:jar:2.0.3:compile
```

## Does this solution apply anywhere else?

- [ ] yes
- [x] no

The fix is centralized in `kafka-connect-storage-common-parent`. All downstream consumers inherit it via the parent POM. No changes needed in other repos — once this merges and pint-merges to `11.2.x` and `12.0.x`, consumers will pick up `aircompressor:2.0.3` automatically on next parent version bump.

## Test Strategy

**Testing done:**

- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [x] Manual tests

**Details:**
- `mvn clean verify` — all 13 modules pass (JDK 11)
- Dependency tree verified: `mvn dependency:tree -Dincludes=io.airlift:aircompressor` confirms `aircompressor:2.0.3` resolves across all affected modules (`format`, `hive`, `package`, `orc-core-shaded-jackson`)
- S3 Sink connector unit tests (323 tests, 0 failures) pass against `storage-common` with this fix applied
- S3 Sink integration tests — failures are AWS infra-related (bucket timeouts, STS role not configured locally), not code regressions
- KPD (kafka-docker-playground) S3 Sink end-to-end test: connector starts and runs successfully

## Release Plan

1. Merge this PR (pint-merges to `11.2.x` and `12.0.x`)
2. Release new `kafka-connect-storage-common-parent` version
3. Bump parent version in `kafka-connect-storage-cloud`
4. Release updated connector version
5. Build updated FedRAMP cc-connect image
6. Trivy scan to confirm CVE remediation