### PR TITLE
Update the netty-version in kafka-connect-storage-hive

### DIFF
--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -33,7 +33,7 @@
         <xml-apis.version>1.4.01</xml-apis.version>
         <jamon.runtime.version>2.4.1</jamon.runtime.version>
         <jettison.version>1.5.4</jettison.version>
-        <netty.all.version>4.1.109.Final</netty.all.version>
+        <netty.all.version>4.1.132.Final</netty.all.version>
     </properties>
 
     <dependencies>

--- a/parquet-shaded-jackson/pom.xml
+++ b/parquet-shaded-jackson/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>11.2.35-SNAPSHOT</version>
+        <version>12.0.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>kafka-connect-storage-common-parquet-shaded-jackson</artifactId>


### PR DESCRIPTION
## Problem
https://confluentinc.atlassian.net/browse/CC-40258 has CVE in kafka-connect-gcs which pull it from kafka-connect-storage-hive module in this kafka-connect-storage-common.


## Solution
Updating the netty-version in kafka-connect-storage-hive and will be releasing the new version to update in kafka-connect-gcs

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
