### PR TITLE
CC-42340: Upgrade jackson to 2.22.0 to fix parquet-shaded jackson-databind CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,8 +79,9 @@
         <hive.version>2.3.10</hive.version>
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.4</httpcore.version>
-        <jackson.version>2.18.6</jackson.version>
-        <jackson.databind.version>2.18.6</jackson.databind.version>
+        <jackson.version>2.22.0</jackson.version>
+        <jackson.databind.version>2.22.0</jackson.databind.version>
+        <jackson.annotations.version>2.22</jackson.annotations.version>
         <jackson.mapper.asl.version>1.9.14.jdk17-redhat-00001</jackson.mapper.asl.version>
         <jetty.version>9.4.53.v20231009</jetty.version>
         <jline.version>2.12.1</jline.version>
@@ -187,7 +188,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>${jackson.version}</version>
+                <version>${jackson.annotations.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>


### PR DESCRIPTION
## Summary

Bumps the Jackson version used by `kafka-connect-storage-common` from **2.18.6 → 2.22.0** to remediate jackson-databind CVEs in the **parquet-shaded** Jackson that ships inside `kafka-connect-storage-format`.

The `format` module shades `com.fasterxml.jackson.core:*` under `shaded.parquet.*`, so the Jackson version that ends up relocated as `shaded/parquet/com/fasterxml/jackson/databind/...` is controlled by `jackson.version` / `jackson.databind.version` here. Connectors that depend on `kafka-connect-storage-format` (e.g. **kafka-connect-sftp** — CC-42340) inherit this shaded copy and cannot fix it on their side.

### Changes
```
jackson.version            2.18.6 -> 2.22.0
jackson.databind.version   2.18.6 -> 2.22.0
+ jackson.annotations.version = 2.22   (new property)
jackson-annotations dependencyManagement version: ${jackson.version} -> ${jackson.annotations.version}
```

**Why a separate annotations property:** since Jackson 2.20, `jackson-annotations` drops the patch component — `jackson-databind 2.22.0` pairs with `jackson-annotations 2.22` (per `jackson-bom`). It can no longer inherit `${jackson.version}` (there is no `jackson-annotations:2.22.0`), which is why a naive `jackson.version` bump fails to resolve.

## CVEs fixed
- CVE-2026-54512 (HIGH)
- CVE-2026-54513 (HIGH)
- CVE-2026-54514 (MEDIUM)
- CVE-2026-54515 (MEDIUM)

## Verification

### Build — `format` module (+ deps), Java 8
**Command**: `mvn -U clean install -DskipTests -pl format -am`
~~~
[INFO] BUILD SUCCESS
~~~

### Shaded Jackson in the rebuilt `kafka-connect-storage-format` jar
~~~
shaded/parquet/com/fasterxml/jackson/core/...        jackson-core        2.22.0
shaded/parquet/com/fasterxml/jackson/databind/...    jackson-databind    2.22.0
shaded/parquet/com/fasterxml/jackson/annotation/...  jackson-annotations 2.22
~~~

### Trivy CVE scan of the rebuilt format jar
**Command**: `trivy rootfs --scanners vuln kafka-connect-storage-format-10.0.33-SNAPSHOT.jar`
~~~
jackson-databind: 0 vulnerabilities (CLEAN)
~~~
(Before this change the shaded copy was jackson-databind 2.18.6 with the four CVEs above.)

## Downstream
Once a `10.0.x` release carries this, **kafka-connect-sftp** resolves CC-42340 by bumping `kafka.connect.storage.common.version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
