### PR TITLE
CC-39528: Fix parquet-shaded-jackson parent version for 11.1.x

### DIFF
--- a/parquet-shaded-jackson/pom.xml
+++ b/parquet-shaded-jackson/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>11.0.42-SNAPSHOT</version>
+        <version>11.1.23-SNAPSHOT</version>
     </parent>
 
     <artifactId>kafka-connect-storage-common-parquet-shaded-jackson</artifactId>


### PR DESCRIPTION
## Summary
- Fix parent version in `parquet-shaded-jackson/pom.xml` from `11.0.42-SNAPSHOT` to `11.1.23-SNAPSHOT`
- The auto-merge from 11.0.x brought the module with the wrong parent version, causing the build to fail

## Test plan
- [x] `parquet-shaded-jackson` builds successfully with correct parent version

🤖 Generated with [Claude Code](https://claude.com/claude-code)