### PR TITLE
chore: remove redundant pip install of confluent-release-tools

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -37,7 +37,6 @@ blocks:
       jobs:
         - name: Test
           commands:
-            - pip install confluent-release-tools -q
             - . sem-pint -c
             - mvn -Dcloud -Pjenkins -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress clean verify install dependency:analyze validate -Ddependency.check.skip=true
             - cve-scan


### PR DESCRIPTION
### Change Description
As part of the [depot migration task](https://confluentinc.atlassian.net/wiki/spaces/TOOLS/pages/4020831896/Depot+-+Python+Walled+Garden+Repository), replace confluent-release-tools with confluent-devtools. confluent-devtools is already installed on the CI build agent image, which includes confluent-release-tools. The explicit pip install is unnecessary.

### Testing
CI pipeline passes without the explicit pip install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)