### PR TITLE
Bump master version to 12.1.0-SNAPSHOT

### DIFF
--- a/avatica-shaded/pom.xml
+++ b/avatica-shaded/pom.xml
@@ -16,7 +16,7 @@ language governing permissions and limitations under the License. -->
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kafka-connect-storage-common-avatica-shaded</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kafka-connect-storage-common</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kafka-connect-storage-core</artifactId>

--- a/format/pom.xml
+++ b/format/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kafka-connect-storage-format</artifactId>

--- a/hadoop-shaded-guava/pom.xml
+++ b/hadoop-shaded-guava/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kafka-connect-storage-common-hadoop-shaded-guava</artifactId>

--- a/hadoop-shaded-protobuf/pom.xml
+++ b/hadoop-shaded-protobuf/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kafka-connect-storage-common-hadoop-shaded-protobuf</artifactId>

--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kafka-connect-storage-hive</artifactId>

--- a/htrace-core4-shaded/pom.xml
+++ b/htrace-core4-shaded/pom.xml
@@ -16,7 +16,7 @@ language governing permissions and limitations under the License. -->
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kafka-connect-storage-common-htrace-core4-shaded</artifactId>

--- a/orc-core-shaded-jackson/pom.xml
+++ b/orc-core-shaded-jackson/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kafka-connect-storage-common-orc-core-shaded-jackson</artifactId>

--- a/package-kafka-connect-storage-common/pom.xml
+++ b/package-kafka-connect-storage-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kafka-connect-storage-common-package</artifactId>

--- a/parquet-shaded-jackson/pom.xml
+++ b/parquet-shaded-jackson/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>12.0.10-SNAPSHOT</version>
+        <version>12.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kafka-connect-storage-common-parquet-shaded-jackson</artifactId>

--- a/partitioner/pom.xml
+++ b/partitioner/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kafka-connect-storage-partitioner</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <artifactId>kafka-connect-storage-common-parent</artifactId>
     <packaging>pom</packaging>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.1.0-SNAPSHOT</version>
     <name>kafka-connect-storage-common-parent</name>
     <organization>
         <name>Confluent, Inc.</name>
@@ -86,7 +86,7 @@
         <jetty.version>9.4.59</jetty.version>
         <jline.version>2.12.1</jline.version>
         <joda.version>2.13.1</joda.version>
-        <kafka.connect.storage.common.version>12.0.0-SNAPSHOT</kafka.connect.storage.common.version>
+        <kafka.connect.storage.common.version>12.1.0-SNAPSHOT</kafka.connect.storage.common.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
         <netty.version>4.1.130.Final</netty.version>
         <parquet.version>1.15.2</parquet.version>

--- a/wal/pom.xml
+++ b/wal/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kafka-connect-storage-wal</artifactId>


### PR DESCRIPTION
 

## Problem

Master's version was frozen at 12.0.0-SNAPSHOT while the 12.0.x maintenance branch progressed through releases up to v12.0.11.

## Solution

Bump master to the next minor, 12.1.0-SNAPSHOT, across the root pom and all modules so it correctly tracks ahead of the last released 12.0.x branch.
This also fixes the currently failing master build.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
