### PR TITLE
Upgrade jackson to 2.18.6 to fix CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,8 +79,8 @@
         <hive.version>2.3.10</hive.version>
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.4</httpcore.version>
-        <jackson.version>2.15.2</jackson.version>
-        <jackson.databind.version>2.16.1</jackson.databind.version>
+        <jackson.version>2.18.6</jackson.version>
+        <jackson.databind.version>2.18.6</jackson.databind.version>
         <jackson.mapper.asl.version>1.9.14.jdk17-redhat-00001</jackson.mapper.asl.version>
         <jetty.version>9.4.53.v20231009</jetty.version>
         <jline.version>2.12.1</jline.version>


### PR DESCRIPTION
## Summary
- Upgrade `jackson.version` from `2.15.2` to `2.18.6`
- Upgrade `jackson.databind.version` from `2.16.1` to `2.18.6`
- Fixes CVEs in `com.fasterxml.jackson.core:*` dependencies (jackson-core, jackson-annotations, jackson-databind, jackson-bom) and their shaded variants (avatica-shaded, htrace-core4-shaded)

## Affected connectors
| Connector Repo | storage-common version | Branch |
|---|---|---|
| kafka-connect-gcs | 10.0.24 | 10.0.x |
| kafka-connect-azure-blob-storage | 11.1.15 | 11.1.x |
| kafka-connect-storage-cloud (S3) | 11.2.28 | 11.2.x |

Fix is on `10.0.x` (earliest branch) and should pint merge to `11.1.x`, `11.2.x`, and `master`.

## Test plan
- [x] Built `kafka-connect-storage-common` (`10.0.32-SNAPSHOT`) with `mvn clean install -DskipTests` — all 11 modules succeeded
- [x] Updated `kafka-connect-gcs` to use `10.0.32-SNAPSHOT` and built with `mvn clean install -DskipTests` — build succeeded
- [x] Verified jackson JARs in GCS connector output are all 2.18.6: `jackson-core-2.18.6.jar`, `jackson-databind-2.18.6.jar`, `jackson-annotations-2.18.6.jar`, `jackson-dataformat-cbor-2.18.6.jar`, `jackson-dataformat-yaml-2.18.6.jar`, `jackson-datatype-jsr310-2.18.6.jar`
- [x] Ran Trivy CVE scan (`trivy sbom`) against the GCS connector CycloneDX BOM — **zero jackson CVEs found**
- [x] CI tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)