### PR TITLE
Downgrade jackson to LTS 2.21.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,9 +79,9 @@
         <hive.version>2.3.10</hive.version>
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.4</httpcore.version>
-        <jackson.version>2.22.0</jackson.version>
-        <jackson.databind.version>2.22.0</jackson.databind.version>
-        <jackson.annotations.version>2.22</jackson.annotations.version>
+        <jackson.version>2.21.4</jackson.version>
+        <jackson.databind.version>2.21.4</jackson.databind.version>
+        <jackson.annotations.version>2.21</jackson.annotations.version>
         <jackson.mapper.asl.version>1.9.14.jdk17-redhat-00001</jackson.mapper.asl.version>
         <jetty.version>9.4.53.v20231009</jetty.version>
         <jline.version>2.12.1</jline.version>


### PR DESCRIPTION
## Problem

Versions 2.22.x is not yet LTS.

https://github.com/FasterXML/jackson/wiki/Jackson-Releases


## Solution

Downgrade to 2.21.x LTS

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
