### PR TITLE
chore: remove redundant pip install of confluent-release-tools

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -37,7 +37,6 @@ blocks:
       jobs:
         - name: Test
           commands:
-            - pip install confluent-release-tools -q
             - . sem-pint -c
             - mvn -Dcloud -Pjenkins -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress clean verify install dependency:analyze validate -Ddependency.check.skip=true
             - cve-scan


### PR DESCRIPTION
## Summary
- Remove explicit `pip install confluent-release-tools` from Semaphore CI config
- `confluent-devtools` is already installed on the CI build agent image, which includes `confluent-release-tools`; the explicit install is unnecessary

## Test plan
- [ ] CI pipeline passes without the explicit pip install

🤖 Generated with [Claude Code](https://claude.com/claude-code)