### PR TITLE
CC-39528: Fix jackson CVEs in orc-core-shaded-jackson and add parquet-shaded-jackson

### DIFF
--- a/orc-core-shaded-jackson/pom.xml
+++ b/orc-core-shaded-jackson/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <orc-core.version>2.2.1</orc-core.version>
-        <jackson.version>2.16.0</jackson.version>
+        <jackson.version>2.18.6</jackson.version>
         <maven-shade-plugin.version>3.5.0</maven-shade-plugin.version>
     </properties>
 

--- a/parquet-shaded-jackson/pom.xml
+++ b/parquet-shaded-jackson/pom.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.confluent</groupId>
+        <artifactId>kafka-connect-storage-common-parent</artifactId>
+        <version>11.0.42-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>kafka-connect-storage-common-parquet-shaded-jackson</artifactId>
+    <packaging>jar</packaging>
+    <name>kafka-connect-storage-common-parquet-shaded-jackson</name>
+
+    <properties>
+        <maven-shade-plugin.version>3.5.0</maven-shade-plugin.version>
+    </properties>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>${project.basedir}/..</directory>
+                <targetPath>META-INF</targetPath>
+                <includes>
+                    <include>licenses-binary/*</include>
+                    <include>NOTICE.txt</include>
+                    <include>NOTICE-binary</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>${project.basedir}/src/main/resources</directory>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>${maven-shade-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.fasterxml.jackson.core:*</include>
+                                </includes>
+                            </artifactSet>
+
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/MANIFEST.MF</exclude>
+                                        <exclude>META-INF/LICENSE</exclude>
+                                        <exclude>META-INF/NOTICE</exclude>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+
+                            <!-- Match parquet's relocation pattern exactly -->
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson</pattern>
+                                    <shadedPattern>shaded.parquet.com.fasterxml.jackson</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
         <module>hadoop-shaded-protobuf</module>
         <module>package-kafka-connect-storage-common</module>
         <module>orc-core-shaded-jackson</module>
+        <module>parquet-shaded-jackson</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
## Summary
- Upgrade hardcoded `jackson.version` in `orc-core-shaded-jackson` from `2.16.0` to `2.18.6` to fix GHSA-72hv-8253-57qq
- Add new `parquet-shaded-jackson` module that bundles jackson 2.18.6 with parquet's relocation pattern (`shaded.parquet.com.fasterxml.jackson`), allowing downstream connectors to exclude the vulnerable `parquet-hadoop-bundle`/`parquet-jackson`

## Test plan
- [x] Both modules build successfully
- [x] `orc-core-shaded-jackson` JAR contains jackson-core 2.18.6
- [x] `parquet-shaded-jackson` JAR contains jackson-core 2.18.6 relocated to `shaded/parquet/com/fasterxml/jackson/`
- [x] Downstream connectors Trivy scan: 0 jackson CVEs when using both modules
- [x] Kafka docker playground run is successful for downstream connector 

🤖 Generated with [Claude Code](https://claude.com/claude-code)