### PR TITLE
Pin netty-codec-http in dependencyManagement (CC-38262)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,11 @@
                 <version>${netty.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>net.minidev</groupId>
                 <artifactId>json-smart</artifactId>
                 <version>${json.smart.version}</version>


### PR DESCRIPTION
## Summary
Add `io.netty:netty-codec-http` to `dependencyManagement` using `${netty.version}` (4.1.130.Final on 11.1.x) to ensure downstream modules resolve the fixed netty-codec-http version.

**Note:** The primary fix for `kafka-connect-s3-cloud` is in [connect-plugins-common PR #520](https://github.com/confluentinc/connect-plugins-common/pull/520), since `kafka-connect-s3-cloud` inherits from `connect-plugins-parent`, not `kafka-connect-storage-common-parent`. This PR provides the same fix for connectors that inherit from `kafka-connect-storage-common-parent`.

## Changes
- Added `netty-codec-http` to `dependencyManagement` in parent POM using existing `${netty.version}` property

## Verification

### 1. Dependency Tree
Effective POM confirms `netty-codec-http:4.1.130.Final` is managed.

### 2. Unit & Integration Tests
- Build (`mvn install -N -DskipTests`): PASS
- Full build has pre-existing `-Werror` failure from obsolete Java source/target 8 warnings — unrelated to this change.

### 3. KPD S3 Sink End-to-End Test
- Full chain tested via connect-plugins-common fix (see [PR #520](https://github.com/confluentinc/connect-plugins-common/pull/520) for details)
- S3 Sink connector v12.1.1 with netty 4.1.130.Final: RUNNING, messages produced, S3 upload verified, Avro content confirmed

## References
- Jira: CC-38262
- Fix versions: `io.netty:netty-codec-http` >= 4.1.129.Final or >= 4.2.8.Final
- Related PR: [connect-plugins-common #520](https://github.com/confluentinc/connect-plugins-common/pull/520)