### PR TITLE
CC-39528: Upgrade jackson in orc-core-shaded-jackson to 2.18.6

### DIFF
--- a/orc-core-shaded-jackson/pom.xml
+++ b/orc-core-shaded-jackson/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <orc-core.version>2.2.1</orc-core.version>
-        <jackson.version>2.16.0</jackson.version>
+        <jackson.version>2.18.6</jackson.version>
         <maven-shade-plugin.version>3.5.0</maven-shade-plugin.version>
     </properties>
 


### PR DESCRIPTION
## Summary
- Upgrade hardcoded `jackson.version` in `orc-core-shaded-jackson` from `2.16.0` to `2.18.6`
- The module was shading a vulnerable jackson-core, flagged by Trivy as GHSA-72hv-8253-57qq
- Same fix as PR #472 on `11.0.x`

## Test plan
- [x] Module builds successfully with jackson 2.18.6
- [x] Shaded JAR contains jackson-core 2.18.6 (verified via `pom.properties`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)