### PR TITLE
Fix jackson-annotations version resolution failure in parquet-shaded-jackson

### DIFF
--- a/parquet-shaded-jackson/pom.xml
+++ b/parquet-shaded-jackson/pom.xml
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.annotations.version}</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION

## Problem

jackson-annotations is not published with the same x.y.z scheme as jackson-core/jackson-databind (2.21.0 does not exist upstream, only 2.21 does), so the module failed dependency resolution. Use the existing jackson.annotations.version property instead of jackson.version.

## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
