### PR TITLE
Fix orc-core-shaded-jackson to inherit parent jackson.version (2.21.5)

### DIFF
--- a/orc-core-shaded-jackson/pom.xml
+++ b/orc-core-shaded-jackson/pom.xml
@@ -14,7 +14,6 @@
 
     <properties>
         <orc-core.version>2.2.1</orc-core.version>
-        <jackson.version>2.18.6</jackson.version>
         <maven-shade-plugin.version>3.5.0</maven-shade-plugin.version>
     </properties>
 
@@ -105,7 +104,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.annotations.version}</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
## Problem
`orc-core-shaded-jackson` declares its own local `jackson.version=2.18.6` property, which shadows the parent pom's already-corrected value (bumped to 2.21.5 in 1af3dc4, mirroring #483's fix on `10.0.x`). This means the shaded jar still bundles a vulnerable jackson-databind regardless of the parent bump, exposing CVE-2026-54512, CVE-2026-54513, CVE-2026-54514, and CVE-2026-54515 in the relocated `io.confluent.shaded.com.fasterxml.jackson.*` classes.

The other two shaded modules (`parquet-shaded-jackson`, `htrace-core4-shaded`) don't have this local override and already correctly inherit the parent's `2.21.5` — only `orc-core-shaded-jackson` is affected.

Also fixes `jackson-annotations` to use `jackson.annotations.version` instead of `jackson.version` (same class of bug #482 already fixed in `parquet-shaded-jackson`) — `jackson-annotations` isn't published under the same `x.y.z` scheme as `jackson-core`/`jackson-databind`, so pinning it to `jackson.version` (2.21.5) fails dependency resolution entirely (no such artifact exists).

##### Does this solution apply anywhere else?
- [x] yes
##### If yes, where?
On all 11.0.x + branches

## Test Strategy
##### Testing done:
- [x] Manual tests

- `mvn help:evaluate -Dexpression=jackson.version` on this module now correctly resolves to `2.21.5` (inherited from parent).
- `mvn -pl orc-core-shaded-jackson -am clean install` builds successfully.
- `trivy rootfs --scanners vuln` on the built shaded jar: **0 vulnerabilities** (previously flagged CVE-2026-54512/54513/54514/54515).