### PR TITLE
feat(INIT-5113): add backup envelope infrastructure with shared config validation

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -38,6 +38,12 @@
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
+            <artifactId>kafka-connect-schema-backup-api</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-protobuf-converter</artifactId>
         </dependency>
         <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -39,8 +39,6 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-schema-backup-api</artifactId>
-            <version>8.4.0-736</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-schema-backup-api</artifactId>
-            <version>${io.confluent.schema-registry.version}</version>
+            <version>8.4.0-736</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/core/src/main/java/io/confluent/connect/storage/StorageSinkConnectorConfig.java
+++ b/core/src/main/java/io/confluent/connect/storage/StorageSinkConnectorConfig.java
@@ -100,6 +100,14 @@ public class StorageSinkConnectorConfig extends AbstractConfig implements Compos
   public static final int SCHEMA_CACHE_SIZE_DEFAULT = 1000;
   public static final String SCHEMA_CACHE_SIZE_DISPLAY = "Schema Cache Size";
 
+  public static final String FORMAT_JSON_SCHEMA_ENABLE_CONFIG = "format.json.schema.enable";
+  public static final boolean FORMAT_JSON_SCHEMA_ENABLE_DEFAULT = false;
+  private static final String FORMAT_JSON_SCHEMA_ENABLE_DOC =
+      "Whether to embed the Connect schema in JSON output files. When true, each line "
+      + "is written as {\"schema\":...,\"payload\":...}. Required for BACKUP_FULL_RECORD "
+      + "mode with JsonFormat to enable full restore round-trip.";
+  private static final String FORMAT_JSON_SCHEMA_ENABLE_DISPLAY = "Enable Embedded JSON Schema";
+
   public static final String ENHANCED_AVRO_SCHEMA_SUPPORT_CONFIG = "enhanced.avro.schema.support";
   public static final boolean ENHANCED_AVRO_SCHEMA_SUPPORT_DEFAULT = true;
   public static final String ENHANCED_AVRO_SCHEMA_SUPPORT_DOC =
@@ -144,6 +152,35 @@ public class StorageSinkConnectorConfig extends AbstractConfig implements Compos
       + "supported configurations are NONE, BACKWARD, FORWARD and FULL.";
   public static final String SCHEMA_COMPATIBILITY_DEFAULT = "NONE";
   public static final String SCHEMA_COMPATIBILITY_DISPLAY = "Schema Compatibility";
+
+  // Mode group
+  public static final String MODE_CONFIG = "mode";
+  public static final String MODE_DEFAULT = Mode.GENERIC.name();
+  public static final String MODE_DOC =
+      "The connector's operation mode. "
+      + "GENERIC: standard sink behavior. "
+      + "BACKUP_FULL_RECORD: consolidates key, value, headers and metadata "
+      + "into a single envelope record per message with pristine schema preservation.";
+
+  /**
+   * Connector operation mode. Determines whether the sink operates in
+   * standard mode or backup envelope mode.
+   */
+  public enum Mode {
+    GENERIC,
+    BACKUP_FULL_RECORD;
+
+    public static Mode of(String name) {
+      for (Mode m : values()) {
+        if (m.name().equalsIgnoreCase(name)) {
+          return m;
+        }
+      }
+      throw new org.apache.kafka.common.config.ConfigException(
+          MODE_CONFIG, name,
+          "Invalid mode. Valid values: " + java.util.Arrays.toString(values()));
+    }
+  }
 
   // CHECKSTYLE:OFF
   public static final ConfigDef.Recommender schemaCompatibilityRecommender =
@@ -289,40 +326,45 @@ public class StorageSinkConnectorConfig extends AbstractConfig implements Compos
           FILENAME_OFFSET_ZERO_PAD_WIDTH_DISPLAY
       );
 
-      configDef.define(
-          AVRO_CODEC_CONFIG,
-          Type.STRING,
-          AVRO_CODEC_DEFAULT,
-          ConfigDef.ValidString.in(AVRO_SUPPORTED_CODECS),
-          Importance.LOW,
-          AVRO_CODEC_DOC,
-          group,
-          ++orderInGroup,
-          Width.MEDIUM,
-          AVRO_CODEC_DISPLAY,
-          avroRecommender
-      );
-
-      configDef.define(
-          ALLOW_OPTIONAL_MAP_KEYS,
-          Type.BOOLEAN,
-          ALLOW_OPTIONAL_MAP_KEYS_DEFAULT,
-          Importance.LOW,
-          ALLOW_OPTIONAL_MAP_KEYS_DOC,
-          group,
-          ++orderInGroup,
-          Width.SHORT,
-          ALLOW_OPTIONAL_MAP_KEYS_DISPLAY
-      );
-
+      addCodecAndMapConfigs(configDef, avroRecommender, group, orderInGroup);
     }
+    addSchemaAndModeConfigs(configDef);
+    return configDef;
+  }
 
+  private static void addCodecAndMapConfigs(
+      ConfigDef configDef, ConfigDef.Recommender avroRecommender,
+      String group, int orderInGroup) {
+    configDef.define(
+        AVRO_CODEC_CONFIG,
+        Type.STRING,
+        AVRO_CODEC_DEFAULT,
+        ConfigDef.ValidString.in(AVRO_SUPPORTED_CODECS),
+        Importance.LOW,
+        AVRO_CODEC_DOC,
+        group,
+        ++orderInGroup,
+        Width.MEDIUM,
+        AVRO_CODEC_DISPLAY,
+        avroRecommender
+    );
+    configDef.define(
+        ALLOW_OPTIONAL_MAP_KEYS,
+        Type.BOOLEAN,
+        ALLOW_OPTIONAL_MAP_KEYS_DEFAULT,
+        Importance.LOW,
+        ALLOW_OPTIONAL_MAP_KEYS_DOC,
+        group,
+        ++orderInGroup,
+        Width.SHORT,
+        ALLOW_OPTIONAL_MAP_KEYS_DISPLAY
+    );
+  }
+
+  private static void addSchemaAndModeConfigs(ConfigDef configDef) {
     {
-      // Define Schema configuration group
       final String group = "Schema";
       int orderInGroup = 0;
-
-      // Define Schema configuration group
       configDef.define(
           SCHEMA_COMPATIBILITY_CONFIG,
           Type.STRING,
@@ -336,7 +378,22 @@ public class StorageSinkConnectorConfig extends AbstractConfig implements Compos
           schemaCompatibilityRecommender
       );
     }
-    return configDef;
+    {
+      final String group = "Mode";
+      int orderInGroup = 0;
+      configDef.define(
+          MODE_CONFIG,
+          Type.STRING,
+          MODE_DEFAULT,
+          ConfigDef.ValidString.in(Mode.GENERIC.name(), Mode.BACKUP_FULL_RECORD.name()),
+          Importance.MEDIUM,
+          MODE_DOC,
+          group,
+          ++orderInGroup,
+          Width.SHORT,
+          "Mode"
+      );
+    }
   }
 
   /**
@@ -368,6 +425,17 @@ public class StorageSinkConnectorConfig extends AbstractConfig implements Compos
         Width.MEDIUM,
         PARQUET_CODEC_DISPLAY,
         parquetRecommender
+    );
+    configDef.define(
+        FORMAT_JSON_SCHEMA_ENABLE_CONFIG,
+        Type.BOOLEAN,
+        FORMAT_JSON_SCHEMA_ENABLE_DEFAULT,
+        Importance.LOW,
+        FORMAT_JSON_SCHEMA_ENABLE_DOC,
+        group,
+        ++orderInGroup,
+        Width.SHORT,
+        FORMAT_JSON_SCHEMA_ENABLE_DISPLAY
     );
   }
 
@@ -432,5 +500,24 @@ public class StorageSinkConnectorConfig extends AbstractConfig implements Compos
     props.put(CONNECT_META_DATA_CONFIG, get(CONNECT_META_DATA_CONFIG));
     props.put(ALLOW_OPTIONAL_MAP_KEYS, get(ALLOW_OPTIONAL_MAP_KEYS));
     return new AvroDataConfig(props);
+  }
+
+  public Mode mode() {
+    return Mode.of(getString(MODE_CONFIG));
+  }
+
+  public boolean isBackupMode() {
+    return mode() == Mode.BACKUP_FULL_RECORD;
+  }
+
+  public boolean isJsonSchemaEmbedded() {
+    return getBoolean(FORMAT_JSON_SCHEMA_ENABLE_CONFIG);
+  }
+
+  public String getEffectiveSchemaCompatibility() {
+    if (isBackupMode()) {
+      return "NONE";
+    }
+    return getString(SCHEMA_COMPATIBILITY_CONFIG);
   }
 }

--- a/core/src/main/java/io/confluent/connect/storage/StorageSinkConnectorConfig.java
+++ b/core/src/main/java/io/confluent/connect/storage/StorageSinkConnectorConfig.java
@@ -378,23 +378,25 @@ public class StorageSinkConnectorConfig extends AbstractConfig implements Compos
           schemaCompatibilityRecommender
       );
     }
-    {
-      final String group = "Mode";
-      int orderInGroup = 0;
-      configDef.define(
-          MODE_CONFIG,
-          Type.STRING,
-          MODE_DEFAULT,
-          ConfigDef.ValidString.in(Mode.GENERIC.name(), Mode.BACKUP_FULL_RECORD.name()),
-          Importance.MEDIUM,
-          MODE_DOC,
-          group,
-          ++orderInGroup,
-          Width.SHORT,
-          "Mode"
-      );
-    }
+    addModeGroup(configDef);
     return configDef;
+  }
+
+  private static void addModeGroup(ConfigDef configDef) {
+    final String group = "Mode";
+    int orderInGroup = 0;
+    configDef.define(
+        MODE_CONFIG,
+        Type.STRING,
+        MODE_DEFAULT,
+        ConfigDef.ValidString.in(Mode.GENERIC.name(), Mode.BACKUP_FULL_RECORD.name()),
+        Importance.MEDIUM,
+        MODE_DOC,
+        group,
+        ++orderInGroup,
+        Width.SHORT,
+        "Mode"
+    );
   }
 
   /**

--- a/core/src/main/java/io/confluent/connect/storage/StorageSinkConnectorConfig.java
+++ b/core/src/main/java/io/confluent/connect/storage/StorageSinkConnectorConfig.java
@@ -393,6 +393,17 @@ public class StorageSinkConnectorConfig extends AbstractConfig implements Compos
           Width.SHORT,
           "Mode"
       );
+      configDef.define(
+          FORMAT_JSON_SCHEMA_ENABLE_CONFIG,
+          Type.BOOLEAN,
+          FORMAT_JSON_SCHEMA_ENABLE_DEFAULT,
+          Importance.LOW,
+          FORMAT_JSON_SCHEMA_ENABLE_DOC,
+          group,
+          ++orderInGroup,
+          Width.SHORT,
+          FORMAT_JSON_SCHEMA_ENABLE_DISPLAY
+      );
     }
   }
 
@@ -425,17 +436,6 @@ public class StorageSinkConnectorConfig extends AbstractConfig implements Compos
         Width.MEDIUM,
         PARQUET_CODEC_DISPLAY,
         parquetRecommender
-    );
-    configDef.define(
-        FORMAT_JSON_SCHEMA_ENABLE_CONFIG,
-        Type.BOOLEAN,
-        FORMAT_JSON_SCHEMA_ENABLE_DEFAULT,
-        Importance.LOW,
-        FORMAT_JSON_SCHEMA_ENABLE_DOC,
-        group,
-        ++orderInGroup,
-        Width.SHORT,
-        FORMAT_JSON_SCHEMA_ENABLE_DISPLAY
     );
   }
 

--- a/core/src/main/java/io/confluent/connect/storage/StorageSinkConnectorConfig.java
+++ b/core/src/main/java/io/confluent/connect/storage/StorageSinkConnectorConfig.java
@@ -183,6 +183,21 @@ public class StorageSinkConnectorConfig extends AbstractConfig implements Compos
       new SchemaCompatibilityRecommender();
   // CHECKSTYLE:ON
 
+  private static final ConfigDef.Recommender MODE_RECOMMENDER = new ConfigDef.Recommender() {
+    private final List<Object> values =
+        Arrays.asList(Mode.GENERIC.name(), Mode.BACKUP_FULL_RECORD.name());
+
+    @Override
+    public List<Object> validValues(String name, Map<String, Object> parsedConfig) {
+      return values;
+    }
+
+    @Override
+    public boolean visible(String name, Map<String, Object> parsedConfig) {
+      return true;
+    }
+  };
+
   /**
    * Create a new configuration definition.
    *
@@ -352,7 +367,7 @@ public class StorageSinkConnectorConfig extends AbstractConfig implements Compos
           FORMAT_JSON_SCHEMA_ENABLE_CONFIG,
           Type.BOOLEAN,
           FORMAT_JSON_SCHEMA_ENABLE_DEFAULT,
-          Importance.LOW,
+          Importance.MEDIUM,
           FORMAT_JSON_SCHEMA_ENABLE_DOC,
           group,
           ++orderInGroup,
@@ -395,7 +410,8 @@ public class StorageSinkConnectorConfig extends AbstractConfig implements Compos
         group,
         ++orderInGroup,
         Width.SHORT,
-        "Mode"
+        "Mode",
+        MODE_RECOMMENDER
     );
   }
 

--- a/core/src/main/java/io/confluent/connect/storage/StorageSinkConnectorConfig.java
+++ b/core/src/main/java/io/confluent/connect/storage/StorageSinkConnectorConfig.java
@@ -162,10 +162,6 @@ public class StorageSinkConnectorConfig extends AbstractConfig implements Compos
       + "BACKUP_FULL_RECORD: consolidates key, value, headers and metadata "
       + "into a single envelope record per message with pristine schema preservation.";
 
-  /**
-   * Connector operation mode. Determines whether the sink operates in
-   * standard mode or backup envelope mode.
-   */
   public enum Mode {
     GENERIC,
     BACKUP_FULL_RECORD;
@@ -326,45 +322,49 @@ public class StorageSinkConnectorConfig extends AbstractConfig implements Compos
           FILENAME_OFFSET_ZERO_PAD_WIDTH_DISPLAY
       );
 
-      addCodecAndMapConfigs(configDef, avroRecommender, group, orderInGroup);
+      configDef.define(
+          AVRO_CODEC_CONFIG,
+          Type.STRING,
+          AVRO_CODEC_DEFAULT,
+          ConfigDef.ValidString.in(AVRO_SUPPORTED_CODECS),
+          Importance.LOW,
+          AVRO_CODEC_DOC,
+          group,
+          ++orderInGroup,
+          Width.MEDIUM,
+          AVRO_CODEC_DISPLAY,
+          avroRecommender
+      );
+
+      configDef.define(
+          ALLOW_OPTIONAL_MAP_KEYS,
+          Type.BOOLEAN,
+          ALLOW_OPTIONAL_MAP_KEYS_DEFAULT,
+          Importance.LOW,
+          ALLOW_OPTIONAL_MAP_KEYS_DOC,
+          group,
+          ++orderInGroup,
+          Width.SHORT,
+          ALLOW_OPTIONAL_MAP_KEYS_DISPLAY
+      );
+
+      configDef.define(
+          FORMAT_JSON_SCHEMA_ENABLE_CONFIG,
+          Type.BOOLEAN,
+          FORMAT_JSON_SCHEMA_ENABLE_DEFAULT,
+          Importance.LOW,
+          FORMAT_JSON_SCHEMA_ENABLE_DOC,
+          group,
+          ++orderInGroup,
+          Width.SHORT,
+          FORMAT_JSON_SCHEMA_ENABLE_DISPLAY
+      );
     }
-    addSchemaAndModeConfigs(configDef);
-    return configDef;
-  }
-
-  private static void addCodecAndMapConfigs(
-      ConfigDef configDef, ConfigDef.Recommender avroRecommender,
-      String group, int orderInGroup) {
-    configDef.define(
-        AVRO_CODEC_CONFIG,
-        Type.STRING,
-        AVRO_CODEC_DEFAULT,
-        ConfigDef.ValidString.in(AVRO_SUPPORTED_CODECS),
-        Importance.LOW,
-        AVRO_CODEC_DOC,
-        group,
-        ++orderInGroup,
-        Width.MEDIUM,
-        AVRO_CODEC_DISPLAY,
-        avroRecommender
-    );
-    configDef.define(
-        ALLOW_OPTIONAL_MAP_KEYS,
-        Type.BOOLEAN,
-        ALLOW_OPTIONAL_MAP_KEYS_DEFAULT,
-        Importance.LOW,
-        ALLOW_OPTIONAL_MAP_KEYS_DOC,
-        group,
-        ++orderInGroup,
-        Width.SHORT,
-        ALLOW_OPTIONAL_MAP_KEYS_DISPLAY
-    );
-  }
-
-  private static void addSchemaAndModeConfigs(ConfigDef configDef) {
     {
       final String group = "Schema";
       int orderInGroup = 0;
+
+      // Define Schema configuration group
       configDef.define(
           SCHEMA_COMPATIBILITY_CONFIG,
           Type.STRING,
@@ -393,18 +393,8 @@ public class StorageSinkConnectorConfig extends AbstractConfig implements Compos
           Width.SHORT,
           "Mode"
       );
-      configDef.define(
-          FORMAT_JSON_SCHEMA_ENABLE_CONFIG,
-          Type.BOOLEAN,
-          FORMAT_JSON_SCHEMA_ENABLE_DEFAULT,
-          Importance.LOW,
-          FORMAT_JSON_SCHEMA_ENABLE_DOC,
-          group,
-          ++orderInGroup,
-          Width.SHORT,
-          FORMAT_JSON_SCHEMA_ENABLE_DISPLAY
-      );
     }
+    return configDef;
   }
 
   /**

--- a/core/src/main/java/io/confluent/connect/storage/StorageSinkTestBase.java
+++ b/core/src/main/java/io/confluent/connect/storage/StorageSinkTestBase.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.common.metrics.PluginMetrics;
 import org.apache.kafka.connect.sink.ErrantRecordReporter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTaskContext;
@@ -253,6 +254,11 @@ public class StorageSinkTestBase {
     @Override
     public ErrantRecordReporter errantRecordReporter() {
       throw new UnsupportedOperationException("ErrantRecordReporter is undefined for this class");
+    }
+
+    @Override
+    public PluginMetrics pluginMetrics() {
+      return null;
     }
   }
 

--- a/core/src/main/java/io/confluent/connect/storage/StorageSinkTestBase.java
+++ b/core/src/main/java/io/confluent/connect/storage/StorageSinkTestBase.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.common.metrics.PluginMetrics;
 import org.apache.kafka.connect.sink.ErrantRecordReporter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTaskContext;
@@ -254,11 +253,6 @@ public class StorageSinkTestBase {
     @Override
     public ErrantRecordReporter errantRecordReporter() {
       throw new UnsupportedOperationException("ErrantRecordReporter is undefined for this class");
-    }
-
-    @Override
-    public PluginMetrics pluginMetrics() {
-      return null;
     }
   }
 

--- a/core/src/main/java/io/confluent/connect/storage/backup/BackupEnvelope.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/BackupEnvelope.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.storage.backup;
+
+import io.confluent.connect.schema.backup.api.SchemaBackupConfig;
+
+/**
+ * Constants for the KafkaRecordEnvelope struct.
+ *
+ * <p>Envelope-specific field names and storage metadata constants live here.
+ * Schema type tags, reference field names, and backup config keys are
+ * defined in {@link SchemaBackupConfig} (single source of truth) and
+ * re-exported here for convenience.
+ */
+public final class BackupEnvelope {
+
+  // Envelope struct schema name
+  public static final String NAME =
+      "io.confluent.connect.storage.KafkaRecordEnvelope";
+
+  // Envelope field names
+  public static final String FIELD_KEY = "key";
+  public static final String FIELD_VALUE = "value";
+  public static final String FIELD_HEADERS = "headers";
+  public static final String FIELD_TOPIC = "topic";
+  public static final String FIELD_PARTITION = "partition";
+  public static final String FIELD_OFFSET = "offset";
+  public static final String FIELD_TIMESTAMP = "timestamp";
+  public static final String FIELD_TIMESTAMP_TYPE = "timestampType";
+  public static final String FIELD_KEY_SCHEMA_ID = "keySchemaId";
+  public static final String FIELD_VALUE_SCHEMA_ID = "valueSchemaId";
+  public static final String FIELD_KEY_SCHEMA_TYPE = "keySchemaType";
+  public static final String FIELD_VALUE_SCHEMA_TYPE = "valueSchemaType";
+  public static final String FIELD_KEY_SCHEMA_SUBJECT = "keySchemaSubject";
+  public static final String FIELD_VALUE_SCHEMA_SUBJECT = "valueSchemaSubject";
+  public static final String FIELD_KEY_SCHEMA_GUID = "keySchemaGuid";
+  public static final String FIELD_VALUE_SCHEMA_GUID = "valueSchemaGuid";
+  public static final String FIELD_FORMAT_VERSION = "formatVersion";
+
+  public static final int FORMAT_VERSION = 1;
+
+  // Header struct field names
+  public static final String FIELD_HEADER_KEY = "headerKey";
+  public static final String FIELD_HEADER_VALUE = "headerValue";
+  public static final String FIELD_HEADER_SCHEMA_TYPE = "headerSchemaType";
+
+  // Schema metadata directory structure
+  public static final String METADATA_DIR = "_metadata";
+  public static final String SCHEMAS_DIR = "schemas";
+  public static final String ENTRY_FILE_SUFFIX = ".entry.json";
+
+  // Schema file extensions by type
+  public static final String EXT_AVRO = ".avsc";
+  public static final String EXT_PROTOBUF = ".proto";
+  public static final String EXT_JSON = ".json";
+  public static final String EXT_DEFAULT = ".schema";
+
+  // Converter config key constants
+  public static final String KEY_CONVERTER_CONFIG = "key.converter";
+  public static final String VALUE_CONVERTER_CONFIG = "value.converter";
+
+  // Delegated to SchemaBackupConfig (single source of truth) — no duplication
+  public static final String SCHEMA_BACKUP_ENABLED_CONFIG =
+      SchemaBackupConfig.SCHEMA_BACKUP_ENABLED_CONFIG;
+
+  public static final String REF_FIELD_SUBJECT = SchemaBackupConfig.REF_FIELD_SUBJECT;
+  public static final String REF_FIELD_VERSION = SchemaBackupConfig.REF_FIELD_VERSION;
+  public static final String REF_FIELD_GLOBAL_ID = SchemaBackupConfig.REF_FIELD_GLOBAL_ID;
+  public static final String REF_FIELD_SCHEMA_TYPE = SchemaBackupConfig.REF_FIELD_SCHEMA_TYPE;
+  public static final String REF_FIELD_SCHEMA = SchemaBackupConfig.REF_FIELD_SCHEMA;
+  public static final String REF_FIELD_REFERENCES = SchemaBackupConfig.REF_FIELD_REFERENCES;
+  public static final String REF_FIELD_NAME = SchemaBackupConfig.REF_FIELD_NAME;
+
+  public static final String TYPE_AVRO = SchemaBackupConfig.TYPE_AVRO;
+  public static final String TYPE_PROTOBUF = SchemaBackupConfig.TYPE_PROTOBUF;
+  public static final String TYPE_JSON = SchemaBackupConfig.TYPE_JSON;
+  public static final String TYPE_JSON_SCHEMA = SchemaBackupConfig.TYPE_JSON_SCHEMA;
+  public static final String TYPE_JSON_SCHEMALESS = SchemaBackupConfig.TYPE_JSON_SCHEMALESS;
+  public static final String TYPE_JSON_EMBEDDED_SCHEMA =
+      SchemaBackupConfig.TYPE_JSON_EMBEDDED_SCHEMA;
+  public static final String TYPE_STRING = SchemaBackupConfig.TYPE_STRING;
+  public static final String TYPE_INT16 = SchemaBackupConfig.TYPE_INT16;
+  public static final String TYPE_INT32 = SchemaBackupConfig.TYPE_INT32;
+  public static final String TYPE_INT64 = SchemaBackupConfig.TYPE_INT64;
+  public static final String TYPE_FLOAT32 = SchemaBackupConfig.TYPE_FLOAT32;
+  public static final String TYPE_FLOAT64 = SchemaBackupConfig.TYPE_FLOAT64;
+  public static final String TYPE_BYTES = SchemaBackupConfig.TYPE_BYTES;
+  public static final String TYPE_NONE = SchemaBackupConfig.TYPE_NONE;
+  public static final String TYPE_UNKNOWN = SchemaBackupConfig.TYPE_UNKNOWN;
+
+  /**
+   * Returns whether a schema type is Schema Registry-backed.
+   */
+  public static boolean isSrBackedType(String schemaType) {
+    return SchemaBackupConfig.isSrBackedType(schemaType);
+  }
+
+  /**
+   * Returns the file extension for a schema type.
+   */
+  public static String extensionForType(String schemaType) {
+    if (TYPE_AVRO.equals(schemaType)) {
+      return EXT_AVRO;
+    }
+    if (TYPE_PROTOBUF.equals(schemaType)) {
+      return EXT_PROTOBUF;
+    }
+    if (TYPE_JSON_SCHEMA.equals(schemaType) || TYPE_JSON.equals(schemaType)) {
+      return EXT_JSON;
+    }
+    return EXT_DEFAULT;
+  }
+
+  private BackupEnvelope() {
+  }
+}

--- a/core/src/main/java/io/confluent/connect/storage/backup/BackupEnvelope.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/BackupEnvelope.java
@@ -39,6 +39,13 @@ public final class BackupEnvelope {
   public static final String FIELD_PARTITION = "partition";
   public static final String FIELD_OFFSET = "offset";
   public static final String FIELD_TIMESTAMP = "timestamp";
+  /**
+   * Informational only. Stores {@code TimestampType.name()} from the source
+   * record. Known values: {@code NO_TIMESTAMP_TYPE}, {@code CREATE_TIME},
+   * {@code LOG_APPEND_TIME}. Not consumed on restore; the destination
+   * topic's {@code message.timestamp.type} setting determines the effective
+   * type of the re-produced record.
+   */
   public static final String FIELD_TIMESTAMP_TYPE = "timestampType";
   public static final String FIELD_KEY_SCHEMA_ID = "keySchemaId";
   public static final String FIELD_VALUE_SCHEMA_ID = "valueSchemaId";

--- a/core/src/main/java/io/confluent/connect/storage/backup/BackupEnvelope.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/BackupEnvelope.java
@@ -119,13 +119,14 @@ public final class BackupEnvelope {
    * Returns the file extension for a schema type.
    */
   public static String extensionForType(String schemaType) {
-    if (TYPE_AVRO.equals(schemaType)) {
+    if (TYPE_AVRO.equalsIgnoreCase(schemaType)) {
       return EXT_AVRO;
     }
-    if (TYPE_PROTOBUF.equals(schemaType)) {
+    if (TYPE_PROTOBUF.equalsIgnoreCase(schemaType)) {
       return EXT_PROTOBUF;
     }
-    if (TYPE_JSON_SCHEMA.equals(schemaType) || TYPE_JSON.equals(schemaType)) {
+    if (TYPE_JSON_SCHEMA.equalsIgnoreCase(schemaType)
+        || TYPE_JSON.equalsIgnoreCase(schemaType)) {
       return EXT_JSON;
     }
     return EXT_DEFAULT;

--- a/core/src/main/java/io/confluent/connect/storage/backup/BackupEnvelope.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/BackupEnvelope.java
@@ -16,6 +16,7 @@
 package io.confluent.connect.storage.backup;
 
 import io.confluent.connect.schema.backup.api.SchemaBackupConfig;
+import org.apache.kafka.connect.errors.DataException;
 
 /**
  * Constants for the KafkaRecordEnvelope struct.
@@ -73,7 +74,6 @@ public final class BackupEnvelope {
   public static final String EXT_AVRO = ".avsc";
   public static final String EXT_PROTOBUF = ".proto";
   public static final String EXT_JSON = ".json";
-  public static final String EXT_DEFAULT = ".schema";
 
   // Converter config key constants
   public static final String KEY_CONVERTER_CONFIG = "key.converter";
@@ -116,7 +116,12 @@ public final class BackupEnvelope {
   }
 
   /**
-   * Returns the file extension for a schema type.
+   * Returns the schema file extension for the given schema type.
+   *
+   * @param schemaType schema type tag from {@link SchemaBackupConfig}
+   * @return the file extension including the leading dot
+   * @throws DataException if {@code schemaType} is null or not a type
+   *     that backup can serialize to a schema file
    */
   public static String extensionForType(String schemaType) {
     if (TYPE_AVRO.equalsIgnoreCase(schemaType)) {
@@ -129,7 +134,9 @@ public final class BackupEnvelope {
         || TYPE_JSON.equalsIgnoreCase(schemaType)) {
       return EXT_JSON;
     }
-    return EXT_DEFAULT;
+    throw new DataException(
+        "Unsupported schema type for backup: " + schemaType
+            + ". Expected one of AVRO, PROTOBUF, JSON_SCHEMA, JSON.");
   }
 
   private BackupEnvelope() {

--- a/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.storage.backup;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Shared config validation for backup and restore modes across all
+ * object storage connectors (S3, GCS, Azure). CSP-specific validators
+ * delegate to this class for backup/restore-related checks.
+ *
+ * <p>Validations are organized in three tiers:
+ * <ul>
+ *   <li>Tier 1 (FAIL): Returns errors that prevent connector start</li>
+ *   <li>Tier 2 (WARN): Logs warnings for suboptimal configs</li>
+ *   <li>Tier 3 (INFO): Logs startup summary for troubleshooting</li>
+ * </ul>
+ */
+public final class BackupModeValidator {
+
+  private static final Logger log = LoggerFactory.getLogger(BackupModeValidator.class);
+
+  private static final String AVRO_CONVERTER =
+      "io.confluent.connect.avro.AvroConverter";
+  private static final String PROTOBUF_CONVERTER =
+      "io.confluent.connect.protobuf.ProtobufConverter";
+  private static final String JSON_SCHEMA_CONVERTER =
+      "io.confluent.connect.json.JsonSchemaConverter";
+
+  private static final String FORMAT_SIMPLE_NAME_JSON = "JsonFormat";
+  private static final String FORMAT_SIMPLE_NAME_BYTE_ARRAY = "ByteArrayFormat";
+  private static final String FORMAT_SIMPLE_NAME_AVRO = "AvroFormat";
+  private static final String FORMAT_SIMPLE_NAME_PARQUET = "ParquetFormat";
+
+  private BackupModeValidator() {
+  }
+
+  /**
+   * Validates sink (backup) connector configs. Returns a list of error
+   * messages for Tier 1 failures. Logs Tier 2 warnings.
+   *
+   * @param configs the full connector config map
+   * @param formatClassName the resolved format class simple name
+   * @param jsonSchemaEmbedded whether format.json.schema.enable is true
+   * @return list of error messages (empty if all valid)
+   */
+  public static List<String> validateSinkConfigs(
+      Map<String, String> configs,
+      String formatClassName,
+      boolean jsonSchemaEmbedded) {
+    List<String> errors = new ArrayList<>();
+
+    validateByteArrayFormat(formatClassName, errors);
+    validateJsonFormatSchemaEnable(formatClassName, jsonSchemaEmbedded, errors);
+    validateSchemaBackupEnabled(configs, BackupEnvelope.KEY_CONVERTER_CONFIG, errors);
+    validateSchemaBackupEnabled(configs, BackupEnvelope.VALUE_CONVERTER_CONFIG, errors);
+    validateTransformsRejected(configs, errors);
+
+    warnSinkSuboptimalConfigs(configs, formatClassName);
+
+    return errors;
+  }
+
+  /**
+   * Validates source (restore) connector configs. Returns a list of error
+   * messages for Tier 1 failures. Logs Tier 2 warnings.
+   *
+   * @param configs the full connector config map
+   * @param formatClassName the resolved format class simple name
+   * @return list of error messages (empty if all valid)
+   */
+  public static List<String> validateSourceConfigs(
+      Map<String, String> configs,
+      String formatClassName) {
+    List<String> errors = new ArrayList<>();
+
+    validateByteArrayFormat(formatClassName, errors);
+    warnSourceSuboptimalConfigs(configs);
+
+    return errors;
+  }
+
+  /**
+   * Logs a startup summary for backup mode troubleshooting.
+   *
+   * @param configs the full connector config map
+   * @param formatClassName the format class simple name
+   * @param keyType detected key schema type
+   * @param valueType detected value schema type
+   */
+  public static void logSinkStartupSummary(
+      Map<String, String> configs,
+      String formatClassName, String keyType, String valueType) {
+    String valConverter = configs.get(BackupEnvelope.VALUE_CONVERTER_CONFIG);
+    String keyConverter = configs.get(BackupEnvelope.KEY_CONVERTER_CONFIG);
+    String backupEnabled = configs.get(
+        BackupEnvelope.VALUE_CONVERTER_CONFIG + "."
+        + BackupEnvelope.SCHEMA_BACKUP_ENABLED_CONFIG);
+    log.info("Backup mode started: format={}, keyConverter={} (type={}), "
+        + "valueConverter={} (type={}), schema.backup.enabled={}",
+        formatClassName, keyConverter, keyType, valConverter, valueType,
+        backupEnabled);
+  }
+
+  // ── Tier 1: FAIL ──────────────────────────────────────────────
+
+  private static void validateByteArrayFormat(
+      String formatClassName, List<String> errors) {
+    if (FORMAT_SIMPLE_NAME_BYTE_ARRAY.equals(formatClassName)) {
+      errors.add("format.class=ByteArrayFormat cannot be used with "
+          + "BACKUP_FULL_RECORD mode. ByteArrayFormat does not support "
+          + "structured schema metadata required for envelope wrapping. "
+          + "Use AvroFormat, JsonFormat, or ParquetFormat instead.");
+    }
+  }
+
+  private static void validateJsonFormatSchemaEnable(
+      String formatClassName, boolean jsonSchemaEmbedded,
+      List<String> errors) {
+    if (FORMAT_SIMPLE_NAME_JSON.equals(formatClassName) && !jsonSchemaEmbedded) {
+      errors.add("format.json.schema.enable=true is required with "
+          + "JsonFormat in BACKUP_FULL_RECORD mode. Without it, the "
+          + "envelope schema is not embedded and restore cannot parse "
+          + "the records.");
+    }
+  }
+
+  private static void validateSchemaBackupEnabled(
+      Map<String, String> configs, String converterPrefix,
+      List<String> errors) {
+    String converterClass = configs.get(converterPrefix);
+    String schemaType = ConverterTypeDetector.detectSchemaType(
+        converterClass, configs, converterPrefix);
+    if (!BackupEnvelope.isSrBackedType(schemaType)) {
+      return;
+    }
+    String configKey = converterPrefix + "."
+        + BackupEnvelope.SCHEMA_BACKUP_ENABLED_CONFIG;
+    if (!"true".equalsIgnoreCase(configs.get(configKey))) {
+      errors.add(converterPrefix + " uses SR-backed converter ("
+          + converterClass + ") but " + configKey + " is not set to true. "
+          + "Without this config, backup will NOT preserve schema metadata "
+          + "and restore will produce corrupted data. "
+          + "Set " + configKey + "=true.");
+    }
+  }
+
+  private static void validateTransformsRejected(
+      Map<String, String> configs, List<String> errors) {
+    String transforms = configs.get("transforms");
+    if (transforms != null && !transforms.trim().isEmpty()) {
+      errors.add("Single Message Transforms (SMTs) cannot be used with "
+          + "BACKUP_FULL_RECORD mode. SMTs modify data before envelope "
+          + "wrapping, which corrupts backup fidelity. "
+          + "Remove the 'transforms' config to use backup mode.");
+    }
+  }
+
+  // ── Tier 2: WARN (sink) ───────────────────────────────────────
+
+  private static void warnSinkSuboptimalConfigs(
+      Map<String, String> configs, String formatClassName) {
+    String valConverter = configs.get(BackupEnvelope.VALUE_CONVERTER_CONFIG);
+    String keyConverter = configs.get(BackupEnvelope.KEY_CONVERTER_CONFIG);
+
+    warnConverterConfigs(configs, valConverter,
+        BackupEnvelope.VALUE_CONVERTER_CONFIG, formatClassName);
+    warnConverterConfigs(configs, keyConverter,
+        BackupEnvelope.KEY_CONVERTER_CONFIG, formatClassName);
+
+    warnParquetCompression(configs, formatClassName);
+    warnHeaderConverter(configs);
+  }
+
+  private static void warnConverterConfigs(
+      Map<String, String> configs, String converterClass,
+      String prefix, String formatClassName) {
+    if (converterClass == null) {
+      return;
+    }
+    if (AVRO_CONVERTER.equals(converterClass)) {
+      warnIfNotTrue(configs, prefix + ".enhanced.avro.schema.support",
+          prefix + ": enhanced.avro.schema.support=true is recommended "
+          + "for backup mode. Without it, Avro enum types may not be "
+          + "preserved during restore.");
+    }
+
+    if (PROTOBUF_CONVERTER.equals(converterClass)) {
+      warnIfNotTrue(configs, prefix + ".enhanced.protobuf.schema.support",
+          prefix + ": enhanced.protobuf.schema.support=true is recommended "
+          + "for backup mode. Without it, Protobuf schema fidelity may "
+          + "be reduced during restore.");
+
+      String optNullable = configs.get(prefix + ".optional.for.nullables");
+      String wrapNullable = configs.get(prefix + ".wrapper.for.nullables");
+      if (!"true".equalsIgnoreCase(optNullable)
+          && !"true".equalsIgnoreCase(wrapNullable)) {
+        log.warn("{}: neither optional.for.nullables nor "
+            + "wrapper.for.nullables is set. If the Protobuf schema uses "
+            + "nullable fields, they will not be preserved during restore. "
+            + "Set optional.for.nullables=true (recommended) or "
+            + "wrapper.for.nullables=true.", prefix);
+      }
+    }
+
+    if (JSON_SCHEMA_CONVERTER.equals(converterClass)
+        && FORMAT_SIMPLE_NAME_AVRO.equals(formatClassName)) {
+      warnIfNotTrue(configs, prefix + ".generalized.sum.type.support",
+          prefix + ": generalized.sum.type.support=true is recommended "
+          + "when using JsonSchemaConverter with AvroFormat. "
+          + "oneOf fields may fail without it.");
+      warnIfNotTrue(configs, prefix + ".scrub.invalid.names",
+          prefix + ": scrub.invalid.names=true is recommended when using "
+          + "JsonSchemaConverter with AvroFormat.");
+    }
+  }
+
+  private static void warnParquetCompression(
+      Map<String, String> configs, String formatClassName) {
+    if (!FORMAT_SIMPLE_NAME_PARQUET.equals(formatClassName)) {
+      return;
+    }
+    String codec = configs.get("parquet.codec");
+    if (codec != null && !"none".equalsIgnoreCase(codec)) {
+      log.warn("parquet.codec={} detected with backup mode. "
+          + "parquet.codec=none is recommended for backup mode. "
+          + "Compressed parquet files may cause restore failures.", codec);
+    }
+  }
+
+  private static void warnHeaderConverter(Map<String, String> configs) {
+    String headerConverter = configs.get("header.converter");
+    if (headerConverter == null
+        || !headerConverter.contains("ByteArrayConverter")) {
+      log.info("header.converter={} — for pristine byte-level header "
+          + "preservation, consider using "
+          + "org.apache.kafka.connect.converters.ByteArrayConverter.",
+          headerConverter != null ? headerConverter : "(default)");
+    }
+  }
+
+  // ── Tier 2: WARN (source) ─────────────────────────────────────
+
+  private static void warnSourceSuboptimalConfigs(
+      Map<String, String> configs) {
+    String valConverter = configs.get(BackupEnvelope.VALUE_CONVERTER_CONFIG);
+
+    if (AVRO_CONVERTER.equals(valConverter)) {
+      warnIfNotTrue(configs,
+          BackupEnvelope.VALUE_CONVERTER_CONFIG
+              + ".enhanced.avro.schema.support",
+          "value.converter: enhanced.avro.schema.support=true is "
+          + "recommended for restore mode to match backup fidelity.");
+    }
+
+    if (PROTOBUF_CONVERTER.equals(valConverter)) {
+      warnIfNotTrue(configs,
+          BackupEnvelope.VALUE_CONVERTER_CONFIG
+              + ".enhanced.protobuf.schema.support",
+          "value.converter: enhanced.protobuf.schema.support=true is "
+          + "recommended for restore mode to match backup fidelity.");
+    }
+
+    warnHeaderConverter(configs);
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────
+
+  private static void warnIfNotTrue(
+      Map<String, String> configs, String key, String message) {
+    if (!"true".equalsIgnoreCase(configs.get(key))) {
+      log.warn(message);
+    }
+  }
+}

--- a/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
@@ -377,15 +377,37 @@ public final class BackupModeValidator {
           + "without it.");
     }
 
-    if (JSON_SCHEMA_CONVERTER.equals(converterClass)
-        && FORMAT_SIMPLE_NAME_AVRO.equals(formatClassName)) {
-      warnIfNotTrue(configs, prefix + ".generalized.sum.type.support",
-          prefix + ": generalized.sum.type.support=true is recommended "
-          + "when using JsonSchemaConverter with AvroFormat. "
-          + "oneOf fields may fail without it.");
-      warnIfNotTrue(configs, prefix + ".scrub.invalid.names",
-          prefix + ": scrub.invalid.names=true is recommended when using "
-          + "JsonSchemaConverter with AvroFormat.");
+    if (JSON_SCHEMA_CONVERTER.equals(converterClass)) {
+      warnJsonTypeAllowedPackages(configs, prefix);
+      warnIfNotTrue(configs, prefix + ".preserve.additional.properties",
+          prefix + ": preserve.additional.properties=true is recommended "
+          + "when the JSON schema uses additionalProperties. Default false "
+          + "drops undeclared JSON properties on restore. Must match the "
+          + "source-side setting. Uses reserved field name "
+          + "__connect_additional_properties__; schemas with that literal "
+          + "property name will fail-fast at conversion.");
+      if (FORMAT_SIMPLE_NAME_AVRO.equals(formatClassName)) {
+        warnIfNotTrue(configs, prefix + ".generalized.sum.type.support",
+            prefix + ": generalized.sum.type.support=true is recommended "
+            + "when using JsonSchemaConverter with AvroFormat. "
+            + "oneOf fields may fail without it.");
+        warnIfNotTrue(configs, prefix + ".scrub.invalid.names",
+            prefix + ": scrub.invalid.names=true is recommended when using "
+            + "JsonSchemaConverter with AvroFormat.");
+      }
+    }
+  }
+
+  private static void warnJsonTypeAllowedPackages(
+      Map<String, String> configs, String prefix) {
+    String key = prefix + ".json.type.allowed.packages";
+    String value = configs.get(key);
+    if (value == null || "*".equals(value.trim())) {
+      log.warn("{}: json.type.allowed.packages={} allows any class to be "
+          + "loaded via javaType. Set an explicit whitelist (e.g. "
+          + "\"com.example.models\") or empty string to disallow, and match "
+          + "the setting on the restore side.",
+          prefix, value != null ? value : "* (default)");
     }
   }
 
@@ -423,6 +445,13 @@ public final class BackupModeValidator {
           BackupEnvelope.VALUE_CONVERTER_CONFIG + ".optional.for.nullables",
           "value.converter: optional.for.nullables=true is recommended "
           + "for restore mode and must match the sink-side setting.");
+    }
+    if (JSON_SCHEMA_CONVERTER.equals(valConverter)) {
+      warnJsonTypeAllowedPackages(configs, BackupEnvelope.VALUE_CONVERTER_CONFIG);
+      warnIfNotTrue(configs,
+          BackupEnvelope.VALUE_CONVERTER_CONFIG + ".preserve.additional.properties",
+          "value.converter: preserve.additional.properties=true is "
+          + "recommended for restore mode and must match the sink-side setting.");
     }
 
     warnHeaderConverter(configs);

--- a/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
@@ -64,6 +64,8 @@ public final class BackupModeValidator {
           "RecordField",
           PARTITIONER_PKG + "TimeBasedPartitioner$RecordFieldTimestampExtractor")));
 
+  private static final String TRUE = "true";
+
   private static final String FORMAT_SIMPLE_NAME_JSON = "JsonFormat";
   private static final String FORMAT_SIMPLE_NAME_BYTE_ARRAY = "ByteArrayFormat";
   private static final String FORMAT_SIMPLE_NAME_AVRO = "AvroFormat";
@@ -179,7 +181,7 @@ public final class BackupModeValidator {
   private static void requireTrue(
       Map<String, String> configs, String key, String reason,
       List<String> errors) {
-    if (!"true".equalsIgnoreCase(configs.get(key))) {
+    if (!TRUE.equalsIgnoreCase(configs.get(key))) {
       errors.add(key + " must be set to true. " + reason);
     }
   }
@@ -196,7 +198,7 @@ public final class BackupModeValidator {
   private static void rejectIfTrue(
       Map<String, String> configs, String key, String reason,
       List<String> errors) {
-    if ("true".equalsIgnoreCase(configs.get(key))) {
+    if (TRUE.equalsIgnoreCase(configs.get(key))) {
       errors.add(key + " must not be set to true. " + reason);
     }
   }
@@ -294,7 +296,7 @@ public final class BackupModeValidator {
     }
     String configKey = converterPrefix + "."
         + BackupEnvelope.SCHEMA_BACKUP_ENABLED_CONFIG;
-    if (!"true".equalsIgnoreCase(configs.get(configKey))) {
+    if (!TRUE.equalsIgnoreCase(configs.get(configKey))) {
       errors.add(converterPrefix + " uses SR-backed converter ("
           + converterClass + ") but " + configKey + " is not set to true. "
           + "Without this config, backup will NOT preserve schema metadata "
@@ -334,14 +336,14 @@ public final class BackupModeValidator {
 
   private static void validateStoreKafkaKeysHeadersRejected(
       Map<String, String> configs, List<String> errors) {
-    if ("true".equalsIgnoreCase(configs.get("store.kafka.keys"))) {
+    if (TRUE.equalsIgnoreCase(configs.get("store.kafka.keys"))) {
       errors.add("store.kafka.keys=true cannot be used with "
           + "BACKUP_FULL_RECORD mode. Envelope mode already captures the "
           + "Kafka key inside each backup record. Setting this flag would "
           + "write duplicate key-only files alongside the envelope files. "
           + "Remove store.kafka.keys (or set to false) to use backup mode.");
     }
-    if ("true".equalsIgnoreCase(configs.get("store.kafka.headers"))) {
+    if (TRUE.equalsIgnoreCase(configs.get("store.kafka.headers"))) {
       errors.add("store.kafka.headers=true cannot be used with "
           + "BACKUP_FULL_RECORD mode. Envelope mode already captures the "
           + "Kafka headers inside each backup record. Setting this flag "
@@ -465,7 +467,7 @@ public final class BackupModeValidator {
 
   private static void warnIfNotTrue(
       Map<String, String> configs, String key, String message) {
-    if (!"true".equalsIgnoreCase(configs.get(key))) {
+    if (!TRUE.equalsIgnoreCase(configs.get(key))) {
       log.warn(message);
     }
   }

--- a/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
@@ -81,12 +81,14 @@ public final class BackupModeValidator {
    * @param configs the full connector config map
    * @param formatClassName the resolved format class simple name
    * @param jsonSchemaEmbedded whether format.json.schema.enable is true
+   * @param modeName the resolved sink mode enum name (used in error messages)
    * @return list of error messages (empty if all valid)
    */
   public static List<String> validateSinkConfigs(
       Map<String, String> configs,
       String formatClassName,
-      boolean jsonSchemaEmbedded) {
+      boolean jsonSchemaEmbedded,
+      String modeName) {
     List<String> errors = new ArrayList<>();
 
     validateByteArrayFormat(formatClassName, errors);
@@ -96,7 +98,7 @@ public final class BackupModeValidator {
     validateConverterExplicitlySet(configs, BackupEnvelope.VALUE_CONVERTER_CONFIG, errors);
     validateSinkConverter(configs, BackupEnvelope.KEY_CONVERTER_CONFIG, errors);
     validateSinkConverter(configs, BackupEnvelope.VALUE_CONVERTER_CONFIG, errors);
-    validateTransformsRejected(configs, errors);
+    validateTransformsRejected(configs, errors, modeName);
     validateStoreKafkaKeysHeadersRejected(configs, errors);
     validatePartitionerSupported(configs, errors);
 
@@ -111,11 +113,13 @@ public final class BackupModeValidator {
    *
    * @param configs the full connector config map
    * @param formatClassName the resolved format class simple name
+   * @param modeName the resolved source mode enum name (used in error messages)
    * @return list of error messages (empty if all valid)
    */
   public static List<String> validateSourceConfigs(
       Map<String, String> configs,
-      String formatClassName) {
+      String formatClassName,
+      String modeName) {
     List<String> errors = new ArrayList<>();
 
     validateByteArrayFormat(formatClassName, errors);
@@ -123,6 +127,7 @@ public final class BackupModeValidator {
     validateConverterExplicitlySet(configs, BackupEnvelope.VALUE_CONVERTER_CONFIG, errors);
     validateSourceConverter(configs, BackupEnvelope.KEY_CONVERTER_CONFIG, errors);
     validateSourceConverter(configs, BackupEnvelope.VALUE_CONVERTER_CONFIG, errors);
+    validateTransformsRejected(configs, errors, modeName);
     warnSourceSuboptimalConfigs(configs, formatClassName);
 
     return errors;
@@ -310,13 +315,14 @@ public final class BackupModeValidator {
   }
 
   private static void validateTransformsRejected(
-      Map<String, String> configs, List<String> errors) {
+      Map<String, String> configs, List<String> errors, String modeName) {
     String transforms = configs.get("transforms");
     if (transforms != null && !transforms.trim().isEmpty()) {
       errors.add("Single Message Transforms (SMTs) cannot be used with "
-          + "BACKUP_FULL_RECORD mode. SMTs modify data before envelope "
-          + "wrapping, which corrupts backup fidelity. "
-          + "Remove the 'transforms' config to use backup mode.");
+          + modeName + " mode. SMTs alter records around the envelope "
+          + "wrap/unwrap boundary, which corrupts backup and restore "
+          + "fidelity. Remove the 'transforms' config to use "
+          + modeName + " mode.");
     }
   }
 

--- a/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
@@ -70,6 +70,7 @@ public final class BackupModeValidator {
 
     validateByteArrayFormat(formatClassName, errors);
     validateJsonFormatSchemaEnable(formatClassName, jsonSchemaEmbedded, errors);
+    validateParquetCompression(configs, formatClassName, errors);
     validateSchemaBackupEnabled(configs, BackupEnvelope.KEY_CONVERTER_CONFIG, errors);
     validateSchemaBackupEnabled(configs, BackupEnvelope.VALUE_CONVERTER_CONFIG, errors);
     validateTransformsRejected(configs, errors);
@@ -175,6 +176,24 @@ public final class BackupModeValidator {
     }
   }
 
+  private static void validateParquetCompression(
+      Map<String, String> configs, String formatClassName,
+      List<String> errors) {
+    if (!FORMAT_SIMPLE_NAME_PARQUET.equals(formatClassName)) {
+      return;
+    }
+    String codec = configs.get("parquet.codec");
+    if (codec == null || !"none".equalsIgnoreCase(codec)) {
+      errors.add("parquet.codec=" + (codec != null ? codec : "snappy (default)")
+          + " cannot be used with BACKUP_FULL_RECORD mode. Backup and restore "
+          + "does not support compression end-to-end: the sink writes files "
+          + "with a codec-prefixed extension (e.g. .snappy.parquet) but the "
+          + "restore file matcher only accepts the bare .parquet extension, "
+          + "so compressed files are silently skipped. "
+          + "Set parquet.codec=none to use backup mode.");
+    }
+  }
+
   private static void validateStoreKafkaKeysHeadersRejected(
       Map<String, String> configs, List<String> errors) {
     if ("true".equalsIgnoreCase(configs.get("store.kafka.keys"))) {
@@ -206,7 +225,6 @@ public final class BackupModeValidator {
     warnConverterConfigs(configs, keyConverter,
         BackupEnvelope.KEY_CONVERTER_CONFIG, formatClassName);
 
-    warnParquetCompression(configs, formatClassName);
     warnHeaderConverter(configs);
     warnSchemaCompatibilityOverride(configs);
   }
@@ -251,19 +269,6 @@ public final class BackupModeValidator {
       warnIfNotTrue(configs, prefix + ".scrub.invalid.names",
           prefix + ": scrub.invalid.names=true is recommended when using "
           + "JsonSchemaConverter with AvroFormat.");
-    }
-  }
-
-  private static void warnParquetCompression(
-      Map<String, String> configs, String formatClassName) {
-    if (!FORMAT_SIMPLE_NAME_PARQUET.equals(formatClassName)) {
-      return;
-    }
-    String codec = configs.get("parquet.codec");
-    if (codec != null && !"none".equalsIgnoreCase(codec)) {
-      log.warn("parquet.codec={} detected with backup mode. "
-          + "parquet.codec=none is recommended for backup mode. "
-          + "Compressed parquet files may cause restore failures.", codec);
     }
   }
 

--- a/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
@@ -208,6 +208,7 @@ public final class BackupModeValidator {
 
     warnParquetCompression(configs, formatClassName);
     warnHeaderConverter(configs);
+    warnSchemaCompatibilityOverride(configs);
   }
 
   private static void warnConverterConfigs(
@@ -274,6 +275,18 @@ public final class BackupModeValidator {
           + "preservation, consider using "
           + "org.apache.kafka.connect.converters.ByteArrayConverter.",
           headerConverter != null ? headerConverter : "(default)");
+    }
+  }
+
+  private static void warnSchemaCompatibilityOverride(
+      Map<String, String> configs) {
+    String userValue = configs.get("schema.compatibility");
+    if (userValue != null && !"NONE".equalsIgnoreCase(userValue)) {
+      log.warn("schema.compatibility={} was set but will be overridden to NONE "
+          + "in BACKUP_FULL_RECORD mode. Backup preserves each record's own "
+          + "schema exactly; compatibility rules do not apply. "
+          + "Remove schema.compatibility (or set to NONE) to silence this warning.",
+          userValue);
     }
   }
 

--- a/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
@@ -113,9 +113,28 @@ public final class BackupModeValidator {
     List<String> errors = new ArrayList<>();
 
     validateByteArrayFormat(formatClassName, errors);
+    validateEnhancedAvroSchemaSupport(
+        configs, BackupEnvelope.KEY_CONVERTER_CONFIG, errors);
+    validateEnhancedAvroSchemaSupport(
+        configs, BackupEnvelope.VALUE_CONVERTER_CONFIG, errors);
     warnSourceSuboptimalConfigs(configs);
 
     return errors;
+  }
+
+  private static void validateEnhancedAvroSchemaSupport(
+      Map<String, String> configs, String converterPrefix,
+      List<String> errors) {
+    if (!AVRO_CONVERTER.equals(configs.get(converterPrefix))) {
+      return;
+    }
+    String key = converterPrefix + ".enhanced.avro.schema.support";
+    if (!"true".equalsIgnoreCase(configs.get(key))) {
+      errors.add(converterPrefix + " uses AvroConverter but " + key
+          + " is not set to true. Restore will fail with AvroTypeException on "
+          + "records that contain enum values (e.g. \"value ACTIVE is not a "
+          + "UserStatus\"). Set " + key + "=true.");
+    }
   }
 
   /**
@@ -355,14 +374,6 @@ public final class BackupModeValidator {
   private static void warnSourceSuboptimalConfigs(
       Map<String, String> configs) {
     String valConverter = configs.get(BackupEnvelope.VALUE_CONVERTER_CONFIG);
-
-    if (AVRO_CONVERTER.equals(valConverter)) {
-      warnIfNotTrue(configs,
-          BackupEnvelope.VALUE_CONVERTER_CONFIG
-              + ".enhanced.avro.schema.support",
-          "value.converter: enhanced.avro.schema.support=true is "
-          + "recommended for restore mode to match backup fidelity.");
-    }
 
     if (PROTOBUF_CONVERTER.equals(valConverter)) {
       warnIfNotTrue(configs,

--- a/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
@@ -115,13 +115,18 @@ public final class BackupModeValidator {
       String formatClassName, String keyType, String valueType) {
     String valConverter = configs.get(BackupEnvelope.VALUE_CONVERTER_CONFIG);
     String keyConverter = configs.get(BackupEnvelope.KEY_CONVERTER_CONFIG);
-    String backupEnabled = configs.get(
+    String keyBackupEnabled = configs.get(
+        BackupEnvelope.KEY_CONVERTER_CONFIG + "."
+        + BackupEnvelope.SCHEMA_BACKUP_ENABLED_CONFIG);
+    String valueBackupEnabled = configs.get(
         BackupEnvelope.VALUE_CONVERTER_CONFIG + "."
         + BackupEnvelope.SCHEMA_BACKUP_ENABLED_CONFIG);
-    log.info("Backup mode started: format={}, keyConverter={} (type={}), "
-        + "valueConverter={} (type={}), schema.backup.enabled={}",
-        formatClassName, keyConverter, keyType, valConverter, valueType,
-        backupEnabled);
+    log.info("Backup mode started: format={}, "
+        + "keyConverter={} (type={}, schema.backup.enabled={}), "
+        + "valueConverter={} (type={}, schema.backup.enabled={})",
+        formatClassName,
+        keyConverter, keyType, keyBackupEnabled,
+        valConverter, valueType, valueBackupEnabled);
   }
 
   // ── Tier 1: FAIL ──────────────────────────────────────────────

--- a/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
@@ -71,6 +71,8 @@ public final class BackupModeValidator {
     validateByteArrayFormat(formatClassName, errors);
     validateJsonFormatSchemaEnable(formatClassName, jsonSchemaEmbedded, errors);
     validateParquetCompression(configs, formatClassName, errors);
+    validateConverterExplicitlySet(configs, BackupEnvelope.KEY_CONVERTER_CONFIG, errors);
+    validateConverterExplicitlySet(configs, BackupEnvelope.VALUE_CONVERTER_CONFIG, errors);
     validateSchemaBackupEnabled(configs, BackupEnvelope.KEY_CONVERTER_CONFIG, errors);
     validateSchemaBackupEnabled(configs, BackupEnvelope.VALUE_CONVERTER_CONFIG, errors);
     validateTransformsRejected(configs, errors);
@@ -142,6 +144,18 @@ public final class BackupModeValidator {
           + "JsonFormat in BACKUP_FULL_RECORD mode. Without it, the "
           + "envelope schema is not embedded and restore cannot parse "
           + "the records.");
+    }
+  }
+
+  private static void validateConverterExplicitlySet(
+      Map<String, String> configs, String converterPrefix,
+      List<String> errors) {
+    if (configs.get(converterPrefix) == null) {
+      errors.add(converterPrefix + " must be set explicitly at the connector "
+          + "level in BACKUP_FULL_RECORD mode. Relying on worker.properties "
+          + "defaults hides the converter class from backup validation, so "
+          + "schema type detection falls through to UNKNOWN and schema files "
+          + "are not written. Set " + converterPrefix + " on the connector.");
     }
   }
 

--- a/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
@@ -73,6 +73,7 @@ public final class BackupModeValidator {
     validateSchemaBackupEnabled(configs, BackupEnvelope.KEY_CONVERTER_CONFIG, errors);
     validateSchemaBackupEnabled(configs, BackupEnvelope.VALUE_CONVERTER_CONFIG, errors);
     validateTransformsRejected(configs, errors);
+    validateStoreKafkaKeysHeadersRejected(configs, errors);
 
     warnSinkSuboptimalConfigs(configs, formatClassName);
 
@@ -171,6 +172,25 @@ public final class BackupModeValidator {
           + "BACKUP_FULL_RECORD mode. SMTs modify data before envelope "
           + "wrapping, which corrupts backup fidelity. "
           + "Remove the 'transforms' config to use backup mode.");
+    }
+  }
+
+  private static void validateStoreKafkaKeysHeadersRejected(
+      Map<String, String> configs, List<String> errors) {
+    if ("true".equalsIgnoreCase(configs.get("store.kafka.keys"))) {
+      errors.add("store.kafka.keys=true cannot be used with "
+          + "BACKUP_FULL_RECORD mode. Envelope mode already captures the "
+          + "Kafka key inside each backup record. Setting this flag would "
+          + "write duplicate key-only files alongside the envelope files. "
+          + "Remove store.kafka.keys (or set to false) to use backup mode.");
+    }
+    if ("true".equalsIgnoreCase(configs.get("store.kafka.headers"))) {
+      errors.add("store.kafka.headers=true cannot be used with "
+          + "BACKUP_FULL_RECORD mode. Envelope mode already captures the "
+          + "Kafka headers inside each backup record. Setting this flag "
+          + "would write duplicate header-only files alongside the envelope "
+          + "files. Remove store.kafka.headers (or set to false) to use "
+          + "backup mode.");
     }
   }
 

--- a/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
@@ -123,7 +123,7 @@ public final class BackupModeValidator {
     validateConverterExplicitlySet(configs, BackupEnvelope.VALUE_CONVERTER_CONFIG, errors);
     validateSourceConverter(configs, BackupEnvelope.KEY_CONVERTER_CONFIG, errors);
     validateSourceConverter(configs, BackupEnvelope.VALUE_CONVERTER_CONFIG, errors);
-    warnSourceSuboptimalConfigs(configs);
+    warnSourceSuboptimalConfigs(configs, formatClassName);
 
     return errors;
   }
@@ -382,9 +382,9 @@ public final class BackupModeValidator {
     if (PROTOBUF_CONVERTER.equals(converterClass)) {
       warnIfNotTrue(configs, prefix + ".optional.for.nullables",
           prefix + ": optional.for.nullables=true is recommended for "
-          + "backup mode and must match the source-side setting. Restore "
-          + "may drop proto3 optional scalars holding default values "
-          + "without it.");
+          + "backup and restore modes and must match on both sides. "
+          + "Restore may drop proto3 optional scalars holding default "
+          + "values without it.");
     }
 
     if (JSON_SCHEMA_CONVERTER.equals(converterClass)) {
@@ -392,8 +392,8 @@ public final class BackupModeValidator {
       warnIfNotTrue(configs, prefix + ".preserve.additional.properties",
           prefix + ": preserve.additional.properties=true is recommended "
           + "when the JSON schema uses additionalProperties. Default false "
-          + "drops undeclared JSON properties on restore. Must match the "
-          + "source-side setting. Uses reserved field name "
+          + "drops undeclared JSON properties on restore. Must match on "
+          + "both sides. Uses reserved field name "
           + "__connect_additional_properties__; schemas with that literal "
           + "property name will fail-fast at conversion.");
       if (FORMAT_SIMPLE_NAME_AVRO.equals(formatClassName)) {
@@ -447,22 +447,14 @@ public final class BackupModeValidator {
   // ── Tier 2: WARN (source) ─────────────────────────────────────
 
   private static void warnSourceSuboptimalConfigs(
-      Map<String, String> configs) {
+      Map<String, String> configs, String formatClassName) {
     String valConverter = configs.get(BackupEnvelope.VALUE_CONVERTER_CONFIG);
+    String keyConverter = configs.get(BackupEnvelope.KEY_CONVERTER_CONFIG);
 
-    if (PROTOBUF_CONVERTER.equals(valConverter)) {
-      warnIfNotTrue(configs,
-          BackupEnvelope.VALUE_CONVERTER_CONFIG + ".optional.for.nullables",
-          "value.converter: optional.for.nullables=true is recommended "
-          + "for restore mode and must match the sink-side setting.");
-    }
-    if (JSON_SCHEMA_CONVERTER.equals(valConverter)) {
-      warnJsonTypeAllowedPackages(configs, BackupEnvelope.VALUE_CONVERTER_CONFIG);
-      warnIfNotTrue(configs,
-          BackupEnvelope.VALUE_CONVERTER_CONFIG + ".preserve.additional.properties",
-          "value.converter: preserve.additional.properties=true is "
-          + "recommended for restore mode and must match the sink-side setting.");
-    }
+    warnConverterConfigs(configs, valConverter,
+        BackupEnvelope.VALUE_CONVERTER_CONFIG, formatClassName);
+    warnConverterConfigs(configs, keyConverter,
+        BackupEnvelope.KEY_CONVERTER_CONFIG, formatClassName);
 
     warnHeaderConverter(configs);
   }

--- a/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
@@ -57,8 +57,12 @@ public final class BackupModeValidator {
           PARTITIONER_PKG + "TimeBasedPartitioner",
           PARTITIONER_PKG + "DailyPartitioner",
           PARTITIONER_PKG + "HourlyPartitioner")));
-  private static final String UNSUPPORTED_TIMESTAMP_EXTRACTOR =
-      PARTITIONER_PKG + "TimeBasedPartitioner$RecordFieldTimestampExtractor";
+  // TimeBasedPartitioner.newTimestampExtractor() expands the short name
+  // "RecordField" to the FQCN at runtime, so both must be rejected.
+  private static final Set<String> UNSUPPORTED_TIMESTAMP_EXTRACTORS =
+      Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+          "RecordField",
+          PARTITIONER_PKG + "TimeBasedPartitioner$RecordFieldTimestampExtractor")));
 
   private static final String FORMAT_SIMPLE_NAME_JSON = "JsonFormat";
   private static final String FORMAT_SIMPLE_NAME_BYTE_ARRAY = "ByteArrayFormat";
@@ -259,11 +263,11 @@ public final class BackupModeValidator {
           + "TimeBasedPartitioner, DailyPartitioner, or HourlyPartitioner.");
     }
     String extractor = configs.get("timestamp.extractor");
-    if (extractor != null && extractor.equals(UNSUPPORTED_TIMESTAMP_EXTRACTOR)) {
-      errors.add("timestamp.extractor=RecordFieldTimestampExtractor is not "
-          + "supported in BACKUP_FULL_RECORD mode. It reads a field from the "
-          + "record value, which is now the envelope Struct. "
-          + "Use Wallclock or Record extractor instead.");
+    if (extractor != null && UNSUPPORTED_TIMESTAMP_EXTRACTORS.contains(extractor)) {
+      errors.add("timestamp.extractor=" + extractor + " is not supported in "
+          + "BACKUP_FULL_RECORD mode. It reads a field from the record value, "
+          + "which is now the envelope Struct. Use Wallclock or Record "
+          + "extractor instead.");
     }
   }
 

--- a/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
@@ -92,7 +92,7 @@ public final class BackupModeValidator {
     List<String> errors = new ArrayList<>();
 
     validateByteArrayFormat(formatClassName, errors);
-    validateJsonFormatSchemaEnable(formatClassName, jsonSchemaEmbedded, errors);
+    validateJsonFormatSchemaEnable(formatClassName, jsonSchemaEmbedded, modeName, errors);
     validateParquetCompression(configs, formatClassName, errors);
     validateConverterExplicitlySet(configs, BackupEnvelope.KEY_CONVERTER_CONFIG, errors);
     validateConverterExplicitlySet(configs, BackupEnvelope.VALUE_CONVERTER_CONFIG, errors);
@@ -113,16 +113,19 @@ public final class BackupModeValidator {
    *
    * @param configs the full connector config map
    * @param formatClassName the resolved format class simple name
+   * @param jsonSchemaEmbedded whether format.json.schema.enable is true
    * @param modeName the resolved source mode enum name (used in error messages)
    * @return list of error messages (empty if all valid)
    */
   public static List<String> validateSourceConfigs(
       Map<String, String> configs,
       String formatClassName,
+      boolean jsonSchemaEmbedded,
       String modeName) {
     List<String> errors = new ArrayList<>();
 
     validateByteArrayFormat(formatClassName, errors);
+    validateJsonFormatSchemaEnable(formatClassName, jsonSchemaEmbedded, modeName, errors);
     validateConverterExplicitlySet(configs, BackupEnvelope.KEY_CONVERTER_CONFIG, errors);
     validateConverterExplicitlySet(configs, BackupEnvelope.VALUE_CONVERTER_CONFIG, errors);
     validateSourceConverter(configs, BackupEnvelope.KEY_CONVERTER_CONFIG, errors);
@@ -250,13 +253,12 @@ public final class BackupModeValidator {
   }
 
   private static void validateJsonFormatSchemaEnable(
-      String formatClassName, boolean jsonSchemaEmbedded,
+      String formatClassName, boolean jsonSchemaEmbedded, String modeName,
       List<String> errors) {
     if (FORMAT_SIMPLE_NAME_JSON.equals(formatClassName) && !jsonSchemaEmbedded) {
-      errors.add("format.json.schema.enable=true is required with "
-          + "JsonFormat in BACKUP_FULL_RECORD mode. Without it, the "
-          + "envelope schema is not embedded and restore cannot parse "
-          + "the records.");
+      errors.add("format.json.schema.enable=true is required with JsonFormat in "
+          + modeName + " mode. Without it, the envelope schema is not embedded, "
+          + "so restore cannot parse the backup files.");
     }
   }
 
@@ -456,6 +458,17 @@ public final class BackupModeValidator {
         BackupEnvelope.KEY_CONVERTER_CONFIG, formatClassName);
 
     warnHeaderConverter(configs);
+    warnFileMetadataHeadersEnabled(configs);
+  }
+
+  private static void warnFileMetadataHeadersEnabled(Map<String, String> configs) {
+    if (TRUE.equalsIgnoreCase(configs.get("file.metadata.headers.enable"))) {
+      log.warn("file.metadata.headers.enable=true adds file-metadata headers "
+          + "(file.path, file.name, file.last.modified, file.size, "
+          + "file.creation.time) to every restored record. This is not pristine "
+          + "restore: the original messages did not carry these headers. "
+          + "Set file.metadata.headers.enable=false for pristine restore.");
+    }
   }
 
   // ── Helpers ───────────────────────────────────────────────────

--- a/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
@@ -90,6 +90,10 @@ public final class BackupModeValidator {
     validateConverterExplicitlySet(configs, BackupEnvelope.VALUE_CONVERTER_CONFIG, errors);
     validateSchemaBackupEnabled(configs, BackupEnvelope.KEY_CONVERTER_CONFIG, errors);
     validateSchemaBackupEnabled(configs, BackupEnvelope.VALUE_CONVERTER_CONFIG, errors);
+    validateEnhancedAvroSchemaSupport(
+        configs, BackupEnvelope.KEY_CONVERTER_CONFIG, errors);
+    validateEnhancedAvroSchemaSupport(
+        configs, BackupEnvelope.VALUE_CONVERTER_CONFIG, errors);
     validateTransformsRejected(configs, errors);
     validateStoreKafkaKeysHeadersRejected(configs, errors);
     validatePartitionerSupported(configs, errors);
@@ -309,13 +313,6 @@ public final class BackupModeValidator {
     if (converterClass == null) {
       return;
     }
-    if (AVRO_CONVERTER.equals(converterClass)) {
-      warnIfNotTrue(configs, prefix + ".enhanced.avro.schema.support",
-          prefix + ": enhanced.avro.schema.support=true is recommended "
-          + "for backup mode. Without it, Avro enum types may not be "
-          + "preserved during restore.");
-    }
-
     if (PROTOBUF_CONVERTER.equals(converterClass)) {
       warnIfNotTrue(configs, prefix + ".enhanced.protobuf.schema.support",
           prefix + ": enhanced.protobuf.schema.support=true is recommended "

--- a/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
@@ -88,12 +88,8 @@ public final class BackupModeValidator {
     validateParquetCompression(configs, formatClassName, errors);
     validateConverterExplicitlySet(configs, BackupEnvelope.KEY_CONVERTER_CONFIG, errors);
     validateConverterExplicitlySet(configs, BackupEnvelope.VALUE_CONVERTER_CONFIG, errors);
-    validateSchemaBackupEnabled(configs, BackupEnvelope.KEY_CONVERTER_CONFIG, errors);
-    validateSchemaBackupEnabled(configs, BackupEnvelope.VALUE_CONVERTER_CONFIG, errors);
-    validateEnhancedAvroSchemaSupport(
-        configs, BackupEnvelope.KEY_CONVERTER_CONFIG, errors);
-    validateEnhancedAvroSchemaSupport(
-        configs, BackupEnvelope.VALUE_CONVERTER_CONFIG, errors);
+    validateSinkConverter(configs, BackupEnvelope.KEY_CONVERTER_CONFIG, errors);
+    validateSinkConverter(configs, BackupEnvelope.VALUE_CONVERTER_CONFIG, errors);
     validateTransformsRejected(configs, errors);
     validateStoreKafkaKeysHeadersRejected(configs, errors);
     validatePartitionerSupported(configs, errors);
@@ -117,27 +113,87 @@ public final class BackupModeValidator {
     List<String> errors = new ArrayList<>();
 
     validateByteArrayFormat(formatClassName, errors);
-    validateEnhancedAvroSchemaSupport(
-        configs, BackupEnvelope.KEY_CONVERTER_CONFIG, errors);
-    validateEnhancedAvroSchemaSupport(
-        configs, BackupEnvelope.VALUE_CONVERTER_CONFIG, errors);
+    validateSourceConverter(configs, BackupEnvelope.KEY_CONVERTER_CONFIG, errors);
+    validateSourceConverter(configs, BackupEnvelope.VALUE_CONVERTER_CONFIG, errors);
     warnSourceSuboptimalConfigs(configs);
 
     return errors;
   }
 
-  private static void validateEnhancedAvroSchemaSupport(
-      Map<String, String> configs, String converterPrefix,
-      List<String> errors) {
-    if (!AVRO_CONVERTER.equals(configs.get(converterPrefix))) {
+  private static void validateSinkConverter(
+      Map<String, String> configs, String prefix, List<String> errors) {
+    String converterClass = configs.get(prefix);
+    if (converterClass == null) {
       return;
     }
-    String key = converterPrefix + ".enhanced.avro.schema.support";
+    validateSchemaBackupEnabled(configs, prefix, errors);
+    if (AVRO_CONVERTER.equals(converterClass)) {
+      requireTrue(configs, prefix + ".enhanced.avro.schema.support",
+          "Restore will fail with AvroTypeException on records that contain "
+          + "enum values (e.g. \"value ACTIVE is not a UserStatus\").",
+          errors);
+    } else if (PROTOBUF_CONVERTER.equals(converterClass)) {
+      requireTrue(configs, prefix + ".enhanced.protobuf.schema.support",
+          "Package qualification in Connect Schema is not preserved, which "
+          + "can break restore.",
+          errors);
+      requireFalse(configs, prefix + ".wrapper.for.raw.primitives",
+          "Default is true. With the default, ProtobufData strips wrapper "
+          + "type info from BackupWrapper.data and restore cannot re-create "
+          + "the wrappers from the flattened Struct.",
+          errors);
+      rejectIfTrue(configs, prefix + ".wrapper.for.nullables",
+          "Breaks records that omit proto3 optional scalar fields with "
+          + "DataException 'Invalid value: null used for required field'.",
+          errors);
+    }
+  }
+
+  private static void validateSourceConverter(
+      Map<String, String> configs, String prefix, List<String> errors) {
+    String converterClass = configs.get(prefix);
+    if (converterClass == null) {
+      return;
+    }
+    if (AVRO_CONVERTER.equals(converterClass)) {
+      requireTrue(configs, prefix + ".enhanced.avro.schema.support",
+          "Restore will fail with AvroTypeException on records that contain "
+          + "enum values (e.g. \"value ACTIVE is not a UserStatus\").",
+          errors);
+    } else if (PROTOBUF_CONVERTER.equals(converterClass)) {
+      requireTrue(configs, prefix + ".enhanced.protobuf.schema.support",
+          "Package qualification in Connect Schema is not preserved, which "
+          + "can break restore.",
+          errors);
+      rejectIfTrue(configs, prefix + ".wrapper.for.nullables",
+          "Breaks records that omit proto3 optional scalar fields with "
+          + "DataException 'Invalid value: null used for required field'.",
+          errors);
+    }
+  }
+
+  private static void requireTrue(
+      Map<String, String> configs, String key, String reason,
+      List<String> errors) {
     if (!"true".equalsIgnoreCase(configs.get(key))) {
-      errors.add(converterPrefix + " uses AvroConverter but " + key
-          + " is not set to true. Restore will fail with AvroTypeException on "
-          + "records that contain enum values (e.g. \"value ACTIVE is not a "
-          + "UserStatus\"). Set " + key + "=true.");
+      errors.add(key + " must be set to true. " + reason);
+    }
+  }
+
+  private static void requireFalse(
+      Map<String, String> configs, String key, String reason,
+      List<String> errors) {
+    String value = configs.get(key);
+    if (value == null || !"false".equalsIgnoreCase(value)) {
+      errors.add(key + " must be set to false. " + reason);
+    }
+  }
+
+  private static void rejectIfTrue(
+      Map<String, String> configs, String key, String reason,
+      List<String> errors) {
+    if ("true".equalsIgnoreCase(configs.get(key))) {
+      errors.add(key + " must not be set to true. " + reason);
     }
   }
 
@@ -314,21 +370,11 @@ public final class BackupModeValidator {
       return;
     }
     if (PROTOBUF_CONVERTER.equals(converterClass)) {
-      warnIfNotTrue(configs, prefix + ".enhanced.protobuf.schema.support",
-          prefix + ": enhanced.protobuf.schema.support=true is recommended "
-          + "for backup mode. Without it, Protobuf schema fidelity may "
-          + "be reduced during restore.");
-
-      String optNullable = configs.get(prefix + ".optional.for.nullables");
-      String wrapNullable = configs.get(prefix + ".wrapper.for.nullables");
-      if (!"true".equalsIgnoreCase(optNullable)
-          && !"true".equalsIgnoreCase(wrapNullable)) {
-        log.warn("{}: neither optional.for.nullables nor "
-            + "wrapper.for.nullables is set. If the Protobuf schema uses "
-            + "nullable fields, they will not be preserved during restore. "
-            + "Set optional.for.nullables=true (recommended) or "
-            + "wrapper.for.nullables=true.", prefix);
-      }
+      warnIfNotTrue(configs, prefix + ".optional.for.nullables",
+          prefix + ": optional.for.nullables=true is recommended for "
+          + "backup mode and must match the source-side setting. Restore "
+          + "may drop proto3 optional scalars holding default values "
+          + "without it.");
     }
 
     if (JSON_SCHEMA_CONVERTER.equals(converterClass)
@@ -374,10 +420,9 @@ public final class BackupModeValidator {
 
     if (PROTOBUF_CONVERTER.equals(valConverter)) {
       warnIfNotTrue(configs,
-          BackupEnvelope.VALUE_CONVERTER_CONFIG
-              + ".enhanced.protobuf.schema.support",
-          "value.converter: enhanced.protobuf.schema.support=true is "
-          + "recommended for restore mode to match backup fidelity.");
+          BackupEnvelope.VALUE_CONVERTER_CONFIG + ".optional.for.nullables",
+          "value.converter: optional.for.nullables=true is recommended "
+          + "for restore mode and must match the sink-side setting.");
     }
 
     warnHeaderConverter(configs);

--- a/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
@@ -19,8 +19,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.HashSet;
 
 /**
  * Shared config validation for backup and restore modes across all
@@ -44,6 +48,17 @@ public final class BackupModeValidator {
       "io.confluent.connect.protobuf.ProtobufConverter";
   private static final String JSON_SCHEMA_CONVERTER =
       "io.confluent.connect.json.JsonSchemaConverter";
+
+  private static final String PARTITIONER_PKG =
+      "io.confluent.connect.storage.partitioner.";
+  private static final Set<String> SUPPORTED_PARTITIONERS =
+      Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+          PARTITIONER_PKG + "DefaultPartitioner",
+          PARTITIONER_PKG + "TimeBasedPartitioner",
+          PARTITIONER_PKG + "DailyPartitioner",
+          PARTITIONER_PKG + "HourlyPartitioner")));
+  private static final String UNSUPPORTED_TIMESTAMP_EXTRACTOR =
+      PARTITIONER_PKG + "TimeBasedPartitioner$RecordFieldTimestampExtractor";
 
   private static final String FORMAT_SIMPLE_NAME_JSON = "JsonFormat";
   private static final String FORMAT_SIMPLE_NAME_BYTE_ARRAY = "ByteArrayFormat";
@@ -77,6 +92,7 @@ public final class BackupModeValidator {
     validateSchemaBackupEnabled(configs, BackupEnvelope.VALUE_CONVERTER_CONFIG, errors);
     validateTransformsRejected(configs, errors);
     validateStoreKafkaKeysHeadersRejected(configs, errors);
+    validatePartitionerSupported(configs, errors);
 
     warnSinkSuboptimalConfigs(configs, formatClassName);
 
@@ -149,6 +165,26 @@ public final class BackupModeValidator {
           + "JsonFormat in BACKUP_FULL_RECORD mode. Without it, the "
           + "envelope schema is not embedded and restore cannot parse "
           + "the records.");
+    }
+  }
+
+  private static void validatePartitionerSupported(
+      Map<String, String> configs, List<String> errors) {
+    String partitioner = configs.get("partitioner.class");
+    if (partitioner != null && !SUPPORTED_PARTITIONERS.contains(partitioner)) {
+      errors.add("partitioner.class=" + partitioner + " is not supported in "
+          + "BACKUP_FULL_RECORD mode. The sink task passes a "
+          + "KafkaRecordEnvelope Struct to the partitioner, not the original "
+          + "payload, so partitioners that read user-data fields (e.g. "
+          + "FieldPartitioner) fail. Use DefaultPartitioner, "
+          + "TimeBasedPartitioner, DailyPartitioner, or HourlyPartitioner.");
+    }
+    String extractor = configs.get("timestamp.extractor");
+    if (extractor != null && extractor.equals(UNSUPPORTED_TIMESTAMP_EXTRACTOR)) {
+      errors.add("timestamp.extractor=RecordFieldTimestampExtractor is not "
+          + "supported in BACKUP_FULL_RECORD mode. It reads a field from the "
+          + "record value, which is now the envelope Struct. "
+          + "Use Wallclock or Record extractor instead.");
     }
   }
 

--- a/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
@@ -119,6 +119,8 @@ public final class BackupModeValidator {
     List<String> errors = new ArrayList<>();
 
     validateByteArrayFormat(formatClassName, errors);
+    validateConverterExplicitlySet(configs, BackupEnvelope.KEY_CONVERTER_CONFIG, errors);
+    validateConverterExplicitlySet(configs, BackupEnvelope.VALUE_CONVERTER_CONFIG, errors);
     validateSourceConverter(configs, BackupEnvelope.KEY_CONVERTER_CONFIG, errors);
     validateSourceConverter(configs, BackupEnvelope.VALUE_CONVERTER_CONFIG, errors);
     warnSourceSuboptimalConfigs(configs);
@@ -278,10 +280,12 @@ public final class BackupModeValidator {
       List<String> errors) {
     if (configs.get(converterPrefix) == null) {
       errors.add(converterPrefix + " must be set explicitly at the connector "
-          + "level in BACKUP_FULL_RECORD mode. Relying on worker.properties "
-          + "defaults hides the converter class from backup validation, so "
-          + "schema type detection falls through to UNKNOWN and schema files "
-          + "are not written. Set " + converterPrefix + " on the connector.");
+          + "level in backup and restore modes. Relying on worker.properties "
+          + "defaults hides the converter class from connector validation, so "
+          + "schema type detection falls through to UNKNOWN. On backup this "
+          + "skips writing schema files; on restore this skips converter-"
+          + "specific validations. Set "
+          + converterPrefix + " on the connector.");
     }
   }
 

--- a/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/BackupModeValidator.java
@@ -379,13 +379,6 @@ public final class BackupModeValidator {
     if (converterClass == null) {
       return;
     }
-    if (PROTOBUF_CONVERTER.equals(converterClass)) {
-      warnIfNotTrue(configs, prefix + ".optional.for.nullables",
-          prefix + ": optional.for.nullables=true is recommended for "
-          + "backup and restore modes and must match on both sides. "
-          + "Restore may drop proto3 optional scalars holding default "
-          + "values without it.");
-    }
 
     if (JSON_SCHEMA_CONVERTER.equals(converterClass)) {
       warnJsonTypeAllowedPackages(configs, prefix);

--- a/core/src/main/java/io/confluent/connect/storage/backup/BackupReferenceParser.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/BackupReferenceParser.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.storage.backup;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.connect.errors.DataException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Parses reference tree JSON from the Wrapper into manifest-compatible
+ * {@link SchemaManifest.SchemaReferenceEntry} records for storage.
+ */
+public final class BackupReferenceParser {
+
+  private static final Logger log = LoggerFactory.getLogger(BackupReferenceParser.class);
+  private static final ObjectMapper JSON = new ObjectMapper();
+
+  private BackupReferenceParser() {
+  }
+
+  /**
+   * Parse the direct references JSON using globalIds from the reference tree.
+   * Only direct references are returned (not transitive ones).
+   *
+   * @param directRefsJson the JSON from Wrapper's directRefs field
+   * @param referenceTreeJson the JSON from Wrapper's referenceTree field
+   * @return list of direct reference entries, or empty list if either is null
+   */
+  @SuppressWarnings("unchecked")
+  public static List<SchemaManifest.SchemaReferenceEntry> parseDirectRefsToManifestEntries(
+      String directRefsJson, String referenceTreeJson) {
+    if (directRefsJson == null || directRefsJson.isEmpty()
+        || referenceTreeJson == null || referenceTreeJson.isEmpty()) {
+      return Collections.emptyList();
+    }
+    try {
+      List<Map<String, Object>> directRefs = JSON.readValue(directRefsJson,
+          new TypeReference<List<Map<String, Object>>>() {});
+      Map<String, Map<String, Object>> tree = JSON.readValue(
+          referenceTreeJson,
+          new TypeReference<Map<String, Map<String, Object>>>() {});
+
+      List<SchemaManifest.SchemaReferenceEntry> result =
+          new ArrayList<>();
+      for (Map<String, Object> ref : directRefs) {
+        String name = (String) ref.get(BackupEnvelope.REF_FIELD_NAME);
+        String subject = (String) ref.get(BackupEnvelope.REF_FIELD_SUBJECT);
+        int version = ref.get(BackupEnvelope.REF_FIELD_VERSION) instanceof Number
+            ? ((Number) ref.get(BackupEnvelope.REF_FIELD_VERSION)).intValue() : 0;
+        int globalId = 0;
+        Map<String, Object> treeEntry = tree.get(name);
+        if (treeEntry != null
+            && treeEntry.get(BackupEnvelope.REF_FIELD_GLOBAL_ID) instanceof Number) {
+          globalId =
+              ((Number) treeEntry.get(BackupEnvelope.REF_FIELD_GLOBAL_ID)).intValue();
+        }
+        result.add(new SchemaManifest.SchemaReferenceEntry(
+            name, subject, version, globalId));
+      }
+      return result;
+    } catch (IOException e) {
+      throw new DataException(
+          "Failed to parse reference JSON. Cannot guarantee "
+          + "pristine restore.", e);
+    }
+  }
+
+}

--- a/core/src/main/java/io/confluent/connect/storage/backup/BackupReferenceParser.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/BackupReferenceParser.java
@@ -18,8 +18,6 @@ package io.confluent.connect.storage.backup;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.kafka.connect.errors.DataException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -33,7 +31,6 @@ import java.util.Map;
  */
 public final class BackupReferenceParser {
 
-  private static final Logger log = LoggerFactory.getLogger(BackupReferenceParser.class);
   private static final ObjectMapper JSON = new ObjectMapper();
 
   private BackupReferenceParser() {

--- a/core/src/main/java/io/confluent/connect/storage/backup/BackupReferenceParser.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/BackupReferenceParser.java
@@ -64,19 +64,7 @@ public final class BackupReferenceParser {
       List<SchemaManifest.SchemaReferenceEntry> result =
           new ArrayList<>();
       for (Map<String, Object> ref : directRefs) {
-        String name = (String) ref.get(BackupEnvelope.REF_FIELD_NAME);
-        String subject = (String) ref.get(BackupEnvelope.REF_FIELD_SUBJECT);
-        int version = ref.get(BackupEnvelope.REF_FIELD_VERSION) instanceof Number
-            ? ((Number) ref.get(BackupEnvelope.REF_FIELD_VERSION)).intValue() : 0;
-        int globalId = 0;
-        Map<String, Object> treeEntry = tree.get(name);
-        if (treeEntry != null
-            && treeEntry.get(BackupEnvelope.REF_FIELD_GLOBAL_ID) instanceof Number) {
-          globalId =
-              ((Number) treeEntry.get(BackupEnvelope.REF_FIELD_GLOBAL_ID)).intValue();
-        }
-        result.add(new SchemaManifest.SchemaReferenceEntry(
-            name, subject, version, globalId));
+        result.add(toManifestEntry(ref, tree));
       }
       return result;
     } catch (IOException e) {
@@ -84,6 +72,30 @@ public final class BackupReferenceParser {
           "Failed to parse reference JSON. Cannot guarantee "
           + "pristine restore.", e);
     }
+  }
+
+  private static SchemaManifest.SchemaReferenceEntry toManifestEntry(
+      Map<String, Object> ref, Map<String, Map<String, Object>> tree) {
+    String name = (String) ref.get(BackupEnvelope.REF_FIELD_NAME);
+    String subject = (String) ref.get(BackupEnvelope.REF_FIELD_SUBJECT);
+    int version = ref.get(BackupEnvelope.REF_FIELD_VERSION) instanceof Number
+        ? ((Number) ref.get(BackupEnvelope.REF_FIELD_VERSION)).intValue() : 0;
+    Map<String, Object> treeEntry = tree.get(name);
+    if (treeEntry == null
+        || !(treeEntry.get(BackupEnvelope.REF_FIELD_GLOBAL_ID) instanceof Number)) {
+      throw new DataException(
+          "Direct reference '" + name + "' has no matching entry with a "
+          + "globalId in the reference tree. Cannot guarantee pristine "
+          + "restore; the referenced schema file would be missing.");
+    }
+    int globalId =
+        ((Number) treeEntry.get(BackupEnvelope.REF_FIELD_GLOBAL_ID)).intValue();
+    if (globalId <= 0) {
+      throw new DataException(
+          "Direct reference '" + name + "' has invalid globalId=" + globalId
+          + " in the reference tree. Cannot guarantee pristine restore.");
+    }
+    return new SchemaManifest.SchemaReferenceEntry(name, subject, version, globalId);
   }
 
 }

--- a/core/src/main/java/io/confluent/connect/storage/backup/ConverterTypeDetector.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/ConverterTypeDetector.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.storage.backup;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Maps converter class names to schema type tags used in the backup envelope.
+ * Uses a registry pattern for extensibility — new converter types can be
+ * registered via {@link #register(String, String)}.
+ */
+public final class ConverterTypeDetector {
+
+  private static final Map<String, String> KNOWN_TYPES = new ConcurrentHashMap<>();
+
+  static {
+    KNOWN_TYPES.put("io.confluent.connect.avro.AvroConverter", BackupEnvelope.TYPE_AVRO);
+    KNOWN_TYPES.put("io.confluent.connect.protobuf.ProtobufConverter",
+        BackupEnvelope.TYPE_PROTOBUF);
+    KNOWN_TYPES.put("io.confluent.connect.json.JsonSchemaConverter",
+        BackupEnvelope.TYPE_JSON_SCHEMA);
+    KNOWN_TYPES.put("org.apache.kafka.connect.storage.StringConverter",
+        BackupEnvelope.TYPE_STRING);
+    KNOWN_TYPES.put("org.apache.kafka.connect.converters.IntegerConverter",
+        BackupEnvelope.TYPE_INT32);
+    KNOWN_TYPES.put("org.apache.kafka.connect.converters.LongConverter",
+        BackupEnvelope.TYPE_INT64);
+    KNOWN_TYPES.put("org.apache.kafka.connect.converters.ShortConverter",
+        BackupEnvelope.TYPE_INT16);
+    KNOWN_TYPES.put("org.apache.kafka.connect.converters.FloatConverter",
+        BackupEnvelope.TYPE_FLOAT32);
+    KNOWN_TYPES.put("org.apache.kafka.connect.converters.DoubleConverter",
+        BackupEnvelope.TYPE_FLOAT64);
+    KNOWN_TYPES.put("org.apache.kafka.connect.converters.ByteArrayConverter",
+        BackupEnvelope.TYPE_BYTES);
+    KNOWN_TYPES.put(
+        "io.confluent.connect.schema.backup.core.BackupAwareByteArrayConverter",
+        BackupEnvelope.TYPE_BYTES);
+  }
+
+  private ConverterTypeDetector() {
+  }
+
+  /**
+   * Register a custom converter type mapping. Call during connector startup
+   * for converters not in the built-in list.
+   */
+  public static void register(String converterClassName, String schemaType) {
+    KNOWN_TYPES.put(converterClassName, schemaType);
+  }
+
+  /**
+   * Detect the schema type tag for a given converter class name.
+   *
+   * @param converterClass fully qualified converter class name
+   * @param config task config map (used for JsonConverter schemas.enable check)
+   * @param converterPrefix converter config prefix (e.g. "key.converter")
+   * @return the schema type tag, or "UNKNOWN" if not recognized
+   */
+  public static String detectSchemaType(
+      String converterClass, Map<String, String> config, String converterPrefix) {
+    if (converterClass == null) {
+      return BackupEnvelope.TYPE_NONE;
+    }
+
+    // JsonConverter needs special handling: check schemas.enable
+    if ("org.apache.kafka.connect.json.JsonConverter".equals(converterClass)) {
+      String schemasEnable = config.get(converterPrefix + ".schemas.enable");
+      return "false".equalsIgnoreCase(schemasEnable)
+          ? BackupEnvelope.TYPE_JSON_SCHEMALESS
+          : BackupEnvelope.TYPE_JSON_EMBEDDED_SCHEMA;
+    }
+
+    String type = KNOWN_TYPES.get(converterClass);
+    return type != null ? type : BackupEnvelope.TYPE_UNKNOWN;
+  }
+}

--- a/core/src/main/java/io/confluent/connect/storage/backup/ConverterTypeDetector.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/ConverterTypeDetector.java
@@ -15,6 +15,9 @@
 
 package io.confluent.connect.storage.backup;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -23,6 +26,8 @@ import java.util.Map;
  * Maps converter class names to schema type tags used in the backup envelope.
  */
 public final class ConverterTypeDetector {
+
+  private static final Logger log = LoggerFactory.getLogger(ConverterTypeDetector.class);
 
   private static final Map<String, String> KNOWN_TYPES;
 
@@ -65,18 +70,23 @@ public final class ConverterTypeDetector {
    */
   public static String detectSchemaType(
       String converterClass, Map<String, String> config, String converterPrefix) {
+    String detected = detect(converterClass, config, converterPrefix);
+    log.debug("Detected schemaType={} for converter={} at prefix={}",
+        detected, converterClass, converterPrefix);
+    return detected;
+  }
+
+  private static String detect(
+      String converterClass, Map<String, String> config, String converterPrefix) {
     if (converterClass == null) {
       return BackupEnvelope.TYPE_UNKNOWN;
     }
-
-    // JsonConverter needs special handling: check schemas.enable
     if ("org.apache.kafka.connect.json.JsonConverter".equals(converterClass)) {
       String schemasEnable = config.get(converterPrefix + ".schemas.enable");
       return "false".equalsIgnoreCase(schemasEnable)
           ? BackupEnvelope.TYPE_JSON_SCHEMALESS
           : BackupEnvelope.TYPE_JSON_EMBEDDED_SCHEMA;
     }
-
     String type = KNOWN_TYPES.get(converterClass);
     return type != null ? type : BackupEnvelope.TYPE_UNKNOWN;
   }

--- a/core/src/main/java/io/confluent/connect/storage/backup/ConverterTypeDetector.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/ConverterTypeDetector.java
@@ -66,7 +66,7 @@ public final class ConverterTypeDetector {
   public static String detectSchemaType(
       String converterClass, Map<String, String> config, String converterPrefix) {
     if (converterClass == null) {
-      return BackupEnvelope.TYPE_NONE;
+      return BackupEnvelope.TYPE_UNKNOWN;
     }
 
     // JsonConverter needs special handling: check schemas.enable

--- a/core/src/main/java/io/confluent/connect/storage/backup/ConverterTypeDetector.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/ConverterTypeDetector.java
@@ -15,52 +15,44 @@
 
 package io.confluent.connect.storage.backup;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Maps converter class names to schema type tags used in the backup envelope.
- * Uses a registry pattern for extensibility — new converter types can be
- * registered via {@link #register(String, String)}.
  */
 public final class ConverterTypeDetector {
 
-  private static final Map<String, String> KNOWN_TYPES = new ConcurrentHashMap<>();
+  private static final Map<String, String> KNOWN_TYPES;
 
   static {
-    KNOWN_TYPES.put("io.confluent.connect.avro.AvroConverter", BackupEnvelope.TYPE_AVRO);
-    KNOWN_TYPES.put("io.confluent.connect.protobuf.ProtobufConverter",
+    Map<String, String> m = new HashMap<>();
+    m.put("io.confluent.connect.avro.AvroConverter", BackupEnvelope.TYPE_AVRO);
+    m.put("io.confluent.connect.protobuf.ProtobufConverter",
         BackupEnvelope.TYPE_PROTOBUF);
-    KNOWN_TYPES.put("io.confluent.connect.json.JsonSchemaConverter",
+    m.put("io.confluent.connect.json.JsonSchemaConverter",
         BackupEnvelope.TYPE_JSON_SCHEMA);
-    KNOWN_TYPES.put("org.apache.kafka.connect.storage.StringConverter",
+    m.put("org.apache.kafka.connect.storage.StringConverter",
         BackupEnvelope.TYPE_STRING);
-    KNOWN_TYPES.put("org.apache.kafka.connect.converters.IntegerConverter",
+    m.put("org.apache.kafka.connect.converters.IntegerConverter",
         BackupEnvelope.TYPE_INT32);
-    KNOWN_TYPES.put("org.apache.kafka.connect.converters.LongConverter",
+    m.put("org.apache.kafka.connect.converters.LongConverter",
         BackupEnvelope.TYPE_INT64);
-    KNOWN_TYPES.put("org.apache.kafka.connect.converters.ShortConverter",
+    m.put("org.apache.kafka.connect.converters.ShortConverter",
         BackupEnvelope.TYPE_INT16);
-    KNOWN_TYPES.put("org.apache.kafka.connect.converters.FloatConverter",
+    m.put("org.apache.kafka.connect.converters.FloatConverter",
         BackupEnvelope.TYPE_FLOAT32);
-    KNOWN_TYPES.put("org.apache.kafka.connect.converters.DoubleConverter",
+    m.put("org.apache.kafka.connect.converters.DoubleConverter",
         BackupEnvelope.TYPE_FLOAT64);
-    KNOWN_TYPES.put("org.apache.kafka.connect.converters.ByteArrayConverter",
+    m.put("org.apache.kafka.connect.converters.ByteArrayConverter",
         BackupEnvelope.TYPE_BYTES);
-    KNOWN_TYPES.put(
-        "io.confluent.connect.schema.backup.core.BackupAwareByteArrayConverter",
+    m.put("io.confluent.connect.schema.backup.core.BackupAwareByteArrayConverter",
         BackupEnvelope.TYPE_BYTES);
+    KNOWN_TYPES = Collections.unmodifiableMap(m);
   }
 
   private ConverterTypeDetector() {
-  }
-
-  /**
-   * Register a custom converter type mapping. Call during connector startup
-   * for converters not in the built-in list.
-   */
-  public static void register(String converterClassName, String schemaType) {
-    KNOWN_TYPES.put(converterClassName, schemaType);
   }
 
   /**

--- a/core/src/main/java/io/confluent/connect/storage/backup/EnvelopeSchemaBuilder.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/EnvelopeSchemaBuilder.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.storage.backup;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.data.Values;
+import org.apache.kafka.connect.header.Header;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Builds the {@code KafkaRecordEnvelope} Connect schema and struct
+ * that wraps a full Kafka record (key, value, headers, metadata)
+ * for backup storage. Used by {@code EnvelopeTransformer} on the
+ * sink path.
+ */
+public final class EnvelopeSchemaBuilder {
+
+  private EnvelopeSchemaBuilder() {
+  }
+
+  public static final Schema HEADER_SCHEMA =
+      SchemaBuilder.struct()
+          .name("io.confluent.connect.storage.Header")
+          .field(BackupEnvelope.FIELD_HEADER_KEY, Schema.STRING_SCHEMA)
+          .field(BackupEnvelope.FIELD_HEADER_VALUE, Schema.OPTIONAL_STRING_SCHEMA)
+          .field(BackupEnvelope.FIELD_HEADER_SCHEMA_TYPE, Schema.OPTIONAL_STRING_SCHEMA)
+          .build();
+
+  public static final Schema HEADERS_ARRAY_SCHEMA =
+      SchemaBuilder.array(HEADER_SCHEMA).optional().build();
+
+  public static Schema buildEnvelopeSchema(
+      Schema keySchema, Schema valueSchema,
+      String keySchemaType, String valueSchemaType) {
+
+    SchemaBuilder b = SchemaBuilder.struct().name(BackupEnvelope.NAME);
+    b.field(BackupEnvelope.FIELD_KEY,
+        keySchema != null ? keySchema : Schema.OPTIONAL_STRING_SCHEMA);
+    b.field(BackupEnvelope.FIELD_VALUE,
+        valueSchema != null ? valueSchema : Schema.OPTIONAL_STRING_SCHEMA);
+    b.field(BackupEnvelope.FIELD_HEADERS, HEADERS_ARRAY_SCHEMA);
+    b.field(BackupEnvelope.FIELD_TOPIC, Schema.STRING_SCHEMA);
+    b.field(BackupEnvelope.FIELD_PARTITION, Schema.INT32_SCHEMA);
+    b.field(BackupEnvelope.FIELD_OFFSET, Schema.INT64_SCHEMA);
+    b.field(BackupEnvelope.FIELD_TIMESTAMP, Schema.OPTIONAL_INT64_SCHEMA);
+    b.field(BackupEnvelope.FIELD_TIMESTAMP_TYPE, Schema.OPTIONAL_STRING_SCHEMA);
+    b.field(BackupEnvelope.FIELD_KEY_SCHEMA_ID, Schema.OPTIONAL_INT32_SCHEMA);
+    b.field(BackupEnvelope.FIELD_VALUE_SCHEMA_ID, Schema.OPTIONAL_INT32_SCHEMA);
+    b.field(BackupEnvelope.FIELD_KEY_SCHEMA_TYPE, Schema.STRING_SCHEMA);
+    b.field(BackupEnvelope.FIELD_VALUE_SCHEMA_TYPE, Schema.STRING_SCHEMA);
+    b.field(BackupEnvelope.FIELD_KEY_SCHEMA_SUBJECT, Schema.OPTIONAL_STRING_SCHEMA);
+    b.field(BackupEnvelope.FIELD_VALUE_SCHEMA_SUBJECT, Schema.OPTIONAL_STRING_SCHEMA);
+    b.field(BackupEnvelope.FIELD_KEY_SCHEMA_GUID, Schema.OPTIONAL_STRING_SCHEMA);
+    b.field(BackupEnvelope.FIELD_VALUE_SCHEMA_GUID, Schema.OPTIONAL_STRING_SCHEMA);
+    b.field(BackupEnvelope.FIELD_FORMAT_VERSION, Schema.INT32_SCHEMA);
+    return b.build();
+  }
+
+  public static Struct buildEnvelopeStruct(
+      Schema envelopeSchema, SinkRecord record,
+      Object keyData, Object valueData,
+      SchemaDescriptor key, SchemaDescriptor value) {
+
+    Struct e = new Struct(envelopeSchema);
+    e.put(BackupEnvelope.FIELD_KEY, keyData);
+    e.put(BackupEnvelope.FIELD_VALUE, valueData);
+    e.put(BackupEnvelope.FIELD_HEADERS, buildHeaders(record));
+    e.put(BackupEnvelope.FIELD_TOPIC, record.topic());
+    e.put(BackupEnvelope.FIELD_PARTITION, record.kafkaPartition());
+    e.put(BackupEnvelope.FIELD_OFFSET, record.kafkaOffset());
+    e.put(BackupEnvelope.FIELD_TIMESTAMP, record.timestamp());
+    e.put(BackupEnvelope.FIELD_TIMESTAMP_TYPE, record.timestampType() != null
+        ? record.timestampType().name() : null);
+    e.put(BackupEnvelope.FIELD_KEY_SCHEMA_ID, key.getSchemaId());
+    e.put(BackupEnvelope.FIELD_VALUE_SCHEMA_ID, value.getSchemaId());
+    e.put(BackupEnvelope.FIELD_KEY_SCHEMA_TYPE, key.getSchemaType());
+    e.put(BackupEnvelope.FIELD_VALUE_SCHEMA_TYPE, value.getSchemaType());
+    e.put(BackupEnvelope.FIELD_KEY_SCHEMA_SUBJECT, key.getSubject());
+    e.put(BackupEnvelope.FIELD_VALUE_SCHEMA_SUBJECT, value.getSubject());
+    e.put(BackupEnvelope.FIELD_KEY_SCHEMA_GUID, key.getSchemaGuid());
+    e.put(BackupEnvelope.FIELD_VALUE_SCHEMA_GUID, value.getSchemaGuid());
+    e.put(BackupEnvelope.FIELD_FORMAT_VERSION, BackupEnvelope.FORMAT_VERSION);
+    return e;
+  }
+
+  public static class SchemaDescriptor {
+    private final Integer schemaId;
+    private final String schemaType;
+    private final String subject;
+    private final String schemaGuid;
+
+    public SchemaDescriptor(
+        Integer schemaId, String schemaType,
+        String subject, String schemaGuid) {
+      this.schemaId = schemaId;
+      this.schemaType = schemaType;
+      this.subject = subject;
+      this.schemaGuid = schemaGuid;
+    }
+
+    public Integer getSchemaId() {
+      return schemaId;
+    }
+
+    public String getSchemaType() {
+      return schemaType;
+    }
+
+    public String getSubject() {
+      return subject;
+    }
+
+    public String getSchemaGuid() {
+      return schemaGuid;
+    }
+  }
+
+  private static List<Struct> buildHeaders(SinkRecord record) {
+    List<Struct> result = new ArrayList<>();
+    if (record.headers() != null) {
+      for (Header h : record.headers()) {
+        Struct hs = new Struct(HEADER_SCHEMA);
+        hs.put(BackupEnvelope.FIELD_HEADER_KEY, h.key());
+        hs.put(BackupEnvelope.FIELD_HEADER_VALUE,
+            h.value() != null
+                ? Values.convertToString(h.schema(), h.value()) : null);
+        hs.put(BackupEnvelope.FIELD_HEADER_SCHEMA_TYPE,
+            h.schema() != null ? h.schema().type().name() : null);
+        result.add(hs);
+      }
+    }
+    return result;
+  }
+}

--- a/core/src/main/java/io/confluent/connect/storage/backup/EnvelopeSchemaBuilder.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/EnvelopeSchemaBuilder.java
@@ -48,8 +48,7 @@ public final class EnvelopeSchemaBuilder {
       SchemaBuilder.array(HEADER_SCHEMA).optional().build();
 
   public static Schema buildEnvelopeSchema(
-      Schema keySchema, Schema valueSchema,
-      String keySchemaType, String valueSchemaType) {
+      Schema keySchema, Schema valueSchema) {
 
     SchemaBuilder b = SchemaBuilder.struct().name(BackupEnvelope.NAME);
     b.field(BackupEnvelope.FIELD_KEY,

--- a/core/src/main/java/io/confluent/connect/storage/backup/EnvelopeSchemaBuilder.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/EnvelopeSchemaBuilder.java
@@ -74,20 +74,20 @@ public final class EnvelopeSchemaBuilder {
   }
 
   public static Struct buildEnvelopeStruct(
-      Schema envelopeSchema, SinkRecord record,
+      Schema envelopeSchema, SinkRecord sinkRecord,
       Object keyData, Object valueData,
       SchemaDescriptor key, SchemaDescriptor value) {
 
     Struct e = new Struct(envelopeSchema);
     e.put(BackupEnvelope.FIELD_KEY, keyData);
     e.put(BackupEnvelope.FIELD_VALUE, valueData);
-    e.put(BackupEnvelope.FIELD_HEADERS, buildHeaders(record));
-    e.put(BackupEnvelope.FIELD_TOPIC, record.topic());
-    e.put(BackupEnvelope.FIELD_PARTITION, record.kafkaPartition());
-    e.put(BackupEnvelope.FIELD_OFFSET, record.kafkaOffset());
-    e.put(BackupEnvelope.FIELD_TIMESTAMP, record.timestamp());
-    e.put(BackupEnvelope.FIELD_TIMESTAMP_TYPE, record.timestampType() != null
-        ? record.timestampType().name() : null);
+    e.put(BackupEnvelope.FIELD_HEADERS, buildHeaders(sinkRecord));
+    e.put(BackupEnvelope.FIELD_TOPIC, sinkRecord.topic());
+    e.put(BackupEnvelope.FIELD_PARTITION, sinkRecord.kafkaPartition());
+    e.put(BackupEnvelope.FIELD_OFFSET, sinkRecord.kafkaOffset());
+    e.put(BackupEnvelope.FIELD_TIMESTAMP, sinkRecord.timestamp());
+    e.put(BackupEnvelope.FIELD_TIMESTAMP_TYPE, sinkRecord.timestampType() != null
+        ? sinkRecord.timestampType().name() : null);
     e.put(BackupEnvelope.FIELD_KEY_SCHEMA_ID, key.getSchemaId());
     e.put(BackupEnvelope.FIELD_VALUE_SCHEMA_ID, value.getSchemaId());
     e.put(BackupEnvelope.FIELD_KEY_SCHEMA_TYPE, key.getSchemaType());
@@ -132,10 +132,10 @@ public final class EnvelopeSchemaBuilder {
     }
   }
 
-  private static List<Struct> buildHeaders(SinkRecord record) {
+  private static List<Struct> buildHeaders(SinkRecord sinkRecord) {
     List<Struct> result = new ArrayList<>();
-    if (record.headers() != null) {
-      for (Header h : record.headers()) {
+    if (sinkRecord.headers() != null) {
+      for (Header h : sinkRecord.headers()) {
         Struct hs = new Struct(HEADER_SCHEMA);
         hs.put(BackupEnvelope.FIELD_HEADER_KEY, h.key());
         hs.put(BackupEnvelope.FIELD_HEADER_VALUE,

--- a/core/src/main/java/io/confluent/connect/storage/backup/ObjectStoreSchemaBackupStore.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/ObjectStoreSchemaBackupStore.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.storage.backup;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.kafka.connect.errors.DataException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Backs up schemas as per-schema files: {id}.{ext} + {id}.entry.json.
+ * Three-level dedup: in-memory ConcurrentSet → exists() → write.
+ * No shared manifest. Zero contention between tasks.
+ */
+public class ObjectStoreSchemaBackupStore implements SchemaBackupStore {
+
+  private static final Logger log =
+      LoggerFactory.getLogger(ObjectStoreSchemaBackupStore.class);
+  private static final String DEDUP_KEY_SEPARATOR = ":";
+  private final StorageWriter writer;
+  private final String topicsDir;
+  private final String dirDelim;
+  private final Set<String> backedUpKeys =
+      Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+  public ObjectStoreSchemaBackupStore(
+      StorageWriter writer, String topicsDir, String dirDelim) {
+    this.writer = writer;
+    this.topicsDir = topicsDir;
+    this.dirDelim = dirDelim;
+  }
+
+  @Override
+  public void backupIfNeeded(
+      String topic, String schemaKey, int version,
+      String schemaType, String subject, String rawSchema,
+      List<SchemaManifest.SchemaReferenceEntry> references) {
+    if (schemaKey == null || schemaKey.isEmpty()) {
+      log.warn("No schema key for topic={}, skipping backup", topic);
+      return;
+    }
+    String dedupKey = topic + DEDUP_KEY_SEPARATOR + schemaKey;
+
+    if (backedUpKeys.contains(dedupKey)) {
+      return;
+    }
+
+    String entryPath = schemasPath(topic) + schemaKey + BackupEnvelope.ENTRY_FILE_SUFFIX;
+
+    if (writer.exists(entryPath)) {
+      backedUpKeys.add(dedupKey);
+      log.debug("Schema already backed up (exists check): topic={}, key={}",
+          topic, schemaKey);
+      return;
+    }
+
+    String ext = extensionFor(schemaType);
+    String schemaPath = schemasPath(topic) + schemaKey + ext;
+    writer.write(schemaPath, rawSchema);
+
+    SchemaManifest.SchemaEntry entry = new SchemaManifest.SchemaEntry(
+        schemaKey, schemaType, subject, version,
+        schemaKey + ext, references);
+    String entryJson;
+    try {
+      entryJson = entry.toJsonString();
+    } catch (JsonProcessingException e) {
+      throw new DataException(
+          "Failed to serialize schema entry for key=" + schemaKey, e);
+    }
+    writer.write(entryPath, entryJson);
+
+    backedUpKeys.add(dedupKey);
+    log.info("Backed up schema: topic={}, key={}, subject={}, refs={}",
+        topic, schemaKey, subject,
+        references != null ? references.size() : 0);
+  }
+
+  private String schemasPath(String topic) {
+    StringBuilder sb = new StringBuilder();
+    if (topicsDir != null && !topicsDir.isEmpty()) {
+      sb.append(topicsDir).append(dirDelim);
+    }
+    sb.append(topic).append(dirDelim)
+        .append(BackupEnvelope.METADATA_DIR).append(dirDelim)
+        .append(BackupEnvelope.SCHEMAS_DIR).append(dirDelim);
+    return sb.toString();
+  }
+
+  private String extensionFor(String type) {
+    return BackupEnvelope.extensionForType(type);
+  }
+}

--- a/core/src/main/java/io/confluent/connect/storage/backup/ObjectStoreSchemaBackupStore.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/ObjectStoreSchemaBackupStore.java
@@ -79,14 +79,7 @@ public class ObjectStoreSchemaBackupStore implements SchemaBackupStore {
       SchemaManifest.SchemaEntry entry = new SchemaManifest.SchemaEntry(
           schemaKey, schemaType, subject, version,
           schemaKey + ext, references);
-      String entryJson;
-      try {
-        entryJson = entry.toJsonString();
-      } catch (JsonProcessingException e) {
-        throw new DataException(
-            "Failed to serialize schema entry for key=" + schemaKey, e);
-      }
-      writer.write(entryPath, entryJson);
+      writer.write(entryPath, toJson(entry, schemaKey));
 
       log.info("Backed up schema: topic={}, key={}, subject={}, refs={}",
           topic, schemaKey, subject,
@@ -96,6 +89,15 @@ public class ObjectStoreSchemaBackupStore implements SchemaBackupStore {
       log.error("Failed to back up schema: topic={}, key={}",
           topic, schemaKey, e);
       throw e;
+    }
+  }
+
+  private static String toJson(SchemaManifest.SchemaEntry entry, String schemaKey) {
+    try {
+      return entry.toJsonString();
+    } catch (JsonProcessingException e) {
+      throw new DataException(
+          "Failed to serialize schema entry for key=" + schemaKey, e);
     }
   }
 

--- a/core/src/main/java/io/confluent/connect/storage/backup/ObjectStoreSchemaBackupStore.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/ObjectStoreSchemaBackupStore.java
@@ -93,6 +93,8 @@ public class ObjectStoreSchemaBackupStore implements SchemaBackupStore {
           references != null ? references.size() : 0);
     } catch (RuntimeException e) {
       backedUpKeys.remove(dedupKey);
+      log.error("Failed to back up schema: topic={}, key={}",
+          topic, schemaKey, e);
       throw e;
     }
   }

--- a/core/src/main/java/io/confluent/connect/storage/backup/ObjectStoreSchemaBackupStore.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/ObjectStoreSchemaBackupStore.java
@@ -59,39 +59,42 @@ public class ObjectStoreSchemaBackupStore implements SchemaBackupStore {
     }
     String dedupKey = topic + DEDUP_KEY_SEPARATOR + schemaKey;
 
-    if (backedUpKeys.contains(dedupKey)) {
+    if (!backedUpKeys.add(dedupKey)) {
       return;
     }
 
-    String entryPath = schemasPath(topic) + schemaKey + BackupEnvelope.ENTRY_FILE_SUFFIX;
-
-    if (writer.exists(entryPath)) {
-      backedUpKeys.add(dedupKey);
-      log.debug("Schema already backed up (exists check): topic={}, key={}",
-          topic, schemaKey);
-      return;
-    }
-
-    String ext = extensionFor(schemaType);
-    String schemaPath = schemasPath(topic) + schemaKey + ext;
-    writer.write(schemaPath, rawSchema);
-
-    SchemaManifest.SchemaEntry entry = new SchemaManifest.SchemaEntry(
-        schemaKey, schemaType, subject, version,
-        schemaKey + ext, references);
-    String entryJson;
     try {
-      entryJson = entry.toJsonString();
-    } catch (JsonProcessingException e) {
-      throw new DataException(
-          "Failed to serialize schema entry for key=" + schemaKey, e);
-    }
-    writer.write(entryPath, entryJson);
+      String entryPath = schemasPath(topic) + schemaKey + BackupEnvelope.ENTRY_FILE_SUFFIX;
 
-    backedUpKeys.add(dedupKey);
-    log.info("Backed up schema: topic={}, key={}, subject={}, refs={}",
-        topic, schemaKey, subject,
-        references != null ? references.size() : 0);
+      if (writer.exists(entryPath)) {
+        log.debug("Schema already backed up (exists check): topic={}, key={}",
+            topic, schemaKey);
+        return;
+      }
+
+      String ext = extensionFor(schemaType);
+      String schemaPath = schemasPath(topic) + schemaKey + ext;
+      writer.write(schemaPath, rawSchema);
+
+      SchemaManifest.SchemaEntry entry = new SchemaManifest.SchemaEntry(
+          schemaKey, schemaType, subject, version,
+          schemaKey + ext, references);
+      String entryJson;
+      try {
+        entryJson = entry.toJsonString();
+      } catch (JsonProcessingException e) {
+        throw new DataException(
+            "Failed to serialize schema entry for key=" + schemaKey, e);
+      }
+      writer.write(entryPath, entryJson);
+
+      log.info("Backed up schema: topic={}, key={}, subject={}, refs={}",
+          topic, schemaKey, subject,
+          references != null ? references.size() : 0);
+    } catch (RuntimeException e) {
+      backedUpKeys.remove(dedupKey);
+      throw e;
+    }
   }
 
   private String schemasPath(String topic) {

--- a/core/src/main/java/io/confluent/connect/storage/backup/SchemaBackupStore.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/SchemaBackupStore.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.storage.backup;
+
+import java.util.List;
+
+/**
+ * Contract for backing up schemas to object storage.
+ * Writes per-schema files: {key}.{ext} (pristine schema) + {key}.entry.json (metadata).
+ * The key is either the integer schema ID or the schema GUID.
+ * Three-level dedup: in-memory → exists() → write.
+ */
+public interface SchemaBackupStore {
+
+  void backupIfNeeded(
+      String topic, String schemaKey, int version,
+      String schemaType, String subject, String rawSchema,
+      List<SchemaManifest.SchemaReferenceEntry> references);
+}

--- a/core/src/main/java/io/confluent/connect/storage/backup/SchemaManifest.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/SchemaManifest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.storage.backup;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Data model for per-schema entry.json files written during backup and read during restore.
+ *
+ * <p>Uses JsonNode tree API for serialization/deserialization instead of Jackson annotations
+ * to avoid classloader-based annotation introspection issues in Kafka Connect's plugin
+ * isolation environment.
+ */
+public final class SchemaManifest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper()
+      .enable(SerializationFeature.INDENT_OUTPUT);
+
+  private static final int FORMAT_VERSION = 1;
+
+  private static final String JSON_FORMAT = "format";
+  private static final String JSON_ID = "id";
+  private static final String JSON_TYPE = "type";
+  private static final String JSON_SUBJECT = "subject";
+  private static final String JSON_VERSION = "version";
+  private static final String JSON_FILE = "file";
+  private static final String JSON_REFERENCES = "references";
+  private static final String JSON_NAME = "name";
+  private static final String JSON_GLOBAL_ID = "globalId";
+
+  private SchemaManifest() {
+  }
+
+  public static class SchemaEntry {
+    private final String id;
+    private final String type;
+    private final String subject;
+    private final int version;
+    private final String file;
+    private final List<SchemaReferenceEntry> references;
+
+    public SchemaEntry(
+        String id, String type, String subject, int version,
+        String file, List<SchemaReferenceEntry> references) {
+      this.id = id;
+      this.type = type;
+      this.subject = subject;
+      this.version = version;
+      this.file = file;
+      this.references = references != null
+          ? Collections.unmodifiableList(new ArrayList<>(references))
+          : Collections.emptyList();
+    }
+
+    public String getId() {
+      return id;
+    }
+
+    public String getType() {
+      return type;
+    }
+
+    public String getSubject() {
+      return subject;
+    }
+
+    public int getVersion() {
+      return version;
+    }
+
+    public String getFile() {
+      return file;
+    }
+
+    public List<SchemaReferenceEntry> getReferences() {
+      return references;
+    }
+
+    public boolean hasReferences() {
+      return references != null && !references.isEmpty();
+    }
+
+    public JsonNode toJson() {
+      ObjectNode node = MAPPER.createObjectNode();
+      node.put(JSON_FORMAT, FORMAT_VERSION);
+      if (id != null) {
+        node.put(JSON_ID, id);
+      }
+      if (type != null) {
+        node.put(JSON_TYPE, type);
+      }
+      if (subject != null) {
+        node.put(JSON_SUBJECT, subject);
+      }
+      node.put(JSON_VERSION, version);
+      if (file != null) {
+        node.put(JSON_FILE, file);
+      }
+      ArrayNode arr = node.putArray(JSON_REFERENCES);
+      if (references != null) {
+        for (SchemaReferenceEntry ref : references) {
+          arr.add(ref.toJson());
+        }
+      }
+      return node;
+    }
+
+    public static SchemaEntry fromJson(JsonNode node) {
+      int format = node.path(JSON_FORMAT).asInt(0);
+      if (format > FORMAT_VERSION) {
+        throw new IllegalArgumentException(
+            "Unsupported entry.json format version " + format
+            + " (max supported: " + FORMAT_VERSION + ")");
+      }
+      if (!node.has(JSON_ID)) {
+        throw new IllegalArgumentException(
+            "Corrupt entry.json: missing required field '" + JSON_ID + "'");
+      }
+      List<SchemaReferenceEntry> refs = Collections.emptyList();
+      JsonNode refsNode = node.get(JSON_REFERENCES);
+      if (refsNode != null && refsNode.isArray()) {
+        refs = new ArrayList<>();
+        for (JsonNode refNode : refsNode) {
+          refs.add(SchemaReferenceEntry.fromJson(refNode));
+        }
+      }
+      return new SchemaEntry(
+          node.path(JSON_ID).asText(null),
+          node.path(JSON_TYPE).asText(null),
+          node.path(JSON_SUBJECT).asText(null),
+          node.path(JSON_VERSION).asInt(0),
+          node.path(JSON_FILE).asText(null),
+          refs
+      );
+    }
+
+    public String toJsonString() throws JsonProcessingException {
+      return MAPPER.writeValueAsString(toJson());
+    }
+
+    public static SchemaEntry fromJsonString(String json) throws IOException {
+      return fromJson(MAPPER.readTree(json));
+    }
+  }
+
+  public static class SchemaReferenceEntry {
+    private final String name;
+    private final String subject;
+    private final int version;
+    private final int globalId;
+
+    public SchemaReferenceEntry(
+        String name, String subject, int version, int globalId) {
+      this.name = name;
+      this.subject = subject;
+      this.version = version;
+      this.globalId = globalId;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public String getSubject() {
+      return subject;
+    }
+
+    public int getVersion() {
+      return version;
+    }
+
+    public int getGlobalId() {
+      return globalId;
+    }
+
+    public JsonNode toJson() {
+      ObjectNode node = MAPPER.createObjectNode();
+      if (name != null) {
+        node.put(JSON_NAME, name);
+      }
+      if (subject != null) {
+        node.put(JSON_SUBJECT, subject);
+      }
+      node.put(JSON_VERSION, version);
+      node.put(JSON_GLOBAL_ID, globalId);
+      return node;
+    }
+
+    public static SchemaReferenceEntry fromJson(JsonNode node) {
+      return new SchemaReferenceEntry(
+          node.path(JSON_NAME).asText(null),
+          node.path(JSON_SUBJECT).asText(null),
+          node.path(JSON_VERSION).asInt(0),
+          node.path(JSON_GLOBAL_ID).asInt(0)
+      );
+    }
+  }
+}

--- a/core/src/main/java/io/confluent/connect/storage/backup/StorageWriter.java
+++ b/core/src/main/java/io/confluent/connect/storage/backup/StorageWriter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.storage.backup;
+
+/**
+ * Abstraction for writing backup metadata (schema files, entry files)
+ * to object storage. Each storage backend provides its own implementation.
+ *
+ * <p>All writes are idempotent — same schemaId always produces same content.
+ * No CAS or versioning needed.
+ */
+public interface StorageWriter {
+
+  /**
+   * Write string content to the given path, overwriting if exists.
+   */
+  void write(String path, String content);
+
+  /**
+   * Check if a path exists in storage.
+   * Used for three-level dedup: skip writing if entry file already exists.
+   */
+  boolean exists(String path);
+}

--- a/core/src/main/java/io/confluent/connect/storage/tools/SchemaSourceConnector.java
+++ b/core/src/main/java/io/confluent/connect/storage/tools/SchemaSourceConnector.java
@@ -16,7 +16,7 @@
 package io.confluent.connect.storage.tools;
 
 import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.common.utils.AppInfoParser;
+import org.apache.kafka.common.utils.internals.AppInfoParser;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.source.SourceConnector;
 

--- a/core/src/main/java/io/confluent/connect/storage/tools/SchemaSourceConnector.java
+++ b/core/src/main/java/io/confluent/connect/storage/tools/SchemaSourceConnector.java
@@ -16,7 +16,7 @@
 package io.confluent.connect.storage.tools;
 
 import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.common.utils.internals.AppInfoParser;
+import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.source.SourceConnector;
 

--- a/core/src/test/java/io/confluent/connect/storage/StorageSinkConnectorConfigTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/StorageSinkConnectorConfigTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.storage;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class StorageSinkConnectorConfigTest {
+
+  /**
+   * Minimum props to instantiate StorageSinkConnectorConfig. FORMAT_CLASS
+   * has no default in the ConfigDef, so any test that instantiates the
+   * config must supply it.
+   */
+  private static Map<String, String> minimalProps() {
+    Map<String, String> props = new HashMap<>();
+    // format.class is Type.CLASS with no default; any loadable class name
+    // satisfies the parser. Behavior of the format is not exercised here.
+    props.put(StorageSinkConnectorConfig.FORMAT_CLASS_CONFIG,
+        "java.lang.Object");
+    props.put(StorageSinkConnectorConfig.FLUSH_SIZE_CONFIG, "1000");
+    return props;
+  }
+
+  /**
+   * Trivial no-op recommender to satisfy newConfigDef's required parameters.
+   * Tests here do not exercise recommender behavior.
+   */
+  private static ConfigDef.Recommender noOpRecommender() {
+    return new ConfigDef.Recommender() {
+      @Override
+      public List<Object> validValues(String name, Map<String, Object> parsedConfig) {
+        return Collections.emptyList();
+      }
+
+      @Override
+      public boolean visible(String name, Map<String, Object> parsedConfig) {
+        return true;
+      }
+    };
+  }
+
+  // Regression tests for the FORMAT_JSON_SCHEMA_ENABLE_CONFIG define location.
+  // Originally added to enableParquetConfig() by mistake, which meant any
+  // connector consuming just newConfigDef() would ConfigException on
+  // isJsonSchemaEmbedded(). The define now lives in newConfigDef()'s "Mode"
+  // group. These tests lock that in.
+
+  @Test
+  public void testNewConfigDefDefinesFormatJsonSchemaEnableConfig() {
+    ConfigDef configDef = StorageSinkConnectorConfig.newConfigDef(
+        noOpRecommender(), noOpRecommender());
+
+    assertTrue("newConfigDef() must define FORMAT_JSON_SCHEMA_ENABLE_CONFIG "
+        + "so that isJsonSchemaEmbedded() can read it without ConfigException",
+        configDef.configKeys().containsKey(
+            StorageSinkConnectorConfig.FORMAT_JSON_SCHEMA_ENABLE_CONFIG));
+  }
+
+  @Test
+  public void testFormatJsonSchemaEnableDefaultsToFalse() {
+    ConfigDef configDef = StorageSinkConnectorConfig.newConfigDef(
+        noOpRecommender(), noOpRecommender());
+
+    Object defaultValue = configDef.configKeys()
+        .get(StorageSinkConnectorConfig.FORMAT_JSON_SCHEMA_ENABLE_CONFIG)
+        .defaultValue;
+    assertEquals("default must be false to preserve prior behavior",
+        Boolean.FALSE, defaultValue);
+  }
+
+  @Test
+  public void testIsJsonSchemaEmbeddedReturnsDefaultFalseWhenUnset() {
+    ConfigDef configDef = StorageSinkConnectorConfig.newConfigDef(
+        noOpRecommender(), noOpRecommender());
+    StorageSinkConnectorConfig config = new StorageSinkConnectorConfig(
+        configDef, minimalProps());
+
+    assertFalse("unset property must resolve to default false, not throw",
+        config.isJsonSchemaEmbedded());
+  }
+
+  @Test
+  public void testIsJsonSchemaEmbeddedReturnsTrueWhenSet() {
+    ConfigDef configDef = StorageSinkConnectorConfig.newConfigDef(
+        noOpRecommender(), noOpRecommender());
+    Map<String, String> props = minimalProps();
+    props.put(StorageSinkConnectorConfig.FORMAT_JSON_SCHEMA_ENABLE_CONFIG, "true");
+    StorageSinkConnectorConfig config = new StorageSinkConnectorConfig(
+        configDef, props);
+
+    assertTrue("explicit true must be surfaced via isJsonSchemaEmbedded()",
+        config.isJsonSchemaEmbedded());
+  }
+}

--- a/core/src/test/java/io/confluent/connect/storage/backup/BackupEnvelopeTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/BackupEnvelopeTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.storage.backup;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class BackupEnvelopeTest {
+
+  // ── isSrBackedType — delegates to SchemaBackupConfig ─────────────────
+
+  @Test
+  public void testIsSrBackedTypeReturnsTrueForAvro() {
+    assertTrue("AVRO must be recognized as SR-backed",
+        BackupEnvelope.isSrBackedType(BackupEnvelope.TYPE_AVRO));
+  }
+
+  @Test
+  public void testIsSrBackedTypeReturnsTrueForProtobuf() {
+    assertTrue("PROTOBUF must be recognized as SR-backed",
+        BackupEnvelope.isSrBackedType(BackupEnvelope.TYPE_PROTOBUF));
+  }
+
+  @Test
+  public void testIsSrBackedTypeReturnsTrueForJsonSchema() {
+    assertTrue("JSON_SCHEMA must be recognized as SR-backed",
+        BackupEnvelope.isSrBackedType(BackupEnvelope.TYPE_JSON_SCHEMA));
+  }
+
+  @Test
+  public void testIsSrBackedTypeReturnsFalseForString() {
+    assertFalse("STRING must not be recognized as SR-backed",
+        BackupEnvelope.isSrBackedType(BackupEnvelope.TYPE_STRING));
+  }
+
+  @Test
+  public void testIsSrBackedTypeReturnsFalseForBytes() {
+    assertFalse("BYTES must not be recognized as SR-backed",
+        BackupEnvelope.isSrBackedType(BackupEnvelope.TYPE_BYTES));
+  }
+
+  @Test
+  public void testIsSrBackedTypeReturnsFalseForJsonSchemaless() {
+    assertFalse("JSON_SCHEMALESS must not be recognized as SR-backed",
+        BackupEnvelope.isSrBackedType(BackupEnvelope.TYPE_JSON_SCHEMALESS));
+  }
+
+  @Test
+  public void testIsSrBackedTypeReturnsFalseForNone() {
+    assertFalse("NONE must not be recognized as SR-backed",
+        BackupEnvelope.isSrBackedType(BackupEnvelope.TYPE_NONE));
+  }
+
+  @Test
+  public void testIsSrBackedTypeReturnsFalseForUnknown() {
+    assertFalse("UNKNOWN must not be recognized as SR-backed",
+        BackupEnvelope.isSrBackedType(BackupEnvelope.TYPE_UNKNOWN));
+  }
+
+  @Test
+  public void testIsSrBackedTypeReturnsFalseForNull() {
+    assertFalse("null must not be recognized as SR-backed",
+        BackupEnvelope.isSrBackedType(null));
+  }
+
+  // ── extensionForType — 4 branches (Avro / Protobuf / Json family / default)
+
+  @Test
+  public void testExtensionForTypeAvroReturnsAvsc() {
+    assertEquals(BackupEnvelope.EXT_AVRO,
+        BackupEnvelope.extensionForType(BackupEnvelope.TYPE_AVRO));
+  }
+
+  @Test
+  public void testExtensionForTypeProtobufReturnsProto() {
+    assertEquals(BackupEnvelope.EXT_PROTOBUF,
+        BackupEnvelope.extensionForType(BackupEnvelope.TYPE_PROTOBUF));
+  }
+
+  @Test
+  public void testExtensionForTypeJsonSchemaReturnsJson() {
+    assertEquals(BackupEnvelope.EXT_JSON,
+        BackupEnvelope.extensionForType(BackupEnvelope.TYPE_JSON_SCHEMA));
+  }
+
+  @Test
+  public void testExtensionForTypeJsonReturnsJson() {
+    assertEquals(BackupEnvelope.EXT_JSON,
+        BackupEnvelope.extensionForType(BackupEnvelope.TYPE_JSON));
+  }
+
+  @Test
+  public void testExtensionForTypeStringReturnsDefault() {
+    assertEquals("non-schema type falls back to default extension",
+        BackupEnvelope.EXT_DEFAULT,
+        BackupEnvelope.extensionForType(BackupEnvelope.TYPE_STRING));
+  }
+
+  @Test
+  public void testExtensionForTypeUnknownReturnsDefault() {
+    assertEquals(BackupEnvelope.EXT_DEFAULT,
+        BackupEnvelope.extensionForType("SOMETHING_ELSE"));
+  }
+
+  @Test
+  public void testExtensionForTypeNullReturnsDefault() {
+    assertEquals(BackupEnvelope.EXT_DEFAULT,
+        BackupEnvelope.extensionForType(null));
+  }
+}

--- a/core/src/test/java/io/confluent/connect/storage/backup/BackupEnvelopeTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/BackupEnvelopeTest.java
@@ -123,4 +123,12 @@ public class BackupEnvelopeTest {
     assertEquals(BackupEnvelope.EXT_DEFAULT,
         BackupEnvelope.extensionForType(null));
   }
+
+  @Test
+  public void testExtensionForTypeIsCaseInsensitive() {
+    assertEquals(BackupEnvelope.EXT_AVRO, BackupEnvelope.extensionForType("avro"));
+    assertEquals(BackupEnvelope.EXT_PROTOBUF, BackupEnvelope.extensionForType("Protobuf"));
+    assertEquals(BackupEnvelope.EXT_JSON, BackupEnvelope.extensionForType("json_schema"));
+    assertEquals(BackupEnvelope.EXT_JSON, BackupEnvelope.extensionForType("Json"));
+  }
 }

--- a/core/src/test/java/io/confluent/connect/storage/backup/BackupEnvelopeTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/BackupEnvelopeTest.java
@@ -15,10 +15,12 @@
 
 package io.confluent.connect.storage.backup;
 
+import org.apache.kafka.connect.errors.DataException;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class BackupEnvelopeTest {
@@ -106,22 +108,23 @@ public class BackupEnvelopeTest {
   }
 
   @Test
-  public void testExtensionForTypeStringReturnsDefault() {
-    assertEquals("non-schema type falls back to default extension",
-        BackupEnvelope.EXT_DEFAULT,
-        BackupEnvelope.extensionForType(BackupEnvelope.TYPE_STRING));
+  public void testExtensionForTypeStringThrows() {
+    DataException e = assertThrows(DataException.class,
+        () -> BackupEnvelope.extensionForType(BackupEnvelope.TYPE_STRING));
+    assertTrue(e.getMessage().contains("STRING"));
   }
 
   @Test
-  public void testExtensionForTypeUnknownReturnsDefault() {
-    assertEquals(BackupEnvelope.EXT_DEFAULT,
-        BackupEnvelope.extensionForType("SOMETHING_ELSE"));
+  public void testExtensionForTypeUnknownThrows() {
+    DataException e = assertThrows(DataException.class,
+        () -> BackupEnvelope.extensionForType("SOMETHING_ELSE"));
+    assertTrue(e.getMessage().contains("SOMETHING_ELSE"));
   }
 
   @Test
-  public void testExtensionForTypeNullReturnsDefault() {
-    assertEquals(BackupEnvelope.EXT_DEFAULT,
-        BackupEnvelope.extensionForType(null));
+  public void testExtensionForTypeNullThrows() {
+    assertThrows(DataException.class,
+        () -> BackupEnvelope.extensionForType(null));
   }
 
   @Test

--- a/core/src/test/java/io/confluent/connect/storage/backup/BackupModeValidatorTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/BackupModeValidatorTest.java
@@ -344,32 +344,11 @@ public class BackupModeValidatorTest {
   }
 
   @Test
-  public void testProtobufConverterWithoutOptionalOrWrapperExercisesWarnPath() {
-    Map<String, String> configs = baseSinkConfigs();
-    configs.put(VALUE_CONVERTER, PROTOBUF_CONVERTER);
+  public void testProtobufConverterOptionalForNullablesWarnPath() {
+    Map<String, String> configs = protobufSinkConfigs();
 
     List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
-    assertEquals(0, errors.size());
-  }
-
-  @Test
-  public void testProtobufConverterWithOptionalForNullablesExercisesWarnPath() {
-    Map<String, String> configs = baseSinkConfigs();
-    configs.put(VALUE_CONVERTER, PROTOBUF_CONVERTER);
-    configs.put("value.converter.optional.for.nullables", TRUE);
-
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
-    assertEquals(0, errors.size());
-  }
-
-  @Test
-  public void testProtobufConverterWithWrapperForNullablesExercisesWarnPath() {
-    Map<String, String> configs = baseSinkConfigs();
-    configs.put(VALUE_CONVERTER, PROTOBUF_CONVERTER);
-    configs.put("value.converter.wrapper.for.nullables", TRUE);
-
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
-    assertEquals(0, errors.size());
+    assertFalse(containsError(errors, "optional.for.nullables"));
   }
 
   @Test
@@ -555,12 +534,12 @@ public class BackupModeValidatorTest {
   }
 
   @Test
-  public void testSourceProtobufValueConverterWithoutEnhancedExercisesWarnPath() {
+  public void testSourceProtobufValueConverterWithoutEnhancedFails() {
     Map<String, String> configs = new HashMap<>();
     configs.put(VALUE_CONVERTER, PROTOBUF_CONVERTER);
 
     List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
-    assertEquals(0, errors.size());
+    assertTrue(containsError(errors, "value.converter.enhanced.protobuf.schema.support"));
   }
 
   @Test
@@ -634,5 +613,111 @@ public class BackupModeValidatorTest {
 
     List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
     assertTrue(containsError(errors, "RecordFieldTimestampExtractor"));
+  }
+
+  // ── Protobuf converter validators ────────────────────────────────
+
+  private Map<String, String> protobufSinkConfigs() {
+    Map<String, String> configs = new HashMap<>();
+    configs.put(KEY_CONVERTER, STRING_CONVERTER);
+    configs.put(VALUE_CONVERTER, PROTOBUF_CONVERTER);
+    configs.put(VALUE_SCHEMA_BACKUP_ENABLED, TRUE);
+    configs.put("value.converter.enhanced.protobuf.schema.support", TRUE);
+    configs.put("value.converter.wrapper.for.raw.primitives", FALSE);
+    return configs;
+  }
+
+  @Test
+  public void testProtobufSinkAllFlagsSetPasses() {
+    List<String> errors = BackupModeValidator.validateSinkConfigs(
+        protobufSinkConfigs(), AVRO_FORMAT, true);
+    assertFalse(containsError(errors, "protobuf"));
+    assertFalse(containsError(errors, "wrapper.for"));
+  }
+
+  @Test
+  public void testProtobufSinkWithoutEnhancedFails() {
+    Map<String, String> configs = protobufSinkConfigs();
+    configs.remove("value.converter.enhanced.protobuf.schema.support");
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertTrue(containsError(errors, "value.converter.enhanced.protobuf.schema.support"));
+  }
+
+  @Test
+  public void testProtobufSinkWrapperForRawPrimitivesUnsetFails() {
+    Map<String, String> configs = protobufSinkConfigs();
+    configs.remove("value.converter.wrapper.for.raw.primitives");
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertTrue(containsError(errors, "value.converter.wrapper.for.raw.primitives"));
+  }
+
+  @Test
+  public void testProtobufSinkWrapperForRawPrimitivesTrueFails() {
+    Map<String, String> configs = protobufSinkConfigs();
+    configs.put("value.converter.wrapper.for.raw.primitives", TRUE);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertTrue(containsError(errors, "value.converter.wrapper.for.raw.primitives"));
+  }
+
+  @Test
+  public void testProtobufSinkWrapperForNullablesTrueFails() {
+    Map<String, String> configs = protobufSinkConfigs();
+    configs.put("value.converter.wrapper.for.nullables", TRUE);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertTrue(containsError(errors, "value.converter.wrapper.for.nullables"));
+  }
+
+  @Test
+  public void testProtobufKeyConverterValidatedToo() {
+    Map<String, String> configs = protobufSinkConfigs();
+    configs.put(KEY_CONVERTER, PROTOBUF_CONVERTER);
+    configs.put(KEY_SCHEMA_BACKUP_ENABLED, TRUE);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertTrue(containsError(errors, "key.converter.enhanced.protobuf.schema.support"));
+    assertTrue(containsError(errors, "key.converter.wrapper.for.raw.primitives"));
+  }
+
+  @Test
+  public void testProtobufSourceWithoutEnhancedFails() {
+    Map<String, String> configs = new HashMap<>();
+    configs.put(VALUE_CONVERTER, PROTOBUF_CONVERTER);
+
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
+    assertTrue(containsError(errors, "value.converter.enhanced.protobuf.schema.support"));
+  }
+
+  @Test
+  public void testProtobufSourceWrapperForRawPrimitivesNotValidated() {
+    Map<String, String> configs = new HashMap<>();
+    configs.put(VALUE_CONVERTER, PROTOBUF_CONVERTER);
+    configs.put("value.converter.enhanced.protobuf.schema.support", TRUE);
+
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
+    assertFalse(containsError(errors, "wrapper.for.raw.primitives"));
+  }
+
+  @Test
+  public void testProtobufSourceWrapperForNullablesTrueFails() {
+    Map<String, String> configs = new HashMap<>();
+    configs.put(VALUE_CONVERTER, PROTOBUF_CONVERTER);
+    configs.put("value.converter.enhanced.protobuf.schema.support", TRUE);
+    configs.put("value.converter.wrapper.for.nullables", TRUE);
+
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
+    assertTrue(containsError(errors, "value.converter.wrapper.for.nullables"));
+  }
+
+  @Test
+  public void testNonProtobufConverterSkipsAllProtobufChecks() {
+    Map<String, String> configs = baseSinkConfigs();
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertFalse(containsError(errors, "protobuf"));
+    assertFalse(containsError(errors, "wrapper.for"));
   }
 }

--- a/core/src/test/java/io/confluent/connect/storage/backup/BackupModeValidatorTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/BackupModeValidatorTest.java
@@ -720,4 +720,44 @@ public class BackupModeValidatorTest {
     assertFalse(containsError(errors, "protobuf"));
     assertFalse(containsError(errors, "wrapper.for"));
   }
+
+  // ── JsonSchemaConverter json.type.allowed.packages ─────────────
+
+  @Test
+  public void testJsonSchemaConverterWithDefaultAllowedPackagesDoesNotThrow() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(VALUE_CONVERTER, JSON_SCHEMA_CONVERTER);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertFalse(containsError(errors, "json.type.allowed.packages"));
+  }
+
+  @Test
+  public void testJsonSchemaConverterWithWildcardAllowedPackagesDoesNotThrow() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(VALUE_CONVERTER, JSON_SCHEMA_CONVERTER);
+    configs.put("value.converter.json.type.allowed.packages", "*");
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertFalse(containsError(errors, "json.type.allowed.packages"));
+  }
+
+  @Test
+  public void testJsonSchemaConverterWithExplicitWhitelistDoesNotThrow() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(VALUE_CONVERTER, JSON_SCHEMA_CONVERTER);
+    configs.put("value.converter.json.type.allowed.packages", "com.example.models");
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertFalse(containsError(errors, "json.type.allowed.packages"));
+  }
+
+  @Test
+  public void testJsonSchemaConverterSourceSideExercisesWarn() {
+    Map<String, String> configs = new HashMap<>();
+    configs.put(VALUE_CONVERTER, JSON_SCHEMA_CONVERTER);
+
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
+    assertFalse(containsError(errors, "json.type.allowed.packages"));
+  }
 }

--- a/core/src/test/java/io/confluent/connect/storage/backup/BackupModeValidatorTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/BackupModeValidatorTest.java
@@ -477,11 +477,40 @@ public class BackupModeValidatorTest {
   @Test
   public void testValidSourceConfigProducesZeroErrors() {
     Map<String, String> configs = new HashMap<>();
+    configs.put(KEY_CONVERTER, STRING_CONVERTER);
     configs.put(VALUE_CONVERTER, AVRO_CONVERTER);
     configs.put(VALUE_ENHANCED_AVRO, TRUE);
 
     List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
     assertEquals(0, errors.size());
+  }
+
+  @Test
+  public void testSourceMissingKeyConverterFails() {
+    Map<String, String> configs = new HashMap<>();
+    configs.put(VALUE_CONVERTER, AVRO_CONVERTER);
+    configs.put(VALUE_ENHANCED_AVRO, TRUE);
+
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
+    assertTrue(containsError(errors, ERR_KEY_CONVERTER_UNSET));
+  }
+
+  @Test
+  public void testSourceMissingValueConverterFails() {
+    Map<String, String> configs = new HashMap<>();
+    configs.put(KEY_CONVERTER, STRING_CONVERTER);
+
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
+    assertTrue(containsError(errors, ERR_VALUE_CONVERTER_UNSET));
+  }
+
+  @Test
+  public void testSourceMissingBothConvertersFails() {
+    Map<String, String> configs = new HashMap<>();
+
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
+    assertTrue(containsError(errors, ERR_KEY_CONVERTER_UNSET));
+    assertTrue(containsError(errors, ERR_VALUE_CONVERTER_UNSET));
   }
 
   @Test

--- a/core/src/test/java/io/confluent/connect/storage/backup/BackupModeValidatorTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/BackupModeValidatorTest.java
@@ -290,6 +290,7 @@ public class BackupModeValidatorTest {
   public void testJsonSchemaConverterWithNonAvroFormatSkipsRecommendation() {
     Map<String, String> configs = baseSinkConfigs();
     configs.put(VALUE_CONVERTER, JSON_SCHEMA_CONVERTER);
+    configs.put(PARQUET_CODEC, "none");
 
     List<String> errors = BackupModeValidator.validateSinkConfigs(configs, PARQUET_FORMAT, true);
     assertEquals(0, errors.size());
@@ -306,18 +307,48 @@ public class BackupModeValidatorTest {
   }
 
   @Test
-  public void testParquetFormatWithCodecTriggersWarnPath() {
+  public void testParquetFormatWithSnappyCodecFails() {
     Map<String, String> configs = baseSinkConfigs();
     configs.put(PARQUET_CODEC, "snappy");
 
     List<String> errors = BackupModeValidator.validateSinkConfigs(configs, PARQUET_FORMAT, true);
-    assertEquals(0, errors.size());
+    assertEquals(1, errors.size());
+    assertTrue(errors.get(0).contains("parquet.codec=snappy"));
+  }
+
+  @Test
+  public void testParquetFormatWithGzipCodecFails() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(PARQUET_CODEC, "gzip");
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, PARQUET_FORMAT, true);
+    assertEquals(1, errors.size());
+    assertTrue(errors.get(0).contains("parquet.codec=gzip"));
+  }
+
+  @Test
+  public void testParquetFormatWithUnsetCodecFails() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.remove(PARQUET_CODEC);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, PARQUET_FORMAT, true);
+    assertEquals(1, errors.size());
+    assertTrue(errors.get(0).contains("snappy (default)"));
   }
 
   @Test
   public void testParquetFormatWithNoneCodecPasses() {
     Map<String, String> configs = baseSinkConfigs();
     configs.put(PARQUET_CODEC, "none");
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, PARQUET_FORMAT, true);
+    assertEquals(0, errors.size());
+  }
+
+  @Test
+  public void testParquetFormatWithNoneCodecCaseInsensitivePasses() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(PARQUET_CODEC, "NONE");
 
     List<String> errors = BackupModeValidator.validateSinkConfigs(configs, PARQUET_FORMAT, true);
     assertEquals(0, errors.size());

--- a/core/src/test/java/io/confluent/connect/storage/backup/BackupModeValidatorTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/BackupModeValidatorTest.java
@@ -79,6 +79,7 @@ public class BackupModeValidatorTest {
     configs.put(KEY_CONVERTER, STRING_CONVERTER);
     configs.put(VALUE_CONVERTER, AVRO_CONVERTER);
     configs.put(VALUE_SCHEMA_BACKUP_ENABLED, TRUE);
+    configs.put("value.converter.enhanced.avro.schema.support", TRUE);
     return configs;
   }
 
@@ -204,9 +205,40 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = baseSinkConfigs();
     configs.put(KEY_CONVERTER, AVRO_CONVERTER);
     configs.put(KEY_SCHEMA_BACKUP_ENABLED, TRUE);
+    configs.put("key.converter.enhanced.avro.schema.support", TRUE);
 
     List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
     assertFalse(containsError(errors, "schema.backup.enabled"));
+  }
+
+  @Test
+  public void testSinkAvroValueConverterWithoutEnhancedFails() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.remove("value.converter.enhanced.avro.schema.support");
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertTrue(containsError(errors, "value.converter.enhanced.avro.schema.support"));
+  }
+
+  @Test
+  public void testSinkAvroKeyConverterWithoutEnhancedFails() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(KEY_CONVERTER, AVRO_CONVERTER);
+    configs.put(KEY_SCHEMA_BACKUP_ENABLED, TRUE);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertTrue(containsError(errors, "key.converter.enhanced.avro.schema.support"));
+  }
+
+  @Test
+  public void testSinkNonAvroConverterSkipsEnhancedCheck() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(VALUE_CONVERTER, STRING_CONVERTER);
+    configs.remove("value.converter.enhanced.avro.schema.support");
+    configs.remove(VALUE_SCHEMA_BACKUP_ENABLED);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertFalse(containsError(errors, "enhanced.avro.schema.support"));
   }
 
   @Test

--- a/core/src/test/java/io/confluent/connect/storage/backup/BackupModeValidatorTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/BackupModeValidatorTest.java
@@ -81,6 +81,9 @@ public class BackupModeValidatorTest {
   private static final String TRUE = "true";
   private static final String FALSE = "false";
 
+  private static final String SINK_MODE = "BACKUP_FULL_RECORD";
+  private static final String SOURCE_MODE = "RESTORE_BACKUP_FULL_RECORD";
+
   private static final String ERR_STORE_KAFKA_KEYS_TRUE = "store.kafka.keys=true";
   private static final String ERR_STORE_KAFKA_HEADERS_TRUE = "store.kafka.headers=true";
   private static final String ERR_SR_BACKED_VALUE = "value.converter uses SR-backed converter";
@@ -105,7 +108,7 @@ public class BackupModeValidatorTest {
 
   @Test
   public void testValidSinkConfigProducesZeroErrors() {
-    List<String> errors = BackupModeValidator.validateSinkConfigs(baseSinkConfigs(), AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(baseSinkConfigs(), AVRO_FORMAT, true, SINK_MODE);
     assertEquals(0, errors.size());
   }
 
@@ -114,7 +117,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = baseSinkConfigs();
     configs.remove(KEY_CONVERTER);
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertTrue(containsError(errors, ERR_KEY_CONVERTER_UNSET));
   }
 
@@ -123,7 +126,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = baseSinkConfigs();
     configs.remove(VALUE_CONVERTER);
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertTrue(containsError(errors, ERR_VALUE_CONVERTER_UNSET));
   }
 
@@ -133,38 +136,38 @@ public class BackupModeValidatorTest {
     configs.remove(KEY_CONVERTER);
     configs.remove(VALUE_CONVERTER);
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertTrue(containsError(errors, ERR_KEY_CONVERTER_UNSET));
     assertTrue(containsError(errors, ERR_VALUE_CONVERTER_UNSET));
   }
 
   @Test
   public void testByteArrayFormatSinkIsRejected() {
-    List<String> errors = BackupModeValidator.validateSinkConfigs(baseSinkConfigs(), BYTE_ARRAY_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(baseSinkConfigs(), BYTE_ARRAY_FORMAT, true, SINK_MODE);
     assertTrue(containsError(errors, BYTE_ARRAY_FORMAT));
   }
 
   @Test
   public void testAvroFormatSinkPassesFormatCheck() {
-    List<String> errors = BackupModeValidator.validateSinkConfigs(baseSinkConfigs(), AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(baseSinkConfigs(), AVRO_FORMAT, true, SINK_MODE);
     assertFalse(containsError(errors, BYTE_ARRAY_FORMAT));
   }
 
   @Test
   public void testJsonFormatWithoutSchemaEnableIsRejected() {
-    List<String> errors = BackupModeValidator.validateSinkConfigs(baseSinkConfigs(), JSON_FORMAT, false);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(baseSinkConfigs(), JSON_FORMAT, false, SINK_MODE);
     assertTrue(containsError(errors, ERR_JSON_SCHEMA_ENABLE));
   }
 
   @Test
   public void testJsonFormatWithSchemaEnableIsAccepted() {
-    List<String> errors = BackupModeValidator.validateSinkConfigs(baseSinkConfigs(), JSON_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(baseSinkConfigs(), JSON_FORMAT, true, SINK_MODE);
     assertFalse(containsError(errors, ERR_JSON_SCHEMA_ENABLE));
   }
 
   @Test
   public void testNonJsonFormatIgnoresSchemaEnableFlag() {
-    List<String> errors = BackupModeValidator.validateSinkConfigs(baseSinkConfigs(), AVRO_FORMAT, false);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(baseSinkConfigs(), AVRO_FORMAT, false, SINK_MODE);
     assertFalse(containsError(errors, ERR_JSON_SCHEMA_ENABLE));
   }
 
@@ -173,7 +176,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = baseSinkConfigs();
     configs.remove(VALUE_SCHEMA_BACKUP_ENABLED);
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertTrue(containsError(errors, ERR_SR_BACKED_VALUE));
   }
 
@@ -183,7 +186,7 @@ public class BackupModeValidatorTest {
     configs.put(VALUE_CONVERTER, PROTOBUF_CONVERTER);
     configs.remove(VALUE_SCHEMA_BACKUP_ENABLED);
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertTrue(containsError(errors, ERR_SR_BACKED_VALUE));
   }
 
@@ -193,7 +196,7 @@ public class BackupModeValidatorTest {
     configs.put(VALUE_CONVERTER, STRING_CONVERTER);
     configs.remove(VALUE_SCHEMA_BACKUP_ENABLED);
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertFalse(containsError(errors, "schema.backup.enabled"));
   }
 
@@ -202,7 +205,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = baseSinkConfigs();
     configs.put(KEY_CONVERTER, AVRO_CONVERTER);
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertTrue(containsError(errors, ERR_SR_BACKED_KEY));
   }
 
@@ -211,7 +214,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = baseSinkConfigs();
     configs.put(KEY_CONVERTER, AVRO_CONVERTER);
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertTrue(containsError(errors, ERR_SR_BACKED_KEY));
     assertFalse(containsError(errors, ERR_SR_BACKED_VALUE));
   }
@@ -223,7 +226,7 @@ public class BackupModeValidatorTest {
     configs.put(KEY_SCHEMA_BACKUP_ENABLED, TRUE);
     configs.put(KEY_ENHANCED_AVRO, TRUE);
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertFalse(containsError(errors, "schema.backup.enabled"));
   }
 
@@ -232,7 +235,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = baseSinkConfigs();
     configs.remove(VALUE_ENHANCED_AVRO);
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertTrue(containsError(errors, VALUE_ENHANCED_AVRO));
   }
 
@@ -242,7 +245,7 @@ public class BackupModeValidatorTest {
     configs.put(KEY_CONVERTER, AVRO_CONVERTER);
     configs.put(KEY_SCHEMA_BACKUP_ENABLED, TRUE);
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertTrue(containsError(errors, KEY_ENHANCED_AVRO));
   }
 
@@ -253,7 +256,7 @@ public class BackupModeValidatorTest {
     configs.remove(VALUE_ENHANCED_AVRO);
     configs.remove(VALUE_SCHEMA_BACKUP_ENABLED);
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertFalse(containsError(errors, "enhanced.avro.schema.support"));
   }
 
@@ -262,7 +265,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = baseSinkConfigs();
     configs.put(TRANSFORMS, "myTransform");
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertTrue(containsError(errors, ERR_TRANSFORMS));
   }
 
@@ -271,13 +274,13 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = baseSinkConfigs();
     configs.put(TRANSFORMS, "   ");
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertFalse(containsError(errors, ERR_TRANSFORMS));
   }
 
   @Test
   public void testTransformsAbsentIsAccepted() {
-    List<String> errors = BackupModeValidator.validateSinkConfigs(baseSinkConfigs(), AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(baseSinkConfigs(), AVRO_FORMAT, true, SINK_MODE);
     assertFalse(containsError(errors, ERR_TRANSFORMS));
   }
 
@@ -286,7 +289,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = baseSinkConfigs();
     configs.put(STORE_KAFKA_KEYS, TRUE);
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertTrue(containsError(errors, ERR_STORE_KAFKA_KEYS_TRUE));
   }
 
@@ -295,7 +298,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = baseSinkConfigs();
     configs.put(STORE_KAFKA_HEADERS, TRUE);
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertTrue(containsError(errors, ERR_STORE_KAFKA_HEADERS_TRUE));
   }
 
@@ -304,7 +307,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = baseSinkConfigs();
     configs.put(STORE_KAFKA_KEYS, FALSE);
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertFalse(containsError(errors, STORE_KAFKA_KEYS));
   }
 
@@ -313,13 +316,13 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = baseSinkConfigs();
     configs.put(STORE_KAFKA_HEADERS, FALSE);
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertFalse(containsError(errors, STORE_KAFKA_HEADERS));
   }
 
   @Test
   public void testStoreKafkaKeysAbsentIsAccepted() {
-    List<String> errors = BackupModeValidator.validateSinkConfigs(baseSinkConfigs(), AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(baseSinkConfigs(), AVRO_FORMAT, true, SINK_MODE);
     assertFalse(containsError(errors, STORE_KAFKA_KEYS));
   }
 
@@ -329,7 +332,7 @@ public class BackupModeValidatorTest {
     configs.put(STORE_KAFKA_KEYS, TRUE);
     configs.put(STORE_KAFKA_HEADERS, TRUE);
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertTrue(containsError(errors, ERR_STORE_KAFKA_KEYS_TRUE));
     assertTrue(containsError(errors, ERR_STORE_KAFKA_HEADERS_TRUE));
   }
@@ -339,7 +342,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = baseSinkConfigs();
     configs.put(STORE_KAFKA_KEYS, TRUE);
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertTrue(errors.stream().anyMatch(e ->
         e.contains(ERR_STORE_KAFKA_KEYS_TRUE) && e.contains("Envelope")));
   }
@@ -348,7 +351,7 @@ public class BackupModeValidatorTest {
   public void testProtobufConverterOptionalForNullablesWarnPath() {
     Map<String, String> configs = protobufSinkConfigs();
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertFalse(containsError(errors, "optional.for.nullables"));
   }
 
@@ -357,7 +360,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = baseSinkConfigs();
     configs.put(VALUE_CONVERTER, JSON_SCHEMA_CONVERTER);
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertEquals(0, errors.size());
   }
 
@@ -367,7 +370,7 @@ public class BackupModeValidatorTest {
     configs.put(VALUE_CONVERTER, JSON_SCHEMA_CONVERTER);
     configs.put(PARQUET_CODEC, "none");
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, PARQUET_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, PARQUET_FORMAT, true, SINK_MODE);
     assertEquals(0, errors.size());
   }
 
@@ -377,7 +380,7 @@ public class BackupModeValidatorTest {
     configs.put(VALUE_CONVERTER, STRING_CONVERTER);
     configs.remove(VALUE_SCHEMA_BACKUP_ENABLED);
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertEquals(0, errors.size());
   }
 
@@ -386,7 +389,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = baseSinkConfigs();
     configs.put(PARQUET_CODEC, "snappy");
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, PARQUET_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, PARQUET_FORMAT, true, SINK_MODE);
     assertEquals(1, errors.size());
     assertTrue(errors.get(0).contains("parquet.codec=snappy"));
   }
@@ -396,7 +399,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = baseSinkConfigs();
     configs.put(PARQUET_CODEC, "gzip");
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, PARQUET_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, PARQUET_FORMAT, true, SINK_MODE);
     assertEquals(1, errors.size());
     assertTrue(errors.get(0).contains("parquet.codec=gzip"));
   }
@@ -406,7 +409,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = baseSinkConfigs();
     configs.remove(PARQUET_CODEC);
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, PARQUET_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, PARQUET_FORMAT, true, SINK_MODE);
     assertEquals(1, errors.size());
     assertTrue(errors.get(0).contains("snappy (default)"));
   }
@@ -416,7 +419,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = baseSinkConfigs();
     configs.put(PARQUET_CODEC, "none");
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, PARQUET_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, PARQUET_FORMAT, true, SINK_MODE);
     assertEquals(0, errors.size());
   }
 
@@ -425,7 +428,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = baseSinkConfigs();
     configs.put(PARQUET_CODEC, "NONE");
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, PARQUET_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, PARQUET_FORMAT, true, SINK_MODE);
     assertEquals(0, errors.size());
   }
 
@@ -434,7 +437,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = baseSinkConfigs();
     configs.put(PARQUET_CODEC, "snappy");
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertEquals(0, errors.size());
   }
 
@@ -443,7 +446,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = baseSinkConfigs();
     configs.put(HEADER_CONVERTER, BYTE_ARRAY_CONVERTER);
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertEquals(0, errors.size());
   }
 
@@ -452,7 +455,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = baseSinkConfigs();
     configs.put(HEADER_CONVERTER, SIMPLE_HEADER_CONVERTER);
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertEquals(0, errors.size());
   }
 
@@ -461,7 +464,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = baseSinkConfigs();
     configs.put(SCHEMA_COMPATIBILITY, "NONE");
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertEquals(0, errors.size());
   }
 
@@ -470,7 +473,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = baseSinkConfigs();
     configs.put(SCHEMA_COMPATIBILITY, "BACKWARD");
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertEquals(0, errors.size());
   }
 
@@ -481,7 +484,7 @@ public class BackupModeValidatorTest {
     configs.put(VALUE_CONVERTER, AVRO_CONVERTER);
     configs.put(VALUE_ENHANCED_AVRO, TRUE);
 
-    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, SOURCE_MODE);
     assertEquals(0, errors.size());
   }
 
@@ -491,7 +494,7 @@ public class BackupModeValidatorTest {
     configs.put(VALUE_CONVERTER, AVRO_CONVERTER);
     configs.put(VALUE_ENHANCED_AVRO, TRUE);
 
-    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, SOURCE_MODE);
     assertTrue(containsError(errors, ERR_KEY_CONVERTER_UNSET));
   }
 
@@ -500,7 +503,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = new HashMap<>();
     configs.put(KEY_CONVERTER, STRING_CONVERTER);
 
-    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, SOURCE_MODE);
     assertTrue(containsError(errors, ERR_VALUE_CONVERTER_UNSET));
   }
 
@@ -508,7 +511,7 @@ public class BackupModeValidatorTest {
   public void testSourceMissingBothConvertersFails() {
     Map<String, String> configs = new HashMap<>();
 
-    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, SOURCE_MODE);
     assertTrue(containsError(errors, ERR_KEY_CONVERTER_UNSET));
     assertTrue(containsError(errors, ERR_VALUE_CONVERTER_UNSET));
   }
@@ -519,7 +522,7 @@ public class BackupModeValidatorTest {
     configs.put(VALUE_CONVERTER, AVRO_CONVERTER);
     configs.put(VALUE_ENHANCED_AVRO, TRUE);
 
-    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, BYTE_ARRAY_FORMAT);
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, BYTE_ARRAY_FORMAT, SOURCE_MODE);
     assertTrue(containsError(errors, BYTE_ARRAY_FORMAT));
   }
 
@@ -528,7 +531,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = new HashMap<>();
     configs.put(VALUE_CONVERTER, AVRO_CONVERTER);
 
-    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, SOURCE_MODE);
     assertTrue(containsError(errors, VALUE_ENHANCED_AVRO));
   }
 
@@ -538,7 +541,7 @@ public class BackupModeValidatorTest {
     configs.put(KEY_CONVERTER, AVRO_CONVERTER);
     configs.put(VALUE_CONVERTER, STRING_CONVERTER);
 
-    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, SOURCE_MODE);
     assertTrue(containsError(errors, KEY_ENHANCED_AVRO));
   }
 
@@ -547,8 +550,43 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = new HashMap<>();
     configs.put(VALUE_CONVERTER, STRING_CONVERTER);
 
-    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, SOURCE_MODE);
     assertFalse(containsError(errors, "enhanced.avro.schema.support"));
+  }
+
+  @Test
+  public void testSourceTransformsSetIsRejected() {
+    Map<String, String> configs = new HashMap<>();
+    configs.put(KEY_CONVERTER, STRING_CONVERTER);
+    configs.put(VALUE_CONVERTER, AVRO_CONVERTER);
+    configs.put(VALUE_ENHANCED_AVRO, TRUE);
+    configs.put(TRANSFORMS, "myTransform");
+
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, SOURCE_MODE);
+    assertTrue(containsError(errors, ERR_TRANSFORMS));
+  }
+
+  @Test
+  public void testSourceTransformsAbsentIsAccepted() {
+    Map<String, String> configs = new HashMap<>();
+    configs.put(KEY_CONVERTER, STRING_CONVERTER);
+    configs.put(VALUE_CONVERTER, AVRO_CONVERTER);
+    configs.put(VALUE_ENHANCED_AVRO, TRUE);
+
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, SOURCE_MODE);
+    assertFalse(containsError(errors, ERR_TRANSFORMS));
+  }
+
+  @Test
+  public void testSourceTransformsWhitespaceIsAccepted() {
+    Map<String, String> configs = new HashMap<>();
+    configs.put(KEY_CONVERTER, STRING_CONVERTER);
+    configs.put(VALUE_CONVERTER, AVRO_CONVERTER);
+    configs.put(VALUE_ENHANCED_AVRO, TRUE);
+    configs.put(TRANSFORMS, "   ");
+
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, SOURCE_MODE);
+    assertFalse(containsError(errors, ERR_TRANSFORMS));
   }
 
   @Test
@@ -566,7 +604,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = baseSinkConfigs();
     configs.put(PARTITIONER_CLASS, DEFAULT_PARTITIONER);
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertFalse(containsError(errors, PARTITIONER_CLASS));
   }
 
@@ -575,7 +613,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = baseSinkConfigs();
     configs.put(PARTITIONER_CLASS, TIME_BASED_PARTITIONER);
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertFalse(containsError(errors, PARTITIONER_CLASS));
   }
 
@@ -584,7 +622,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = baseSinkConfigs();
     configs.put(PARTITIONER_CLASS, FIELD_PARTITIONER);
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertTrue(containsError(errors, "FieldPartitioner"));
   }
 
@@ -593,14 +631,14 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = baseSinkConfigs();
     configs.put(PARTITIONER_CLASS, "com.example.CustomPartitioner");
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertTrue(containsError(errors, "com.example.CustomPartitioner"));
   }
 
   @Test
   public void testUnsetPartitionerPasses() {
     List<String> errors = BackupModeValidator.validateSinkConfigs(
-        baseSinkConfigs(), AVRO_FORMAT, true);
+        baseSinkConfigs(), AVRO_FORMAT, true, SINK_MODE);
     assertFalse(containsError(errors, PARTITIONER_CLASS));
   }
 
@@ -610,7 +648,7 @@ public class BackupModeValidatorTest {
     configs.put(PARTITIONER_CLASS, TIME_BASED_PARTITIONER);
     configs.put(TIMESTAMP_EXTRACTOR, WALLCLOCK_EXTRACTOR);
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertFalse(containsError(errors, TIMESTAMP_EXTRACTOR));
   }
 
@@ -620,7 +658,7 @@ public class BackupModeValidatorTest {
     configs.put(PARTITIONER_CLASS, TIME_BASED_PARTITIONER);
     configs.put(TIMESTAMP_EXTRACTOR, RECORD_FIELD_EXTRACTOR);
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertTrue(containsError(errors, "RecordFieldTimestampExtractor"));
   }
 
@@ -630,7 +668,7 @@ public class BackupModeValidatorTest {
     configs.put(PARTITIONER_CLASS, TIME_BASED_PARTITIONER);
     configs.put(TIMESTAMP_EXTRACTOR, "RecordField");
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertTrue(containsError(errors, "timestamp.extractor=RecordField"));
   }
 
@@ -649,7 +687,7 @@ public class BackupModeValidatorTest {
   @Test
   public void testProtobufSinkAllFlagsSetPasses() {
     List<String> errors = BackupModeValidator.validateSinkConfigs(
-        protobufSinkConfigs(), AVRO_FORMAT, true);
+        protobufSinkConfigs(), AVRO_FORMAT, true, SINK_MODE);
     assertFalse(containsError(errors, "protobuf"));
     assertFalse(containsError(errors, "wrapper.for"));
   }
@@ -659,7 +697,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = protobufSinkConfigs();
     configs.remove(VALUE_ENHANCED_PROTOBUF);
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertTrue(containsError(errors, VALUE_ENHANCED_PROTOBUF));
   }
 
@@ -668,7 +706,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = protobufSinkConfigs();
     configs.remove(VALUE_WRAPPER_FOR_RAW);
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertTrue(containsError(errors, VALUE_WRAPPER_FOR_RAW));
   }
 
@@ -677,7 +715,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = protobufSinkConfigs();
     configs.put(VALUE_WRAPPER_FOR_RAW, TRUE);
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertTrue(containsError(errors, VALUE_WRAPPER_FOR_RAW));
   }
 
@@ -686,7 +724,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = protobufSinkConfigs();
     configs.put(VALUE_WRAPPER_FOR_NULLABLES, TRUE);
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertTrue(containsError(errors, VALUE_WRAPPER_FOR_NULLABLES));
   }
 
@@ -696,7 +734,7 @@ public class BackupModeValidatorTest {
     configs.put(KEY_CONVERTER, PROTOBUF_CONVERTER);
     configs.put(KEY_SCHEMA_BACKUP_ENABLED, TRUE);
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertTrue(containsError(errors, KEY_ENHANCED_PROTOBUF));
     assertTrue(containsError(errors, KEY_WRAPPER_FOR_RAW));
   }
@@ -706,7 +744,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = new HashMap<>();
     configs.put(VALUE_CONVERTER, PROTOBUF_CONVERTER);
 
-    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, SOURCE_MODE);
     assertTrue(containsError(errors, VALUE_ENHANCED_PROTOBUF));
   }
 
@@ -716,7 +754,7 @@ public class BackupModeValidatorTest {
     configs.put(VALUE_CONVERTER, PROTOBUF_CONVERTER);
     configs.put(VALUE_ENHANCED_PROTOBUF, TRUE);
 
-    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, SOURCE_MODE);
     assertFalse(containsError(errors, "wrapper.for.raw.primitives"));
   }
 
@@ -727,7 +765,7 @@ public class BackupModeValidatorTest {
     configs.put(VALUE_ENHANCED_PROTOBUF, TRUE);
     configs.put(VALUE_WRAPPER_FOR_NULLABLES, TRUE);
 
-    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, SOURCE_MODE);
     assertTrue(containsError(errors, VALUE_WRAPPER_FOR_NULLABLES));
   }
 
@@ -735,7 +773,7 @@ public class BackupModeValidatorTest {
   public void testNonProtobufConverterSkipsAllProtobufChecks() {
     Map<String, String> configs = baseSinkConfigs();
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertFalse(containsError(errors, "protobuf"));
     assertFalse(containsError(errors, "wrapper.for"));
   }
@@ -747,7 +785,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = baseSinkConfigs();
     configs.put(VALUE_CONVERTER, JSON_SCHEMA_CONVERTER);
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertFalse(containsError(errors, JSON_TYPE_ALLOWED_PACKAGES));
   }
 
@@ -757,7 +795,7 @@ public class BackupModeValidatorTest {
     configs.put(VALUE_CONVERTER, JSON_SCHEMA_CONVERTER);
     configs.put("value.converter.json.type.allowed.packages", "*");
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertFalse(containsError(errors, JSON_TYPE_ALLOWED_PACKAGES));
   }
 
@@ -767,7 +805,7 @@ public class BackupModeValidatorTest {
     configs.put(VALUE_CONVERTER, JSON_SCHEMA_CONVERTER);
     configs.put("value.converter.json.type.allowed.packages", "com.example.models");
 
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true, SINK_MODE);
     assertFalse(containsError(errors, JSON_TYPE_ALLOWED_PACKAGES));
   }
 
@@ -776,7 +814,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = new HashMap<>();
     configs.put(VALUE_CONVERTER, JSON_SCHEMA_CONVERTER);
 
-    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, SOURCE_MODE);
     assertFalse(containsError(errors, JSON_TYPE_ALLOWED_PACKAGES));
   }
 }

--- a/core/src/test/java/io/confluent/connect/storage/backup/BackupModeValidatorTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/BackupModeValidatorTest.java
@@ -1,0 +1,403 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.storage.backup;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class BackupModeValidatorTest {
+
+  private static final String AVRO_CONVERTER = "io.confluent.connect.avro.AvroConverter";
+  private static final String PROTOBUF_CONVERTER = "io.confluent.connect.protobuf.ProtobufConverter";
+  private static final String JSON_SCHEMA_CONVERTER = "io.confluent.connect.json.JsonSchemaConverter";
+  private static final String STRING_CONVERTER = "org.apache.kafka.connect.storage.StringConverter";
+  private static final String BYTE_ARRAY_CONVERTER = "org.apache.kafka.connect.converters.ByteArrayConverter";
+  private static final String SIMPLE_HEADER_CONVERTER = "org.apache.kafka.connect.storage.SimpleHeaderConverter";
+
+  private static final String AVRO_FORMAT = "AvroFormat";
+  private static final String JSON_FORMAT = "JsonFormat";
+  private static final String PARQUET_FORMAT = "ParquetFormat";
+  private static final String BYTE_ARRAY_FORMAT = "ByteArrayFormat";
+
+  private static final String KEY_CONVERTER = "key.converter";
+  private static final String VALUE_CONVERTER = "value.converter";
+  private static final String KEY_SCHEMA_BACKUP_ENABLED = "key.converter.schema.backup.enabled";
+  private static final String VALUE_SCHEMA_BACKUP_ENABLED = "value.converter.schema.backup.enabled";
+  private static final String STORE_KAFKA_KEYS = "store.kafka.keys";
+  private static final String STORE_KAFKA_HEADERS = "store.kafka.headers";
+  private static final String TRANSFORMS = "transforms";
+  private static final String HEADER_CONVERTER = "header.converter";
+  private static final String PARQUET_CODEC = "parquet.codec";
+
+  private static final String TRUE = "true";
+  private static final String FALSE = "false";
+
+  private static final String ERR_STORE_KAFKA_KEYS_TRUE = "store.kafka.keys=true";
+  private static final String ERR_STORE_KAFKA_HEADERS_TRUE = "store.kafka.headers=true";
+  private static final String ERR_SR_BACKED_VALUE = "value.converter uses SR-backed converter";
+  private static final String ERR_SR_BACKED_KEY = "key.converter uses SR-backed converter";
+  private static final String ERR_TRANSFORMS = "Single Message Transforms";
+  private static final String ERR_JSON_SCHEMA_ENABLE = "format.json.schema.enable=true is required";
+
+  private Map<String, String> baseSinkConfigs() {
+    Map<String, String> configs = new HashMap<>();
+    configs.put(KEY_CONVERTER, STRING_CONVERTER);
+    configs.put(VALUE_CONVERTER, AVRO_CONVERTER);
+    configs.put(VALUE_SCHEMA_BACKUP_ENABLED, TRUE);
+    return configs;
+  }
+
+  private static boolean containsError(List<String> errors, String snippet) {
+    return errors.stream().anyMatch(e -> e.contains(snippet));
+  }
+
+  @Test
+  public void testValidSinkConfigProducesZeroErrors() {
+    List<String> errors = BackupModeValidator.validateSinkConfigs(baseSinkConfigs(), AVRO_FORMAT, true);
+    assertEquals(0, errors.size());
+  }
+
+  @Test
+  public void testByteArrayFormatSinkIsRejected() {
+    List<String> errors = BackupModeValidator.validateSinkConfigs(baseSinkConfigs(), BYTE_ARRAY_FORMAT, true);
+    assertTrue(containsError(errors, BYTE_ARRAY_FORMAT));
+  }
+
+  @Test
+  public void testAvroFormatSinkPassesFormatCheck() {
+    List<String> errors = BackupModeValidator.validateSinkConfigs(baseSinkConfigs(), AVRO_FORMAT, true);
+    assertFalse(containsError(errors, BYTE_ARRAY_FORMAT));
+  }
+
+  @Test
+  public void testJsonFormatWithoutSchemaEnableIsRejected() {
+    List<String> errors = BackupModeValidator.validateSinkConfigs(baseSinkConfigs(), JSON_FORMAT, false);
+    assertTrue(containsError(errors, ERR_JSON_SCHEMA_ENABLE));
+  }
+
+  @Test
+  public void testJsonFormatWithSchemaEnableIsAccepted() {
+    List<String> errors = BackupModeValidator.validateSinkConfigs(baseSinkConfigs(), JSON_FORMAT, true);
+    assertFalse(containsError(errors, ERR_JSON_SCHEMA_ENABLE));
+  }
+
+  @Test
+  public void testNonJsonFormatIgnoresSchemaEnableFlag() {
+    List<String> errors = BackupModeValidator.validateSinkConfigs(baseSinkConfigs(), AVRO_FORMAT, false);
+    assertFalse(containsError(errors, ERR_JSON_SCHEMA_ENABLE));
+  }
+
+  @Test
+  public void testAvroValueConverterWithoutSchemaBackupEnabledIsRejected() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.remove(VALUE_SCHEMA_BACKUP_ENABLED);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertTrue(containsError(errors, ERR_SR_BACKED_VALUE));
+  }
+
+  @Test
+  public void testProtobufValueConverterWithoutSchemaBackupEnabledIsRejected() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(VALUE_CONVERTER, PROTOBUF_CONVERTER);
+    configs.remove(VALUE_SCHEMA_BACKUP_ENABLED);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertTrue(containsError(errors, ERR_SR_BACKED_VALUE));
+  }
+
+  @Test
+  public void testStringValueConverterSkipsSchemaBackupCheck() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(VALUE_CONVERTER, STRING_CONVERTER);
+    configs.remove(VALUE_SCHEMA_BACKUP_ENABLED);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertFalse(containsError(errors, "schema.backup.enabled"));
+  }
+
+  @Test
+  public void testAvroKeyConverterWithoutSchemaBackupEnabledIsRejected() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(KEY_CONVERTER, AVRO_CONVERTER);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertTrue(containsError(errors, ERR_SR_BACKED_KEY));
+  }
+
+  @Test
+  public void testTransformsSetIsRejected() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(TRANSFORMS, "myTransform");
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertTrue(containsError(errors, ERR_TRANSFORMS));
+  }
+
+  @Test
+  public void testTransformsWhitespaceIsAccepted() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(TRANSFORMS, "   ");
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertFalse(containsError(errors, ERR_TRANSFORMS));
+  }
+
+  @Test
+  public void testTransformsAbsentIsAccepted() {
+    List<String> errors = BackupModeValidator.validateSinkConfigs(baseSinkConfigs(), AVRO_FORMAT, true);
+    assertFalse(containsError(errors, ERR_TRANSFORMS));
+  }
+
+  @Test
+  public void testStoreKafkaKeysTrueIsRejected() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(STORE_KAFKA_KEYS, TRUE);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertTrue(containsError(errors, ERR_STORE_KAFKA_KEYS_TRUE));
+  }
+
+  @Test
+  public void testStoreKafkaHeadersTrueIsRejected() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(STORE_KAFKA_HEADERS, TRUE);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertTrue(containsError(errors, ERR_STORE_KAFKA_HEADERS_TRUE));
+  }
+
+  @Test
+  public void testStoreKafkaKeysFalseIsAccepted() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(STORE_KAFKA_KEYS, FALSE);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertFalse(containsError(errors, STORE_KAFKA_KEYS));
+  }
+
+  @Test
+  public void testStoreKafkaHeadersFalseIsAccepted() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(STORE_KAFKA_HEADERS, FALSE);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertFalse(containsError(errors, STORE_KAFKA_HEADERS));
+  }
+
+  @Test
+  public void testStoreKafkaKeysAbsentIsAccepted() {
+    List<String> errors = BackupModeValidator.validateSinkConfigs(baseSinkConfigs(), AVRO_FORMAT, true);
+    assertFalse(containsError(errors, STORE_KAFKA_KEYS));
+  }
+
+  @Test
+  public void testStoreKafkaKeysAndHeadersBothTrueBothRejected() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(STORE_KAFKA_KEYS, TRUE);
+    configs.put(STORE_KAFKA_HEADERS, TRUE);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertTrue(containsError(errors, ERR_STORE_KAFKA_KEYS_TRUE));
+    assertTrue(containsError(errors, ERR_STORE_KAFKA_HEADERS_TRUE));
+  }
+
+  @Test
+  public void testStoreKafkaKeysErrorMentionsEnvelopeCaptures() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(STORE_KAFKA_KEYS, TRUE);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertTrue(errors.stream().anyMatch(e ->
+        e.contains(ERR_STORE_KAFKA_KEYS_TRUE) && e.contains("Envelope")));
+  }
+
+  @Test
+  public void testAvroConverterWithoutEnhancedSchemaSupportExercisesWarnPath() {
+    List<String> errors = BackupModeValidator.validateSinkConfigs(baseSinkConfigs(), AVRO_FORMAT, true);
+    assertEquals(0, errors.size());
+  }
+
+  @Test
+  public void testAvroConverterWithEnhancedSchemaSupportExercisesWarnPath() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put("value.converter.enhanced.avro.schema.support", TRUE);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertEquals(0, errors.size());
+  }
+
+  @Test
+  public void testProtobufConverterWithoutOptionalOrWrapperExercisesWarnPath() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(VALUE_CONVERTER, PROTOBUF_CONVERTER);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertEquals(0, errors.size());
+  }
+
+  @Test
+  public void testProtobufConverterWithOptionalForNullablesExercisesWarnPath() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(VALUE_CONVERTER, PROTOBUF_CONVERTER);
+    configs.put("value.converter.optional.for.nullables", TRUE);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertEquals(0, errors.size());
+  }
+
+  @Test
+  public void testProtobufConverterWithWrapperForNullablesExercisesWarnPath() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(VALUE_CONVERTER, PROTOBUF_CONVERTER);
+    configs.put("value.converter.wrapper.for.nullables", TRUE);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertEquals(0, errors.size());
+  }
+
+  @Test
+  public void testJsonSchemaConverterWithAvroFormatExercisesWarnPath() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(VALUE_CONVERTER, JSON_SCHEMA_CONVERTER);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertEquals(0, errors.size());
+  }
+
+  @Test
+  public void testJsonSchemaConverterWithNonAvroFormatSkipsRecommendation() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(VALUE_CONVERTER, JSON_SCHEMA_CONVERTER);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, PARQUET_FORMAT, true);
+    assertEquals(0, errors.size());
+  }
+
+  @Test
+  public void testStringValueConverterExercisesWarnPath() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(VALUE_CONVERTER, STRING_CONVERTER);
+    configs.remove(VALUE_SCHEMA_BACKUP_ENABLED);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertEquals(0, errors.size());
+  }
+
+  @Test
+  public void testParquetFormatWithCodecTriggersWarnPath() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(PARQUET_CODEC, "snappy");
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, PARQUET_FORMAT, true);
+    assertEquals(0, errors.size());
+  }
+
+  @Test
+  public void testParquetFormatWithNoneCodecPasses() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(PARQUET_CODEC, "none");
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, PARQUET_FORMAT, true);
+    assertEquals(0, errors.size());
+  }
+
+  @Test
+  public void testNonParquetFormatIgnoresParquetCodec() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(PARQUET_CODEC, "snappy");
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertEquals(0, errors.size());
+  }
+
+  @Test
+  public void testByteArrayHeaderConverterPassesHeaderCheck() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(HEADER_CONVERTER, BYTE_ARRAY_CONVERTER);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertEquals(0, errors.size());
+  }
+
+  @Test
+  public void testAbsentHeaderConverterExercisesInfoLog() {
+    List<String> errors = BackupModeValidator.validateSinkConfigs(baseSinkConfigs(), AVRO_FORMAT, true);
+    assertEquals(0, errors.size());
+  }
+
+  @Test
+  public void testCustomHeaderConverterExercisesInfoLog() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(HEADER_CONVERTER, SIMPLE_HEADER_CONVERTER);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertEquals(0, errors.size());
+  }
+
+  @Test
+  public void testValidSourceConfigProducesZeroErrors() {
+    Map<String, String> configs = new HashMap<>();
+    configs.put(VALUE_CONVERTER, AVRO_CONVERTER);
+
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
+    assertEquals(0, errors.size());
+  }
+
+  @Test
+  public void testByteArrayFormatSourceIsRejected() {
+    Map<String, String> configs = new HashMap<>();
+    configs.put(VALUE_CONVERTER, AVRO_CONVERTER);
+
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, BYTE_ARRAY_FORMAT);
+    assertTrue(containsError(errors, BYTE_ARRAY_FORMAT));
+  }
+
+  @Test
+  public void testSourceAvroValueConverterWithoutEnhancedExercisesWarnPath() {
+    Map<String, String> configs = new HashMap<>();
+    configs.put(VALUE_CONVERTER, AVRO_CONVERTER);
+
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
+    assertEquals(0, errors.size());
+  }
+
+  @Test
+  public void testSourceProtobufValueConverterWithoutEnhancedExercisesWarnPath() {
+    Map<String, String> configs = new HashMap<>();
+    configs.put(VALUE_CONVERTER, PROTOBUF_CONVERTER);
+
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
+    assertEquals(0, errors.size());
+  }
+
+  @Test
+  public void testLogSinkStartupSummaryDoesNotThrow() {
+    BackupModeValidator.logSinkStartupSummary(baseSinkConfigs(), AVRO_FORMAT, "STRING", "AVRO");
+  }
+
+  @Test
+  public void testLogSinkStartupSummaryWithNullConvertersDoesNotThrow() {
+    BackupModeValidator.logSinkStartupSummary(new HashMap<>(), AVRO_FORMAT, "NONE", "NONE");
+  }
+}

--- a/core/src/test/java/io/confluent/connect/storage/backup/BackupModeValidatorTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/BackupModeValidatorTest.java
@@ -59,6 +59,8 @@ public class BackupModeValidatorTest {
   private static final String ERR_SR_BACKED_KEY = "key.converter uses SR-backed converter";
   private static final String ERR_TRANSFORMS = "Single Message Transforms";
   private static final String ERR_JSON_SCHEMA_ENABLE = "format.json.schema.enable=true is required";
+  private static final String ERR_KEY_CONVERTER_UNSET = "key.converter must be set explicitly";
+  private static final String ERR_VALUE_CONVERTER_UNSET = "value.converter must be set explicitly";
 
   private Map<String, String> baseSinkConfigs() {
     Map<String, String> configs = new HashMap<>();
@@ -76,6 +78,35 @@ public class BackupModeValidatorTest {
   public void testValidSinkConfigProducesZeroErrors() {
     List<String> errors = BackupModeValidator.validateSinkConfigs(baseSinkConfigs(), AVRO_FORMAT, true);
     assertEquals(0, errors.size());
+  }
+
+  @Test
+  public void testUnsetKeyConverterFails() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.remove(KEY_CONVERTER);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertTrue(containsError(errors, ERR_KEY_CONVERTER_UNSET));
+  }
+
+  @Test
+  public void testUnsetValueConverterFails() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.remove(VALUE_CONVERTER);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertTrue(containsError(errors, ERR_VALUE_CONVERTER_UNSET));
+  }
+
+  @Test
+  public void testUnsetBothConvertersFailsBoth() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.remove(KEY_CONVERTER);
+    configs.remove(VALUE_CONVERTER);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertTrue(containsError(errors, ERR_KEY_CONVERTER_UNSET));
+    assertTrue(containsError(errors, ERR_VALUE_CONVERTER_UNSET));
   }
 
   @Test

--- a/core/src/test/java/io/confluent/connect/storage/backup/BackupModeValidatorTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/BackupModeValidatorTest.java
@@ -345,21 +345,6 @@ public class BackupModeValidatorTest {
   }
 
   @Test
-  public void testAvroConverterWithoutEnhancedSchemaSupportExercisesWarnPath() {
-    List<String> errors = BackupModeValidator.validateSinkConfigs(baseSinkConfigs(), AVRO_FORMAT, true);
-    assertEquals(0, errors.size());
-  }
-
-  @Test
-  public void testAvroConverterWithEnhancedSchemaSupportExercisesWarnPath() {
-    Map<String, String> configs = baseSinkConfigs();
-    configs.put(VALUE_ENHANCED_AVRO, TRUE);
-
-    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
-    assertEquals(0, errors.size());
-  }
-
-  @Test
   public void testProtobufConverterOptionalForNullablesWarnPath() {
     Map<String, String> configs = protobufSinkConfigs();
 
@@ -463,12 +448,6 @@ public class BackupModeValidatorTest {
   }
 
   @Test
-  public void testAbsentHeaderConverterExercisesInfoLog() {
-    List<String> errors = BackupModeValidator.validateSinkConfigs(baseSinkConfigs(), AVRO_FORMAT, true);
-    assertEquals(0, errors.size());
-  }
-
-  @Test
   public void testCustomHeaderConverterExercisesInfoLog() {
     Map<String, String> configs = baseSinkConfigs();
     configs.put(HEADER_CONVERTER, SIMPLE_HEADER_CONVERTER);
@@ -492,12 +471,6 @@ public class BackupModeValidatorTest {
     configs.put(SCHEMA_COMPATIBILITY, "BACKWARD");
 
     List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
-    assertEquals(0, errors.size());
-  }
-
-  @Test
-  public void testSchemaCompatibilityAbsentExercisesWarnPath() {
-    List<String> errors = BackupModeValidator.validateSinkConfigs(baseSinkConfigs(), AVRO_FORMAT, true);
     assertEquals(0, errors.size());
   }
 
@@ -547,15 +520,6 @@ public class BackupModeValidatorTest {
 
     List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
     assertFalse(containsError(errors, "enhanced.avro.schema.support"));
-  }
-
-  @Test
-  public void testSourceProtobufValueConverterWithoutEnhancedFails() {
-    Map<String, String> configs = new HashMap<>();
-    configs.put(VALUE_CONVERTER, PROTOBUF_CONVERTER);
-
-    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
-    assertTrue(containsError(errors, VALUE_ENHANCED_PROTOBUF));
   }
 
   @Test
@@ -618,7 +582,7 @@ public class BackupModeValidatorTest {
     configs.put(TIMESTAMP_EXTRACTOR, WALLCLOCK_EXTRACTOR);
 
     List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
-    assertFalse(containsError(errors, "timestamp.extractor"));
+    assertFalse(containsError(errors, TIMESTAMP_EXTRACTOR));
   }
 
   @Test

--- a/core/src/test/java/io/confluent/connect/storage/backup/BackupModeValidatorTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/BackupModeValidatorTest.java
@@ -484,7 +484,7 @@ public class BackupModeValidatorTest {
     configs.put(VALUE_CONVERTER, AVRO_CONVERTER);
     configs.put(VALUE_ENHANCED_AVRO, TRUE);
 
-    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, SOURCE_MODE);
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, true, SOURCE_MODE);
     assertEquals(0, errors.size());
   }
 
@@ -494,7 +494,7 @@ public class BackupModeValidatorTest {
     configs.put(VALUE_CONVERTER, AVRO_CONVERTER);
     configs.put(VALUE_ENHANCED_AVRO, TRUE);
 
-    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, SOURCE_MODE);
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, true, SOURCE_MODE);
     assertTrue(containsError(errors, ERR_KEY_CONVERTER_UNSET));
   }
 
@@ -503,7 +503,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = new HashMap<>();
     configs.put(KEY_CONVERTER, STRING_CONVERTER);
 
-    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, SOURCE_MODE);
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, true, SOURCE_MODE);
     assertTrue(containsError(errors, ERR_VALUE_CONVERTER_UNSET));
   }
 
@@ -511,7 +511,7 @@ public class BackupModeValidatorTest {
   public void testSourceMissingBothConvertersFails() {
     Map<String, String> configs = new HashMap<>();
 
-    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, SOURCE_MODE);
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, true, SOURCE_MODE);
     assertTrue(containsError(errors, ERR_KEY_CONVERTER_UNSET));
     assertTrue(containsError(errors, ERR_VALUE_CONVERTER_UNSET));
   }
@@ -522,7 +522,7 @@ public class BackupModeValidatorTest {
     configs.put(VALUE_CONVERTER, AVRO_CONVERTER);
     configs.put(VALUE_ENHANCED_AVRO, TRUE);
 
-    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, BYTE_ARRAY_FORMAT, SOURCE_MODE);
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, BYTE_ARRAY_FORMAT, true, SOURCE_MODE);
     assertTrue(containsError(errors, BYTE_ARRAY_FORMAT));
   }
 
@@ -531,7 +531,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = new HashMap<>();
     configs.put(VALUE_CONVERTER, AVRO_CONVERTER);
 
-    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, SOURCE_MODE);
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, true, SOURCE_MODE);
     assertTrue(containsError(errors, VALUE_ENHANCED_AVRO));
   }
 
@@ -541,7 +541,7 @@ public class BackupModeValidatorTest {
     configs.put(KEY_CONVERTER, AVRO_CONVERTER);
     configs.put(VALUE_CONVERTER, STRING_CONVERTER);
 
-    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, SOURCE_MODE);
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, true, SOURCE_MODE);
     assertTrue(containsError(errors, KEY_ENHANCED_AVRO));
   }
 
@@ -550,7 +550,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = new HashMap<>();
     configs.put(VALUE_CONVERTER, STRING_CONVERTER);
 
-    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, SOURCE_MODE);
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, true, SOURCE_MODE);
     assertFalse(containsError(errors, "enhanced.avro.schema.support"));
   }
 
@@ -562,7 +562,7 @@ public class BackupModeValidatorTest {
     configs.put(VALUE_ENHANCED_AVRO, TRUE);
     configs.put(TRANSFORMS, "myTransform");
 
-    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, SOURCE_MODE);
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, true, SOURCE_MODE);
     assertTrue(containsError(errors, ERR_TRANSFORMS));
   }
 
@@ -573,7 +573,7 @@ public class BackupModeValidatorTest {
     configs.put(VALUE_CONVERTER, AVRO_CONVERTER);
     configs.put(VALUE_ENHANCED_AVRO, TRUE);
 
-    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, SOURCE_MODE);
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, true, SOURCE_MODE);
     assertFalse(containsError(errors, ERR_TRANSFORMS));
   }
 
@@ -585,8 +585,58 @@ public class BackupModeValidatorTest {
     configs.put(VALUE_ENHANCED_AVRO, TRUE);
     configs.put(TRANSFORMS, "   ");
 
-    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, SOURCE_MODE);
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, true, SOURCE_MODE);
     assertFalse(containsError(errors, ERR_TRANSFORMS));
+  }
+
+  @Test
+  public void testSourceJsonFormatWithoutSchemaEnableIsRejected() {
+    Map<String, String> configs = new HashMap<>();
+    configs.put(KEY_CONVERTER, STRING_CONVERTER);
+    configs.put(VALUE_CONVERTER, AVRO_CONVERTER);
+    configs.put(VALUE_ENHANCED_AVRO, TRUE);
+
+    List<String> errors =
+        BackupModeValidator.validateSourceConfigs(configs, JSON_FORMAT, false, SOURCE_MODE);
+    assertTrue(containsError(errors, ERR_JSON_SCHEMA_ENABLE));
+  }
+
+  @Test
+  public void testSourceJsonFormatWithSchemaEnableIsAccepted() {
+    Map<String, String> configs = new HashMap<>();
+    configs.put(KEY_CONVERTER, STRING_CONVERTER);
+    configs.put(VALUE_CONVERTER, AVRO_CONVERTER);
+    configs.put(VALUE_ENHANCED_AVRO, TRUE);
+
+    List<String> errors =
+        BackupModeValidator.validateSourceConfigs(configs, JSON_FORMAT, true, SOURCE_MODE);
+    assertFalse(containsError(errors, ERR_JSON_SCHEMA_ENABLE));
+  }
+
+  @Test
+  public void testSourceNonJsonFormatIgnoresSchemaEnable() {
+    Map<String, String> configs = new HashMap<>();
+    configs.put(KEY_CONVERTER, STRING_CONVERTER);
+    configs.put(VALUE_CONVERTER, AVRO_CONVERTER);
+    configs.put(VALUE_ENHANCED_AVRO, TRUE);
+
+    List<String> errors =
+        BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, false, SOURCE_MODE);
+    assertFalse(containsError(errors, ERR_JSON_SCHEMA_ENABLE));
+  }
+
+  @Test
+  public void testSourceFileMetadataHeadersEnabledDoesNotFail() {
+    Map<String, String> configs = new HashMap<>();
+    configs.put(KEY_CONVERTER, STRING_CONVERTER);
+    configs.put(VALUE_CONVERTER, AVRO_CONVERTER);
+    configs.put(VALUE_ENHANCED_AVRO, TRUE);
+    configs.put("file.metadata.headers.enable", TRUE);
+
+    List<String> errors =
+        BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, true, SOURCE_MODE);
+    // Warn-only: no error produced. Log side effect verified by absence of failure.
+    assertEquals(0, errors.size());
   }
 
   @Test
@@ -744,7 +794,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = new HashMap<>();
     configs.put(VALUE_CONVERTER, PROTOBUF_CONVERTER);
 
-    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, SOURCE_MODE);
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, true, SOURCE_MODE);
     assertTrue(containsError(errors, VALUE_ENHANCED_PROTOBUF));
   }
 
@@ -754,7 +804,7 @@ public class BackupModeValidatorTest {
     configs.put(VALUE_CONVERTER, PROTOBUF_CONVERTER);
     configs.put(VALUE_ENHANCED_PROTOBUF, TRUE);
 
-    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, SOURCE_MODE);
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, true, SOURCE_MODE);
     assertFalse(containsError(errors, "wrapper.for.raw.primitives"));
   }
 
@@ -765,7 +815,7 @@ public class BackupModeValidatorTest {
     configs.put(VALUE_ENHANCED_PROTOBUF, TRUE);
     configs.put(VALUE_WRAPPER_FOR_NULLABLES, TRUE);
 
-    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, SOURCE_MODE);
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, true, SOURCE_MODE);
     assertTrue(containsError(errors, VALUE_WRAPPER_FOR_NULLABLES));
   }
 
@@ -814,7 +864,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = new HashMap<>();
     configs.put(VALUE_CONVERTER, JSON_SCHEMA_CONVERTER);
 
-    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, SOURCE_MODE);
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT, true, SOURCE_MODE);
     assertFalse(containsError(errors, JSON_TYPE_ALLOWED_PACKAGES));
   }
 }

--- a/core/src/test/java/io/confluent/connect/storage/backup/BackupModeValidatorTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/BackupModeValidatorTest.java
@@ -615,6 +615,16 @@ public class BackupModeValidatorTest {
     assertTrue(containsError(errors, "RecordFieldTimestampExtractor"));
   }
 
+  @Test
+  public void testRecordFieldTimestampExtractorShortNameIsRejected() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(PARTITIONER_CLASS, TIME_BASED_PARTITIONER);
+    configs.put(TIMESTAMP_EXTRACTOR, "RecordField");
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertTrue(containsError(errors, "timestamp.extractor=RecordField"));
+  }
+
   // ── Protobuf converter validators ────────────────────────────────
 
   private Map<String, String> protobufSinkConfigs() {

--- a/core/src/test/java/io/confluent/connect/storage/backup/BackupModeValidatorTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/BackupModeValidatorTest.java
@@ -48,6 +48,18 @@ public class BackupModeValidatorTest {
   private static final String TRANSFORMS = "transforms";
   private static final String HEADER_CONVERTER = "header.converter";
   private static final String PARQUET_CODEC = "parquet.codec";
+  private static final String PARTITIONER_CLASS = "partitioner.class";
+  private static final String TIMESTAMP_EXTRACTOR = "timestamp.extractor";
+  private static final String DEFAULT_PARTITIONER =
+      "io.confluent.connect.storage.partitioner.DefaultPartitioner";
+  private static final String TIME_BASED_PARTITIONER =
+      "io.confluent.connect.storage.partitioner.TimeBasedPartitioner";
+  private static final String FIELD_PARTITIONER =
+      "io.confluent.connect.storage.partitioner.FieldPartitioner";
+  private static final String RECORD_FIELD_EXTRACTOR =
+      "io.confluent.connect.storage.partitioner.TimeBasedPartitioner$RecordFieldTimestampExtractor";
+  private static final String WALLCLOCK_EXTRACTOR =
+      "io.confluent.connect.storage.partitioner.TimeBasedPartitioner$WallclockTimestampExtractor";
   private static final String SCHEMA_COMPATIBILITY = "schema.compatibility";
 
   private static final String TRUE = "true";
@@ -506,5 +518,68 @@ public class BackupModeValidatorTest {
   @Test
   public void testLogSinkStartupSummaryWithNullConvertersDoesNotThrow() {
     BackupModeValidator.logSinkStartupSummary(new HashMap<>(), AVRO_FORMAT, "NONE", "NONE");
+  }
+
+  @Test
+  public void testDefaultPartitionerPasses() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(PARTITIONER_CLASS, DEFAULT_PARTITIONER);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertFalse(containsError(errors, "partitioner.class"));
+  }
+
+  @Test
+  public void testTimeBasedPartitionerPasses() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(PARTITIONER_CLASS, TIME_BASED_PARTITIONER);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertFalse(containsError(errors, "partitioner.class"));
+  }
+
+  @Test
+  public void testFieldPartitionerIsRejected() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(PARTITIONER_CLASS, FIELD_PARTITIONER);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertTrue(containsError(errors, "FieldPartitioner"));
+  }
+
+  @Test
+  public void testCustomPartitionerIsRejected() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(PARTITIONER_CLASS, "com.example.CustomPartitioner");
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertTrue(containsError(errors, "com.example.CustomPartitioner"));
+  }
+
+  @Test
+  public void testUnsetPartitionerPasses() {
+    List<String> errors = BackupModeValidator.validateSinkConfigs(
+        baseSinkConfigs(), AVRO_FORMAT, true);
+    assertFalse(containsError(errors, "partitioner.class"));
+  }
+
+  @Test
+  public void testWallclockTimestampExtractorPasses() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(PARTITIONER_CLASS, TIME_BASED_PARTITIONER);
+    configs.put(TIMESTAMP_EXTRACTOR, WALLCLOCK_EXTRACTOR);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertFalse(containsError(errors, "timestamp.extractor"));
+  }
+
+  @Test
+  public void testRecordFieldTimestampExtractorIsRejected() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(PARTITIONER_CLASS, TIME_BASED_PARTITIONER);
+    configs.put(TIMESTAMP_EXTRACTOR, RECORD_FIELD_EXTRACTOR);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertTrue(containsError(errors, "RecordFieldTimestampExtractor"));
   }
 }

--- a/core/src/test/java/io/confluent/connect/storage/backup/BackupModeValidatorTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/BackupModeValidatorTest.java
@@ -48,6 +48,7 @@ public class BackupModeValidatorTest {
   private static final String TRANSFORMS = "transforms";
   private static final String HEADER_CONVERTER = "header.converter";
   private static final String PARQUET_CODEC = "parquet.codec";
+  private static final String SCHEMA_COMPATIBILITY = "schema.compatibility";
 
   private static final String TRUE = "true";
   private static final String FALSE = "false";
@@ -352,6 +353,30 @@ public class BackupModeValidatorTest {
     configs.put(HEADER_CONVERTER, SIMPLE_HEADER_CONVERTER);
 
     List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertEquals(0, errors.size());
+  }
+
+  @Test
+  public void testSchemaCompatibilityNoneExercisesWarnPath() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(SCHEMA_COMPATIBILITY, "NONE");
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertEquals(0, errors.size());
+  }
+
+  @Test
+  public void testSchemaCompatibilityBackwardExercisesWarnPath() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(SCHEMA_COMPATIBILITY, "BACKWARD");
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertEquals(0, errors.size());
+  }
+
+  @Test
+  public void testSchemaCompatibilityAbsentExercisesWarnPath() {
+    List<String> errors = BackupModeValidator.validateSinkConfigs(baseSinkConfigs(), AVRO_FORMAT, true);
     assertEquals(0, errors.size());
   }
 

--- a/core/src/test/java/io/confluent/connect/storage/backup/BackupModeValidatorTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/BackupModeValidatorTest.java
@@ -178,6 +178,26 @@ public class BackupModeValidatorTest {
   }
 
   @Test
+  public void testValueHasFlagKeyDoesNotFailsOnlyKey() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(KEY_CONVERTER, AVRO_CONVERTER);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertTrue(containsError(errors, ERR_SR_BACKED_KEY));
+    assertFalse(containsError(errors, ERR_SR_BACKED_VALUE));
+  }
+
+  @Test
+  public void testBothSrBackedBothHaveFlagPasses() {
+    Map<String, String> configs = baseSinkConfigs();
+    configs.put(KEY_CONVERTER, AVRO_CONVERTER);
+    configs.put(KEY_SCHEMA_BACKUP_ENABLED, TRUE);
+
+    List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
+    assertFalse(containsError(errors, "schema.backup.enabled"));
+  }
+
+  @Test
   public void testTransformsSetIsRejected() {
     Map<String, String> configs = baseSinkConfigs();
     configs.put(TRANSFORMS, "myTransform");

--- a/core/src/test/java/io/confluent/connect/storage/backup/BackupModeValidatorTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/BackupModeValidatorTest.java
@@ -50,6 +50,22 @@ public class BackupModeValidatorTest {
   private static final String PARQUET_CODEC = "parquet.codec";
   private static final String PARTITIONER_CLASS = "partitioner.class";
   private static final String TIMESTAMP_EXTRACTOR = "timestamp.extractor";
+  private static final String VALUE_ENHANCED_AVRO =
+      "value.converter.enhanced.avro.schema.support";
+  private static final String KEY_ENHANCED_AVRO =
+      "key.converter.enhanced.avro.schema.support";
+  private static final String VALUE_ENHANCED_PROTOBUF =
+      "value.converter.enhanced.protobuf.schema.support";
+  private static final String KEY_ENHANCED_PROTOBUF =
+      "key.converter.enhanced.protobuf.schema.support";
+  private static final String VALUE_WRAPPER_FOR_RAW =
+      "value.converter.wrapper.for.raw.primitives";
+  private static final String KEY_WRAPPER_FOR_RAW =
+      "key.converter.wrapper.for.raw.primitives";
+  private static final String VALUE_WRAPPER_FOR_NULLABLES =
+      "value.converter.wrapper.for.nullables";
+  private static final String JSON_TYPE_ALLOWED_PACKAGES =
+      "json.type.allowed.packages";
   private static final String DEFAULT_PARTITIONER =
       "io.confluent.connect.storage.partitioner.DefaultPartitioner";
   private static final String TIME_BASED_PARTITIONER =
@@ -79,7 +95,7 @@ public class BackupModeValidatorTest {
     configs.put(KEY_CONVERTER, STRING_CONVERTER);
     configs.put(VALUE_CONVERTER, AVRO_CONVERTER);
     configs.put(VALUE_SCHEMA_BACKUP_ENABLED, TRUE);
-    configs.put("value.converter.enhanced.avro.schema.support", TRUE);
+    configs.put(VALUE_ENHANCED_AVRO, TRUE);
     return configs;
   }
 
@@ -205,7 +221,7 @@ public class BackupModeValidatorTest {
     Map<String, String> configs = baseSinkConfigs();
     configs.put(KEY_CONVERTER, AVRO_CONVERTER);
     configs.put(KEY_SCHEMA_BACKUP_ENABLED, TRUE);
-    configs.put("key.converter.enhanced.avro.schema.support", TRUE);
+    configs.put(KEY_ENHANCED_AVRO, TRUE);
 
     List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
     assertFalse(containsError(errors, "schema.backup.enabled"));
@@ -214,10 +230,10 @@ public class BackupModeValidatorTest {
   @Test
   public void testSinkAvroValueConverterWithoutEnhancedFails() {
     Map<String, String> configs = baseSinkConfigs();
-    configs.remove("value.converter.enhanced.avro.schema.support");
+    configs.remove(VALUE_ENHANCED_AVRO);
 
     List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
-    assertTrue(containsError(errors, "value.converter.enhanced.avro.schema.support"));
+    assertTrue(containsError(errors, VALUE_ENHANCED_AVRO));
   }
 
   @Test
@@ -227,14 +243,14 @@ public class BackupModeValidatorTest {
     configs.put(KEY_SCHEMA_BACKUP_ENABLED, TRUE);
 
     List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
-    assertTrue(containsError(errors, "key.converter.enhanced.avro.schema.support"));
+    assertTrue(containsError(errors, KEY_ENHANCED_AVRO));
   }
 
   @Test
   public void testSinkNonAvroConverterSkipsEnhancedCheck() {
     Map<String, String> configs = baseSinkConfigs();
     configs.put(VALUE_CONVERTER, STRING_CONVERTER);
-    configs.remove("value.converter.enhanced.avro.schema.support");
+    configs.remove(VALUE_ENHANCED_AVRO);
     configs.remove(VALUE_SCHEMA_BACKUP_ENABLED);
 
     List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
@@ -337,7 +353,7 @@ public class BackupModeValidatorTest {
   @Test
   public void testAvroConverterWithEnhancedSchemaSupportExercisesWarnPath() {
     Map<String, String> configs = baseSinkConfigs();
-    configs.put("value.converter.enhanced.avro.schema.support", TRUE);
+    configs.put(VALUE_ENHANCED_AVRO, TRUE);
 
     List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
     assertEquals(0, errors.size());
@@ -489,7 +505,7 @@ public class BackupModeValidatorTest {
   public void testValidSourceConfigProducesZeroErrors() {
     Map<String, String> configs = new HashMap<>();
     configs.put(VALUE_CONVERTER, AVRO_CONVERTER);
-    configs.put("value.converter.enhanced.avro.schema.support", TRUE);
+    configs.put(VALUE_ENHANCED_AVRO, TRUE);
 
     List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
     assertEquals(0, errors.size());
@@ -499,7 +515,7 @@ public class BackupModeValidatorTest {
   public void testByteArrayFormatSourceIsRejected() {
     Map<String, String> configs = new HashMap<>();
     configs.put(VALUE_CONVERTER, AVRO_CONVERTER);
-    configs.put("value.converter.enhanced.avro.schema.support", TRUE);
+    configs.put(VALUE_ENHANCED_AVRO, TRUE);
 
     List<String> errors = BackupModeValidator.validateSourceConfigs(configs, BYTE_ARRAY_FORMAT);
     assertTrue(containsError(errors, BYTE_ARRAY_FORMAT));
@@ -511,7 +527,7 @@ public class BackupModeValidatorTest {
     configs.put(VALUE_CONVERTER, AVRO_CONVERTER);
 
     List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
-    assertTrue(containsError(errors, "value.converter.enhanced.avro.schema.support"));
+    assertTrue(containsError(errors, VALUE_ENHANCED_AVRO));
   }
 
   @Test
@@ -521,7 +537,7 @@ public class BackupModeValidatorTest {
     configs.put(VALUE_CONVERTER, STRING_CONVERTER);
 
     List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
-    assertTrue(containsError(errors, "key.converter.enhanced.avro.schema.support"));
+    assertTrue(containsError(errors, KEY_ENHANCED_AVRO));
   }
 
   @Test
@@ -539,7 +555,7 @@ public class BackupModeValidatorTest {
     configs.put(VALUE_CONVERTER, PROTOBUF_CONVERTER);
 
     List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
-    assertTrue(containsError(errors, "value.converter.enhanced.protobuf.schema.support"));
+    assertTrue(containsError(errors, VALUE_ENHANCED_PROTOBUF));
   }
 
   @Test
@@ -558,7 +574,7 @@ public class BackupModeValidatorTest {
     configs.put(PARTITIONER_CLASS, DEFAULT_PARTITIONER);
 
     List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
-    assertFalse(containsError(errors, "partitioner.class"));
+    assertFalse(containsError(errors, PARTITIONER_CLASS));
   }
 
   @Test
@@ -567,7 +583,7 @@ public class BackupModeValidatorTest {
     configs.put(PARTITIONER_CLASS, TIME_BASED_PARTITIONER);
 
     List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
-    assertFalse(containsError(errors, "partitioner.class"));
+    assertFalse(containsError(errors, PARTITIONER_CLASS));
   }
 
   @Test
@@ -592,7 +608,7 @@ public class BackupModeValidatorTest {
   public void testUnsetPartitionerPasses() {
     List<String> errors = BackupModeValidator.validateSinkConfigs(
         baseSinkConfigs(), AVRO_FORMAT, true);
-    assertFalse(containsError(errors, "partitioner.class"));
+    assertFalse(containsError(errors, PARTITIONER_CLASS));
   }
 
   @Test
@@ -632,8 +648,8 @@ public class BackupModeValidatorTest {
     configs.put(KEY_CONVERTER, STRING_CONVERTER);
     configs.put(VALUE_CONVERTER, PROTOBUF_CONVERTER);
     configs.put(VALUE_SCHEMA_BACKUP_ENABLED, TRUE);
-    configs.put("value.converter.enhanced.protobuf.schema.support", TRUE);
-    configs.put("value.converter.wrapper.for.raw.primitives", FALSE);
+    configs.put(VALUE_ENHANCED_PROTOBUF, TRUE);
+    configs.put(VALUE_WRAPPER_FOR_RAW, FALSE);
     return configs;
   }
 
@@ -648,37 +664,37 @@ public class BackupModeValidatorTest {
   @Test
   public void testProtobufSinkWithoutEnhancedFails() {
     Map<String, String> configs = protobufSinkConfigs();
-    configs.remove("value.converter.enhanced.protobuf.schema.support");
+    configs.remove(VALUE_ENHANCED_PROTOBUF);
 
     List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
-    assertTrue(containsError(errors, "value.converter.enhanced.protobuf.schema.support"));
+    assertTrue(containsError(errors, VALUE_ENHANCED_PROTOBUF));
   }
 
   @Test
   public void testProtobufSinkWrapperForRawPrimitivesUnsetFails() {
     Map<String, String> configs = protobufSinkConfigs();
-    configs.remove("value.converter.wrapper.for.raw.primitives");
+    configs.remove(VALUE_WRAPPER_FOR_RAW);
 
     List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
-    assertTrue(containsError(errors, "value.converter.wrapper.for.raw.primitives"));
+    assertTrue(containsError(errors, VALUE_WRAPPER_FOR_RAW));
   }
 
   @Test
   public void testProtobufSinkWrapperForRawPrimitivesTrueFails() {
     Map<String, String> configs = protobufSinkConfigs();
-    configs.put("value.converter.wrapper.for.raw.primitives", TRUE);
+    configs.put(VALUE_WRAPPER_FOR_RAW, TRUE);
 
     List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
-    assertTrue(containsError(errors, "value.converter.wrapper.for.raw.primitives"));
+    assertTrue(containsError(errors, VALUE_WRAPPER_FOR_RAW));
   }
 
   @Test
   public void testProtobufSinkWrapperForNullablesTrueFails() {
     Map<String, String> configs = protobufSinkConfigs();
-    configs.put("value.converter.wrapper.for.nullables", TRUE);
+    configs.put(VALUE_WRAPPER_FOR_NULLABLES, TRUE);
 
     List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
-    assertTrue(containsError(errors, "value.converter.wrapper.for.nullables"));
+    assertTrue(containsError(errors, VALUE_WRAPPER_FOR_NULLABLES));
   }
 
   @Test
@@ -688,8 +704,8 @@ public class BackupModeValidatorTest {
     configs.put(KEY_SCHEMA_BACKUP_ENABLED, TRUE);
 
     List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
-    assertTrue(containsError(errors, "key.converter.enhanced.protobuf.schema.support"));
-    assertTrue(containsError(errors, "key.converter.wrapper.for.raw.primitives"));
+    assertTrue(containsError(errors, KEY_ENHANCED_PROTOBUF));
+    assertTrue(containsError(errors, KEY_WRAPPER_FOR_RAW));
   }
 
   @Test
@@ -698,14 +714,14 @@ public class BackupModeValidatorTest {
     configs.put(VALUE_CONVERTER, PROTOBUF_CONVERTER);
 
     List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
-    assertTrue(containsError(errors, "value.converter.enhanced.protobuf.schema.support"));
+    assertTrue(containsError(errors, VALUE_ENHANCED_PROTOBUF));
   }
 
   @Test
   public void testProtobufSourceWrapperForRawPrimitivesNotValidated() {
     Map<String, String> configs = new HashMap<>();
     configs.put(VALUE_CONVERTER, PROTOBUF_CONVERTER);
-    configs.put("value.converter.enhanced.protobuf.schema.support", TRUE);
+    configs.put(VALUE_ENHANCED_PROTOBUF, TRUE);
 
     List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
     assertFalse(containsError(errors, "wrapper.for.raw.primitives"));
@@ -715,11 +731,11 @@ public class BackupModeValidatorTest {
   public void testProtobufSourceWrapperForNullablesTrueFails() {
     Map<String, String> configs = new HashMap<>();
     configs.put(VALUE_CONVERTER, PROTOBUF_CONVERTER);
-    configs.put("value.converter.enhanced.protobuf.schema.support", TRUE);
-    configs.put("value.converter.wrapper.for.nullables", TRUE);
+    configs.put(VALUE_ENHANCED_PROTOBUF, TRUE);
+    configs.put(VALUE_WRAPPER_FOR_NULLABLES, TRUE);
 
     List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
-    assertTrue(containsError(errors, "value.converter.wrapper.for.nullables"));
+    assertTrue(containsError(errors, VALUE_WRAPPER_FOR_NULLABLES));
   }
 
   @Test
@@ -739,7 +755,7 @@ public class BackupModeValidatorTest {
     configs.put(VALUE_CONVERTER, JSON_SCHEMA_CONVERTER);
 
     List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
-    assertFalse(containsError(errors, "json.type.allowed.packages"));
+    assertFalse(containsError(errors, JSON_TYPE_ALLOWED_PACKAGES));
   }
 
   @Test
@@ -749,7 +765,7 @@ public class BackupModeValidatorTest {
     configs.put("value.converter.json.type.allowed.packages", "*");
 
     List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
-    assertFalse(containsError(errors, "json.type.allowed.packages"));
+    assertFalse(containsError(errors, JSON_TYPE_ALLOWED_PACKAGES));
   }
 
   @Test
@@ -759,7 +775,7 @@ public class BackupModeValidatorTest {
     configs.put("value.converter.json.type.allowed.packages", "com.example.models");
 
     List<String> errors = BackupModeValidator.validateSinkConfigs(configs, AVRO_FORMAT, true);
-    assertFalse(containsError(errors, "json.type.allowed.packages"));
+    assertFalse(containsError(errors, JSON_TYPE_ALLOWED_PACKAGES));
   }
 
   @Test
@@ -768,6 +784,6 @@ public class BackupModeValidatorTest {
     configs.put(VALUE_CONVERTER, JSON_SCHEMA_CONVERTER);
 
     List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
-    assertFalse(containsError(errors, "json.type.allowed.packages"));
+    assertFalse(containsError(errors, JSON_TYPE_ALLOWED_PACKAGES));
   }
 }

--- a/core/src/test/java/io/confluent/connect/storage/backup/BackupModeValidatorTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/BackupModeValidatorTest.java
@@ -478,6 +478,7 @@ public class BackupModeValidatorTest {
   public void testValidSourceConfigProducesZeroErrors() {
     Map<String, String> configs = new HashMap<>();
     configs.put(VALUE_CONVERTER, AVRO_CONVERTER);
+    configs.put("value.converter.enhanced.avro.schema.support", TRUE);
 
     List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
     assertEquals(0, errors.size());
@@ -487,18 +488,38 @@ public class BackupModeValidatorTest {
   public void testByteArrayFormatSourceIsRejected() {
     Map<String, String> configs = new HashMap<>();
     configs.put(VALUE_CONVERTER, AVRO_CONVERTER);
+    configs.put("value.converter.enhanced.avro.schema.support", TRUE);
 
     List<String> errors = BackupModeValidator.validateSourceConfigs(configs, BYTE_ARRAY_FORMAT);
     assertTrue(containsError(errors, BYTE_ARRAY_FORMAT));
   }
 
   @Test
-  public void testSourceAvroValueConverterWithoutEnhancedExercisesWarnPath() {
+  public void testSourceAvroValueConverterWithoutEnhancedFails() {
     Map<String, String> configs = new HashMap<>();
     configs.put(VALUE_CONVERTER, AVRO_CONVERTER);
 
     List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
-    assertEquals(0, errors.size());
+    assertTrue(containsError(errors, "value.converter.enhanced.avro.schema.support"));
+  }
+
+  @Test
+  public void testSourceAvroKeyConverterWithoutEnhancedFails() {
+    Map<String, String> configs = new HashMap<>();
+    configs.put(KEY_CONVERTER, AVRO_CONVERTER);
+    configs.put(VALUE_CONVERTER, STRING_CONVERTER);
+
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
+    assertTrue(containsError(errors, "key.converter.enhanced.avro.schema.support"));
+  }
+
+  @Test
+  public void testSourceNonAvroConverterSkipsEnhancedCheck() {
+    Map<String, String> configs = new HashMap<>();
+    configs.put(VALUE_CONVERTER, STRING_CONVERTER);
+
+    List<String> errors = BackupModeValidator.validateSourceConfigs(configs, AVRO_FORMAT);
+    assertFalse(containsError(errors, "enhanced.avro.schema.support"));
   }
 
   @Test

--- a/core/src/test/java/io/confluent/connect/storage/backup/BackupReferenceParserTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/BackupReferenceParserTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.storage.backup;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class BackupReferenceParserTest {
+
+  @Test
+  public void testParseDirectRefsNullInputs() {
+    assertTrue(BackupReferenceParser
+        .parseDirectRefsToManifestEntries(null, null).isEmpty());
+    assertTrue(BackupReferenceParser
+        .parseDirectRefsToManifestEntries("[]", null).isEmpty());
+    assertTrue(BackupReferenceParser
+        .parseDirectRefsToManifestEntries(null, "{}").isEmpty());
+  }
+
+  @Test
+  public void testParseDirectRefsEmptyInputs() {
+    assertTrue(BackupReferenceParser
+        .parseDirectRefsToManifestEntries("", "{}").isEmpty());
+    assertTrue(BackupReferenceParser
+        .parseDirectRefsToManifestEntries("[]", "").isEmpty());
+  }
+
+  @Test
+  public void testParseDirectRefsSingleRef() {
+    String directRefs = "[{\"name\":\"com.example.Address\","
+        + "\"subject\":\"address-value\",\"version\":1}]";
+    String tree = "{\"com.example.Address\":"
+        + "{\"subject\":\"address-value\",\"version\":1,"
+        + "\"globalId\":10,\"schema\":\"{}\","
+        + "\"references\":[],\"schemaType\":\"AVRO\"}}";
+
+    List<SchemaManifest.SchemaReferenceEntry> result =
+        BackupReferenceParser.parseDirectRefsToManifestEntries(
+            directRefs, tree);
+
+    assertEquals(1, result.size());
+    assertEquals("com.example.Address", result.get(0).getName());
+    assertEquals("address-value", result.get(0).getSubject());
+    assertEquals(1, result.get(0).getVersion());
+    assertEquals(10, result.get(0).getGlobalId());
+  }
+
+  @Test
+  public void testParseDirectRefsOnlyDirectNotTransitive() {
+    String directRefs = "[{\"name\":\"com.example.Address\","
+        + "\"subject\":\"address-value\",\"version\":1}]";
+    String tree = "{"
+        + "\"com.example.Address\":"
+        + "{\"subject\":\"address-value\",\"version\":1,"
+        + "\"globalId\":20,\"schema\":\"{}\","
+        + "\"references\":[{\"name\":\"com.example.Country\","
+        + "\"subject\":\"country-value\",\"version\":1}],"
+        + "\"schemaType\":\"AVRO\"},"
+        + "\"com.example.Country\":"
+        + "{\"subject\":\"country-value\",\"version\":1,"
+        + "\"globalId\":10,\"schema\":\"{}\","
+        + "\"references\":[],\"schemaType\":\"AVRO\"}"
+        + "}";
+
+    List<SchemaManifest.SchemaReferenceEntry> result =
+        BackupReferenceParser.parseDirectRefsToManifestEntries(
+            directRefs, tree);
+
+    assertEquals(1, result.size());
+    assertEquals("com.example.Address", result.get(0).getName());
+    assertEquals(20, result.get(0).getGlobalId());
+  }
+
+  @Test
+  public void testParseDirectRefsMultipleDirectRefs() {
+    String directRefs = "["
+        + "{\"name\":\"Address\","
+        + "\"subject\":\"addr\",\"version\":1},"
+        + "{\"name\":\"Country\","
+        + "\"subject\":\"country\",\"version\":2}"
+        + "]";
+    String tree = "{"
+        + "\"Address\":{\"subject\":\"addr\",\"version\":1,"
+        + "\"globalId\":10,\"schema\":\"{}\","
+        + "\"references\":[],\"schemaType\":\"AVRO\"},"
+        + "\"Country\":{\"subject\":\"country\",\"version\":2,"
+        + "\"globalId\":5,\"schema\":\"{}\","
+        + "\"references\":[],\"schemaType\":\"AVRO\"}"
+        + "}";
+
+    List<SchemaManifest.SchemaReferenceEntry> result =
+        BackupReferenceParser.parseDirectRefsToManifestEntries(
+            directRefs, tree);
+
+    assertEquals(2, result.size());
+    assertEquals("Address", result.get(0).getName());
+    assertEquals(10, result.get(0).getGlobalId());
+    assertEquals("Country", result.get(1).getName());
+    assertEquals(5, result.get(1).getGlobalId());
+  }
+
+  @Test
+  public void testParseDirectRefsRefNotInTreeGlobalIdZero() {
+    String directRefs = "[{\"name\":\"Missing\","
+        + "\"subject\":\"missing-value\",\"version\":1}]";
+    String tree = "{}";
+
+    List<SchemaManifest.SchemaReferenceEntry> result =
+        BackupReferenceParser.parseDirectRefsToManifestEntries(
+            directRefs, tree);
+
+    assertEquals(1, result.size());
+    assertEquals("Missing", result.get(0).getName());
+    assertEquals(0, result.get(0).getGlobalId());
+  }
+}

--- a/core/src/test/java/io/confluent/connect/storage/backup/BackupReferenceParserTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/BackupReferenceParserTest.java
@@ -15,11 +15,13 @@
 
 package io.confluent.connect.storage.backup;
 
+import org.apache.kafka.connect.errors.DataException;
 import org.junit.Test;
 
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class BackupReferenceParserTest {
@@ -117,17 +119,29 @@ public class BackupReferenceParserTest {
   }
 
   @Test
-  public void testParseDirectRefsRefNotInTreeGlobalIdZero() {
+  public void testParseDirectRefsRefNotInTreeThrows() {
     String directRefs = "[{\"name\":\"Missing\","
         + "\"subject\":\"missing-value\",\"version\":1}]";
     String tree = "{}";
 
-    List<SchemaManifest.SchemaReferenceEntry> result =
-        BackupReferenceParser.parseDirectRefsToManifestEntries(
-            directRefs, tree);
+    DataException e = assertThrows(DataException.class,
+        () -> BackupReferenceParser.parseDirectRefsToManifestEntries(
+            directRefs, tree));
+    assertTrue(e.getMessage().contains("Missing"));
+    assertTrue(e.getMessage().contains("globalId"));
+  }
 
-    assertEquals(1, result.size());
-    assertEquals("Missing", result.get(0).getName());
-    assertEquals(0, result.get(0).getGlobalId());
+  @Test
+  public void testParseDirectRefsInvalidGlobalIdInTreeThrows() {
+    String directRefs = "[{\"name\":\"Zeroed\","
+        + "\"subject\":\"zeroed-value\",\"version\":1}]";
+    String tree = "{\"Zeroed\":{\"subject\":\"zeroed-value\",\"version\":1,"
+        + "\"globalId\":0,\"schemaType\":\"AVRO\",\"schema\":\"{}\"}}";
+
+    DataException e = assertThrows(DataException.class,
+        () -> BackupReferenceParser.parseDirectRefsToManifestEntries(
+            directRefs, tree));
+    assertTrue(e.getMessage().contains("Zeroed"));
+    assertTrue(e.getMessage().contains("invalid globalId"));
   }
 }

--- a/core/src/test/java/io/confluent/connect/storage/backup/ConverterTypeDetectorTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/ConverterTypeDetectorTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.storage.backup;
+
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class ConverterTypeDetectorTest {
+
+  @Test
+  public void testAvroConverter() {
+    assertEquals(BackupEnvelope.TYPE_AVRO,
+        ConverterTypeDetector.detectSchemaType(
+            "io.confluent.connect.avro.AvroConverter",
+            Collections.emptyMap(), "value.converter"));
+  }
+
+  @Test
+  public void testProtobufConverter() {
+    assertEquals(BackupEnvelope.TYPE_PROTOBUF,
+        ConverterTypeDetector.detectSchemaType(
+            "io.confluent.connect.protobuf.ProtobufConverter",
+            Collections.emptyMap(), "value.converter"));
+  }
+
+  @Test
+  public void testJsonSchemaConverter() {
+    assertEquals(BackupEnvelope.TYPE_JSON_SCHEMA,
+        ConverterTypeDetector.detectSchemaType(
+            "io.confluent.connect.json.JsonSchemaConverter",
+            Collections.emptyMap(), "value.converter"));
+  }
+
+  @Test
+  public void testStringConverter() {
+    assertEquals(BackupEnvelope.TYPE_STRING,
+        ConverterTypeDetector.detectSchemaType(
+            "org.apache.kafka.connect.storage.StringConverter",
+            Collections.emptyMap(), "value.converter"));
+  }
+
+  @Test
+  public void testJsonConverterSchemaless() {
+    Map<String, String> config = new HashMap<>();
+    config.put("value.converter.schemas.enable", "false");
+    assertEquals(BackupEnvelope.TYPE_JSON_SCHEMALESS,
+        ConverterTypeDetector.detectSchemaType(
+            "org.apache.kafka.connect.json.JsonConverter",
+            config, "value.converter"));
+  }
+
+  @Test
+  public void testJsonConverterWithSchema() {
+    Map<String, String> config = new HashMap<>();
+    config.put("value.converter.schemas.enable", "true");
+    assertEquals(BackupEnvelope.TYPE_JSON_EMBEDDED_SCHEMA,
+        ConverterTypeDetector.detectSchemaType(
+            "org.apache.kafka.connect.json.JsonConverter",
+            config, "value.converter"));
+  }
+
+  @Test
+  public void testIntegerConverter() {
+    assertEquals(BackupEnvelope.TYPE_INT32,
+        ConverterTypeDetector.detectSchemaType(
+            "org.apache.kafka.connect.converters.IntegerConverter",
+            Collections.emptyMap(), "key.converter"));
+  }
+
+  @Test
+  public void testLongConverter() {
+    assertEquals(BackupEnvelope.TYPE_INT64,
+        ConverterTypeDetector.detectSchemaType(
+            "org.apache.kafka.connect.converters.LongConverter",
+            Collections.emptyMap(), "key.converter"));
+  }
+
+  @Test
+  public void testBytesConverter() {
+    assertEquals(BackupEnvelope.TYPE_BYTES,
+        ConverterTypeDetector.detectSchemaType(
+            "org.apache.kafka.connect.converters.ByteArrayConverter",
+            Collections.emptyMap(), "value.converter"));
+  }
+
+  @Test
+  public void testNullConverterClass() {
+    assertEquals(BackupEnvelope.TYPE_NONE,
+        ConverterTypeDetector.detectSchemaType(
+            null, Collections.emptyMap(), "value.converter"));
+  }
+
+  @Test
+  public void testUnknownConverter() {
+    assertEquals(BackupEnvelope.TYPE_UNKNOWN,
+        ConverterTypeDetector.detectSchemaType(
+            "com.example.CustomConverter",
+            Collections.emptyMap(), "value.converter"));
+  }
+
+  @Test
+  public void testRegisterCustomConverter() {
+    ConverterTypeDetector.register("com.example.MyConverter", "MY_TYPE");
+    assertEquals("MY_TYPE",
+        ConverterTypeDetector.detectSchemaType(
+            "com.example.MyConverter",
+            Collections.emptyMap(), "value.converter"));
+  }
+}

--- a/core/src/test/java/io/confluent/connect/storage/backup/ConverterTypeDetectorTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/ConverterTypeDetectorTest.java
@@ -25,95 +25,97 @@ import static org.junit.Assert.assertEquals;
 
 public class ConverterTypeDetectorTest {
 
+  private static final String KEY_CONVERTER = BackupEnvelope.KEY_CONVERTER_CONFIG;
+  private static final String VALUE_CONVERTER = BackupEnvelope.VALUE_CONVERTER_CONFIG;
+
+  private static final String AVRO_CONVERTER = "io.confluent.connect.avro.AvroConverter";
+  private static final String PROTOBUF_CONVERTER = "io.confluent.connect.protobuf.ProtobufConverter";
+  private static final String JSON_SCHEMA_CONVERTER = "io.confluent.connect.json.JsonSchemaConverter";
+  private static final String STRING_CONVERTER = "org.apache.kafka.connect.storage.StringConverter";
+  private static final String JSON_CONVERTER = "org.apache.kafka.connect.json.JsonConverter";
+  private static final String INTEGER_CONVERTER = "org.apache.kafka.connect.converters.IntegerConverter";
+  private static final String LONG_CONVERTER = "org.apache.kafka.connect.converters.LongConverter";
+  private static final String BYTE_ARRAY_CONVERTER = "org.apache.kafka.connect.converters.ByteArrayConverter";
+
   @Test
   public void testAvroConverter() {
     assertEquals(BackupEnvelope.TYPE_AVRO,
         ConverterTypeDetector.detectSchemaType(
-            "io.confluent.connect.avro.AvroConverter",
-            Collections.emptyMap(), "value.converter"));
+            AVRO_CONVERTER, Collections.emptyMap(), VALUE_CONVERTER));
   }
 
   @Test
   public void testProtobufConverter() {
     assertEquals(BackupEnvelope.TYPE_PROTOBUF,
         ConverterTypeDetector.detectSchemaType(
-            "io.confluent.connect.protobuf.ProtobufConverter",
-            Collections.emptyMap(), "value.converter"));
+            PROTOBUF_CONVERTER, Collections.emptyMap(), VALUE_CONVERTER));
   }
 
   @Test
   public void testJsonSchemaConverter() {
     assertEquals(BackupEnvelope.TYPE_JSON_SCHEMA,
         ConverterTypeDetector.detectSchemaType(
-            "io.confluent.connect.json.JsonSchemaConverter",
-            Collections.emptyMap(), "value.converter"));
+            JSON_SCHEMA_CONVERTER, Collections.emptyMap(), VALUE_CONVERTER));
   }
 
   @Test
   public void testStringConverter() {
     assertEquals(BackupEnvelope.TYPE_STRING,
         ConverterTypeDetector.detectSchemaType(
-            "org.apache.kafka.connect.storage.StringConverter",
-            Collections.emptyMap(), "value.converter"));
+            STRING_CONVERTER, Collections.emptyMap(), VALUE_CONVERTER));
   }
 
   @Test
   public void testJsonConverterSchemaless() {
     Map<String, String> config = new HashMap<>();
-    config.put("value.converter.schemas.enable", "false");
+    config.put(VALUE_CONVERTER + ".schemas.enable", "false");
     assertEquals(BackupEnvelope.TYPE_JSON_SCHEMALESS,
         ConverterTypeDetector.detectSchemaType(
-            "org.apache.kafka.connect.json.JsonConverter",
-            config, "value.converter"));
+            JSON_CONVERTER, config, VALUE_CONVERTER));
   }
 
   @Test
   public void testJsonConverterWithSchema() {
     Map<String, String> config = new HashMap<>();
-    config.put("value.converter.schemas.enable", "true");
+    config.put(VALUE_CONVERTER + ".schemas.enable", "true");
     assertEquals(BackupEnvelope.TYPE_JSON_EMBEDDED_SCHEMA,
         ConverterTypeDetector.detectSchemaType(
-            "org.apache.kafka.connect.json.JsonConverter",
-            config, "value.converter"));
+            JSON_CONVERTER, config, VALUE_CONVERTER));
   }
 
   @Test
   public void testIntegerConverter() {
     assertEquals(BackupEnvelope.TYPE_INT32,
         ConverterTypeDetector.detectSchemaType(
-            "org.apache.kafka.connect.converters.IntegerConverter",
-            Collections.emptyMap(), "key.converter"));
+            INTEGER_CONVERTER, Collections.emptyMap(), KEY_CONVERTER));
   }
 
   @Test
   public void testLongConverter() {
     assertEquals(BackupEnvelope.TYPE_INT64,
         ConverterTypeDetector.detectSchemaType(
-            "org.apache.kafka.connect.converters.LongConverter",
-            Collections.emptyMap(), "key.converter"));
+            LONG_CONVERTER, Collections.emptyMap(), KEY_CONVERTER));
   }
 
   @Test
   public void testBytesConverter() {
     assertEquals(BackupEnvelope.TYPE_BYTES,
         ConverterTypeDetector.detectSchemaType(
-            "org.apache.kafka.connect.converters.ByteArrayConverter",
-            Collections.emptyMap(), "value.converter"));
+            BYTE_ARRAY_CONVERTER, Collections.emptyMap(), VALUE_CONVERTER));
   }
 
   @Test
   public void testNullConverterClass() {
     assertEquals(BackupEnvelope.TYPE_NONE,
         ConverterTypeDetector.detectSchemaType(
-            null, Collections.emptyMap(), "value.converter"));
+            null, Collections.emptyMap(), VALUE_CONVERTER));
   }
 
   @Test
   public void testUnknownConverter() {
     assertEquals(BackupEnvelope.TYPE_UNKNOWN,
         ConverterTypeDetector.detectSchemaType(
-            "com.example.CustomConverter",
-            Collections.emptyMap(), "value.converter"));
+            "com.example.CustomConverter", Collections.emptyMap(), VALUE_CONVERTER));
   }
 
   @Test
@@ -121,7 +123,6 @@ public class ConverterTypeDetectorTest {
     ConverterTypeDetector.register("com.example.MyConverter", "MY_TYPE");
     assertEquals("MY_TYPE",
         ConverterTypeDetector.detectSchemaType(
-            "com.example.MyConverter",
-            Collections.emptyMap(), "value.converter"));
+            "com.example.MyConverter", Collections.emptyMap(), VALUE_CONVERTER));
   }
 }

--- a/core/src/test/java/io/confluent/connect/storage/backup/ConverterTypeDetectorTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/ConverterTypeDetectorTest.java
@@ -118,11 +118,4 @@ public class ConverterTypeDetectorTest {
             "com.example.CustomConverter", Collections.emptyMap(), VALUE_CONVERTER));
   }
 
-  @Test
-  public void testRegisterCustomConverter() {
-    ConverterTypeDetector.register("com.example.MyConverter", "MY_TYPE");
-    assertEquals("MY_TYPE",
-        ConverterTypeDetector.detectSchemaType(
-            "com.example.MyConverter", Collections.emptyMap(), VALUE_CONVERTER));
-  }
 }

--- a/core/src/test/java/io/confluent/connect/storage/backup/ConverterTypeDetectorTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/ConverterTypeDetectorTest.java
@@ -106,7 +106,7 @@ public class ConverterTypeDetectorTest {
 
   @Test
   public void testNullConverterClass() {
-    assertEquals(BackupEnvelope.TYPE_NONE,
+    assertEquals(BackupEnvelope.TYPE_UNKNOWN,
         ConverterTypeDetector.detectSchemaType(
             null, Collections.emptyMap(), VALUE_CONVERTER));
   }

--- a/core/src/test/java/io/confluent/connect/storage/backup/EnvelopeSchemaBuilderTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/EnvelopeSchemaBuilderTest.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.storage.backup;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.sink.SinkRecord;
+import java.util.List;
+import org.junit.Test;
+
+public class EnvelopeSchemaBuilderTest {
+
+  @Test
+  public void testBuildWithStructSchemas() {
+    Schema keySchema = SchemaBuilder.struct()
+        .field("id", Schema.INT32_SCHEMA).build();
+    Schema valueSchema = SchemaBuilder.struct()
+        .field("name", Schema.STRING_SCHEMA).build();
+
+    Schema envelope = EnvelopeSchemaBuilder.buildEnvelopeSchema(
+        keySchema, valueSchema, "AVRO", "AVRO");
+
+    assertEquals(BackupEnvelope.NAME, envelope.name());
+    assertEquals(keySchema,
+        envelope.field(BackupEnvelope.FIELD_KEY).schema());
+    assertEquals(valueSchema,
+        envelope.field(BackupEnvelope.FIELD_VALUE).schema());
+  }
+
+  @Test
+  public void testBuildWithNullSchemas() {
+    Schema envelope = EnvelopeSchemaBuilder.buildEnvelopeSchema(
+        null, null, "JSON_SCHEMALESS", "JSON_SCHEMALESS");
+
+    assertEquals(Schema.OPTIONAL_STRING_SCHEMA,
+        envelope.field(BackupEnvelope.FIELD_KEY).schema());
+    assertEquals(Schema.OPTIONAL_STRING_SCHEMA,
+        envelope.field(BackupEnvelope.FIELD_VALUE).schema());
+  }
+
+  @Test
+  public void testBuildWithMixedSchemas() {
+    Schema valueSchema = SchemaBuilder.struct()
+        .field("data", Schema.STRING_SCHEMA).build();
+
+    Schema envelope = EnvelopeSchemaBuilder.buildEnvelopeSchema(
+        Schema.STRING_SCHEMA, valueSchema, "STRING", "AVRO");
+
+    assertEquals(Schema.STRING_SCHEMA,
+        envelope.field(BackupEnvelope.FIELD_KEY).schema());
+    assertEquals(valueSchema,
+        envelope.field(BackupEnvelope.FIELD_VALUE).schema());
+  }
+
+  @Test
+  public void testBuildWithPrimitiveSchemas() {
+    Schema envelope = EnvelopeSchemaBuilder.buildEnvelopeSchema(
+        Schema.STRING_SCHEMA, Schema.INT32_SCHEMA,
+        "STRING", "INT32");
+
+    assertEquals(Schema.STRING_SCHEMA,
+        envelope.field(BackupEnvelope.FIELD_KEY).schema());
+    assertEquals(Schema.INT32_SCHEMA,
+        envelope.field(BackupEnvelope.FIELD_VALUE).schema());
+  }
+
+  @Test
+  public void testEnvelopeHasAllMetadataFields() {
+    Schema envelope = EnvelopeSchemaBuilder.buildEnvelopeSchema(
+        null, null, "NONE", "NONE");
+
+    assertNotNull(envelope.field(BackupEnvelope.FIELD_TOPIC));
+    assertNotNull(envelope.field(BackupEnvelope.FIELD_PARTITION));
+    assertNotNull(envelope.field(BackupEnvelope.FIELD_OFFSET));
+    assertNotNull(envelope.field(BackupEnvelope.FIELD_TIMESTAMP));
+    assertNotNull(
+        envelope.field(BackupEnvelope.FIELD_TIMESTAMP_TYPE));
+    assertNotNull(
+        envelope.field(BackupEnvelope.FIELD_KEY_SCHEMA_ID));
+    assertNotNull(
+        envelope.field(BackupEnvelope.FIELD_VALUE_SCHEMA_ID));
+    assertNotNull(
+        envelope.field(BackupEnvelope.FIELD_KEY_SCHEMA_TYPE));
+    assertNotNull(
+        envelope.field(BackupEnvelope.FIELD_VALUE_SCHEMA_TYPE));
+    assertNotNull(
+        envelope.field(BackupEnvelope.FIELD_KEY_SCHEMA_SUBJECT));
+    assertNotNull(
+        envelope.field(BackupEnvelope.FIELD_VALUE_SCHEMA_SUBJECT));
+    assertNotNull(
+        envelope.field(BackupEnvelope.FIELD_KEY_SCHEMA_GUID));
+    assertNotNull(
+        envelope.field(BackupEnvelope.FIELD_VALUE_SCHEMA_GUID));
+    assertNotNull(envelope.field(BackupEnvelope.FIELD_HEADERS));
+  }
+
+  @Test
+  public void testBuildEnvelopeStructAllFields() {
+    Schema keySchema = Schema.STRING_SCHEMA;
+    Schema valueSchema = SchemaBuilder.struct()
+        .field("x", Schema.INT32_SCHEMA).build();
+    Schema envSchema = EnvelopeSchemaBuilder.buildEnvelopeSchema(
+        keySchema, valueSchema, "STRING", "AVRO");
+
+    Struct value = new Struct(valueSchema).put("x", 99);
+    ConnectHeaders headers = new ConnectHeaders();
+    headers.addString("h1", "val1");
+
+    SinkRecord record = new SinkRecord(
+        "test-topic", 0, keySchema, "key1",
+        valueSchema, value, 100L,
+        1234567890L,
+        TimestampType.CREATE_TIME,
+        headers);
+
+    Struct envelope = EnvelopeSchemaBuilder.buildEnvelopeStruct(
+        envSchema, record, "key1", value,
+        new EnvelopeSchemaBuilder.SchemaDescriptor(null, "STRING", null, null),
+        new EnvelopeSchemaBuilder.SchemaDescriptor(42, "AVRO", "test-value", null));
+
+    assertEquals("key1",
+        envelope.get(BackupEnvelope.FIELD_KEY));
+    assertEquals(value,
+        envelope.get(BackupEnvelope.FIELD_VALUE));
+    assertEquals("test-topic",
+        envelope.getString(BackupEnvelope.FIELD_TOPIC));
+    assertEquals(0,
+        (int) envelope.getInt32(BackupEnvelope.FIELD_PARTITION));
+    assertEquals(100L,
+        (long) envelope.getInt64(BackupEnvelope.FIELD_OFFSET));
+    assertEquals(1234567890L,
+        (long) envelope.getInt64(BackupEnvelope.FIELD_TIMESTAMP));
+    assertEquals("CREATE_TIME",
+        envelope.getString(
+            BackupEnvelope.FIELD_TIMESTAMP_TYPE));
+    assertNull(
+        envelope.getInt32(BackupEnvelope.FIELD_KEY_SCHEMA_ID));
+    assertEquals(42,
+        (int) envelope.getInt32(
+            BackupEnvelope.FIELD_VALUE_SCHEMA_ID));
+    assertEquals("STRING",
+        envelope.getString(
+            BackupEnvelope.FIELD_KEY_SCHEMA_TYPE));
+    assertEquals("AVRO",
+        envelope.getString(
+            BackupEnvelope.FIELD_VALUE_SCHEMA_TYPE));
+    assertNull(
+        envelope.getString(
+            BackupEnvelope.FIELD_KEY_SCHEMA_SUBJECT));
+    assertEquals("test-value",
+        envelope.getString(
+            BackupEnvelope.FIELD_VALUE_SCHEMA_SUBJECT));
+
+    @SuppressWarnings("unchecked")
+    List<Struct> hdrs = (List<Struct>) envelope.get(
+        BackupEnvelope.FIELD_HEADERS);
+    assertEquals(1, hdrs.size());
+    assertEquals("h1", hdrs.get(0).getString(
+        BackupEnvelope.FIELD_HEADER_KEY));
+    assertEquals("val1", hdrs.get(0).getString(
+        BackupEnvelope.FIELD_HEADER_VALUE));
+    assertEquals("STRING", hdrs.get(0).getString(
+        BackupEnvelope.FIELD_HEADER_SCHEMA_TYPE));
+  }
+
+  @Test
+  public void testBuildEnvelopeStructNullOptionals() {
+    Schema envSchema = EnvelopeSchemaBuilder.buildEnvelopeSchema(
+        null, null, "NONE", "NONE");
+
+    SinkRecord record = new SinkRecord(
+        "t", 0, null, null, null, null, 0L);
+
+    Struct envelope = EnvelopeSchemaBuilder.buildEnvelopeStruct(
+        envSchema, record, null, null,
+        new EnvelopeSchemaBuilder.SchemaDescriptor(null, "NONE", null, null),
+        new EnvelopeSchemaBuilder.SchemaDescriptor(null, "NONE", null, null));
+
+    assertNull(envelope.get(BackupEnvelope.FIELD_KEY));
+    assertNull(envelope.get(BackupEnvelope.FIELD_VALUE));
+    assertNull(
+        envelope.getInt32(BackupEnvelope.FIELD_KEY_SCHEMA_ID));
+    assertNull(
+        envelope.getInt32(BackupEnvelope.FIELD_VALUE_SCHEMA_ID));
+    assertNull(
+        envelope.getString(
+            BackupEnvelope.FIELD_KEY_SCHEMA_SUBJECT));
+    assertNull(
+        envelope.getString(
+            BackupEnvelope.FIELD_VALUE_SCHEMA_SUBJECT));
+
+    @SuppressWarnings("unchecked")
+    List<Struct> hdrs = (List<Struct>) envelope.get(
+        BackupEnvelope.FIELD_HEADERS);
+    assertTrue(hdrs.isEmpty());
+  }
+
+  @Test
+  public void testBuildHeadersMultipleTypes() {
+    Schema keySchema = Schema.STRING_SCHEMA;
+    Schema envSchema = EnvelopeSchemaBuilder.buildEnvelopeSchema(
+        keySchema, null, "STRING", "NONE");
+
+    ConnectHeaders headers = new ConnectHeaders();
+    headers.addString("str", "text");
+    headers.addInt("num", 42);
+    headers.addBoolean("flag", true);
+
+    SinkRecord record = new SinkRecord(
+        "t", 0, keySchema, "k", null, null, 0L,
+        null, null, headers);
+
+    Struct envelope = EnvelopeSchemaBuilder.buildEnvelopeStruct(
+        envSchema, record, "k", null,
+        new EnvelopeSchemaBuilder.SchemaDescriptor(null, "STRING", null, null),
+        new EnvelopeSchemaBuilder.SchemaDescriptor(null, "NONE", null, null));
+
+    @SuppressWarnings("unchecked")
+    List<Struct> hdrs = (List<Struct>) envelope.get(
+        BackupEnvelope.FIELD_HEADERS);
+    assertEquals(3, hdrs.size());
+
+    assertEquals("str", hdrs.get(0).getString(
+        BackupEnvelope.FIELD_HEADER_KEY));
+    assertEquals("text", hdrs.get(0).getString(
+        BackupEnvelope.FIELD_HEADER_VALUE));
+    assertEquals("STRING", hdrs.get(0).getString(
+        BackupEnvelope.FIELD_HEADER_SCHEMA_TYPE));
+
+    assertEquals("num", hdrs.get(1).getString(
+        BackupEnvelope.FIELD_HEADER_KEY));
+    assertEquals("42", hdrs.get(1).getString(
+        BackupEnvelope.FIELD_HEADER_VALUE));
+    assertEquals("INT32", hdrs.get(1).getString(
+        BackupEnvelope.FIELD_HEADER_SCHEMA_TYPE));
+
+    assertEquals("flag", hdrs.get(2).getString(
+        BackupEnvelope.FIELD_HEADER_KEY));
+    assertEquals("true", hdrs.get(2).getString(
+        BackupEnvelope.FIELD_HEADER_VALUE));
+    assertEquals("BOOLEAN", hdrs.get(2).getString(
+        BackupEnvelope.FIELD_HEADER_SCHEMA_TYPE));
+  }
+}

--- a/core/src/test/java/io/confluent/connect/storage/backup/EnvelopeSchemaBuilderTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/EnvelopeSchemaBuilderTest.java
@@ -185,6 +185,40 @@ public class EnvelopeSchemaBuilderTest {
   }
 
   @Test
+  public void testTimestampTypeLogAppendTime() {
+    Schema envSchema = EnvelopeSchemaBuilder.buildEnvelopeSchema(
+        Schema.STRING_SCHEMA, Schema.STRING_SCHEMA, BackupEnvelope.TYPE_STRING, BackupEnvelope.TYPE_STRING);
+    SinkRecord record = new SinkRecord(
+        "t", 0, Schema.STRING_SCHEMA, "k", Schema.STRING_SCHEMA, "v",
+        0L, 1L, TimestampType.LOG_APPEND_TIME);
+
+    Struct envelope = EnvelopeSchemaBuilder.buildEnvelopeStruct(
+        envSchema, record, "k", "v",
+        new EnvelopeSchemaBuilder.SchemaDescriptor(null, BackupEnvelope.TYPE_STRING, null, null),
+        new EnvelopeSchemaBuilder.SchemaDescriptor(null, BackupEnvelope.TYPE_STRING, null, null));
+
+    assertEquals("LOG_APPEND_TIME",
+        envelope.getString(BackupEnvelope.FIELD_TIMESTAMP_TYPE));
+  }
+
+  @Test
+  public void testTimestampTypeNoTimestampType() {
+    Schema envSchema = EnvelopeSchemaBuilder.buildEnvelopeSchema(
+        Schema.STRING_SCHEMA, Schema.STRING_SCHEMA, BackupEnvelope.TYPE_STRING, BackupEnvelope.TYPE_STRING);
+    SinkRecord record = new SinkRecord(
+        "t", 0, Schema.STRING_SCHEMA, "k", Schema.STRING_SCHEMA, "v",
+        0L, -1L, TimestampType.NO_TIMESTAMP_TYPE);
+
+    Struct envelope = EnvelopeSchemaBuilder.buildEnvelopeStruct(
+        envSchema, record, "k", "v",
+        new EnvelopeSchemaBuilder.SchemaDescriptor(null, BackupEnvelope.TYPE_STRING, null, null),
+        new EnvelopeSchemaBuilder.SchemaDescriptor(null, BackupEnvelope.TYPE_STRING, null, null));
+
+    assertEquals("NO_TIMESTAMP_TYPE",
+        envelope.getString(BackupEnvelope.FIELD_TIMESTAMP_TYPE));
+  }
+
+  @Test
   public void testBuildEnvelopeStructNullOptionals() {
     Schema envSchema = EnvelopeSchemaBuilder.buildEnvelopeSchema(
         null, null, BackupEnvelope.TYPE_NONE, BackupEnvelope.TYPE_NONE);

--- a/core/src/test/java/io/confluent/connect/storage/backup/EnvelopeSchemaBuilderTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/EnvelopeSchemaBuilderTest.java
@@ -39,7 +39,7 @@ public class EnvelopeSchemaBuilderTest {
         .field("name", Schema.STRING_SCHEMA).build();
 
     Schema envelope = EnvelopeSchemaBuilder.buildEnvelopeSchema(
-        keySchema, valueSchema, "AVRO", "AVRO");
+        keySchema, valueSchema, BackupEnvelope.TYPE_AVRO, BackupEnvelope.TYPE_AVRO);
 
     assertEquals(BackupEnvelope.NAME, envelope.name());
     assertEquals(keySchema,
@@ -51,7 +51,7 @@ public class EnvelopeSchemaBuilderTest {
   @Test
   public void testBuildWithNullSchemas() {
     Schema envelope = EnvelopeSchemaBuilder.buildEnvelopeSchema(
-        null, null, "JSON_SCHEMALESS", "JSON_SCHEMALESS");
+        null, null, BackupEnvelope.TYPE_JSON_SCHEMALESS, BackupEnvelope.TYPE_JSON_SCHEMALESS);
 
     assertEquals(Schema.OPTIONAL_STRING_SCHEMA,
         envelope.field(BackupEnvelope.FIELD_KEY).schema());
@@ -65,7 +65,7 @@ public class EnvelopeSchemaBuilderTest {
         .field("data", Schema.STRING_SCHEMA).build();
 
     Schema envelope = EnvelopeSchemaBuilder.buildEnvelopeSchema(
-        Schema.STRING_SCHEMA, valueSchema, "STRING", "AVRO");
+        Schema.STRING_SCHEMA, valueSchema, BackupEnvelope.TYPE_STRING, BackupEnvelope.TYPE_AVRO);
 
     assertEquals(Schema.STRING_SCHEMA,
         envelope.field(BackupEnvelope.FIELD_KEY).schema());
@@ -77,7 +77,7 @@ public class EnvelopeSchemaBuilderTest {
   public void testBuildWithPrimitiveSchemas() {
     Schema envelope = EnvelopeSchemaBuilder.buildEnvelopeSchema(
         Schema.STRING_SCHEMA, Schema.INT32_SCHEMA,
-        "STRING", "INT32");
+        BackupEnvelope.TYPE_STRING, BackupEnvelope.TYPE_INT32);
 
     assertEquals(Schema.STRING_SCHEMA,
         envelope.field(BackupEnvelope.FIELD_KEY).schema());
@@ -88,7 +88,7 @@ public class EnvelopeSchemaBuilderTest {
   @Test
   public void testEnvelopeHasAllMetadataFields() {
     Schema envelope = EnvelopeSchemaBuilder.buildEnvelopeSchema(
-        null, null, "NONE", "NONE");
+        null, null, BackupEnvelope.TYPE_NONE, BackupEnvelope.TYPE_NONE);
 
     assertNotNull(envelope.field(BackupEnvelope.FIELD_TOPIC));
     assertNotNull(envelope.field(BackupEnvelope.FIELD_PARTITION));
@@ -121,7 +121,7 @@ public class EnvelopeSchemaBuilderTest {
     Schema valueSchema = SchemaBuilder.struct()
         .field("x", Schema.INT32_SCHEMA).build();
     Schema envSchema = EnvelopeSchemaBuilder.buildEnvelopeSchema(
-        keySchema, valueSchema, "STRING", "AVRO");
+        keySchema, valueSchema, BackupEnvelope.TYPE_STRING, BackupEnvelope.TYPE_AVRO);
 
     Struct value = new Struct(valueSchema).put("x", 99);
     ConnectHeaders headers = new ConnectHeaders();
@@ -136,8 +136,8 @@ public class EnvelopeSchemaBuilderTest {
 
     Struct envelope = EnvelopeSchemaBuilder.buildEnvelopeStruct(
         envSchema, record, "key1", value,
-        new EnvelopeSchemaBuilder.SchemaDescriptor(null, "STRING", null, null),
-        new EnvelopeSchemaBuilder.SchemaDescriptor(42, "AVRO", "test-value", null));
+        new EnvelopeSchemaBuilder.SchemaDescriptor(null, BackupEnvelope.TYPE_STRING, null, null),
+        new EnvelopeSchemaBuilder.SchemaDescriptor(42, BackupEnvelope.TYPE_AVRO, "test-value", null));
 
     assertEquals("key1",
         envelope.get(BackupEnvelope.FIELD_KEY));
@@ -159,10 +159,10 @@ public class EnvelopeSchemaBuilderTest {
     assertEquals(42,
         (int) envelope.getInt32(
             BackupEnvelope.FIELD_VALUE_SCHEMA_ID));
-    assertEquals("STRING",
+    assertEquals(BackupEnvelope.TYPE_STRING,
         envelope.getString(
             BackupEnvelope.FIELD_KEY_SCHEMA_TYPE));
-    assertEquals("AVRO",
+    assertEquals(BackupEnvelope.TYPE_AVRO,
         envelope.getString(
             BackupEnvelope.FIELD_VALUE_SCHEMA_TYPE));
     assertNull(
@@ -180,22 +180,22 @@ public class EnvelopeSchemaBuilderTest {
         BackupEnvelope.FIELD_HEADER_KEY));
     assertEquals("val1", hdrs.get(0).getString(
         BackupEnvelope.FIELD_HEADER_VALUE));
-    assertEquals("STRING", hdrs.get(0).getString(
+    assertEquals(BackupEnvelope.TYPE_STRING, hdrs.get(0).getString(
         BackupEnvelope.FIELD_HEADER_SCHEMA_TYPE));
   }
 
   @Test
   public void testBuildEnvelopeStructNullOptionals() {
     Schema envSchema = EnvelopeSchemaBuilder.buildEnvelopeSchema(
-        null, null, "NONE", "NONE");
+        null, null, BackupEnvelope.TYPE_NONE, BackupEnvelope.TYPE_NONE);
 
     SinkRecord record = new SinkRecord(
         "t", 0, null, null, null, null, 0L);
 
     Struct envelope = EnvelopeSchemaBuilder.buildEnvelopeStruct(
         envSchema, record, null, null,
-        new EnvelopeSchemaBuilder.SchemaDescriptor(null, "NONE", null, null),
-        new EnvelopeSchemaBuilder.SchemaDescriptor(null, "NONE", null, null));
+        new EnvelopeSchemaBuilder.SchemaDescriptor(null, BackupEnvelope.TYPE_NONE, null, null),
+        new EnvelopeSchemaBuilder.SchemaDescriptor(null, BackupEnvelope.TYPE_NONE, null, null));
 
     assertNull(envelope.get(BackupEnvelope.FIELD_KEY));
     assertNull(envelope.get(BackupEnvelope.FIELD_VALUE));
@@ -220,7 +220,7 @@ public class EnvelopeSchemaBuilderTest {
   public void testBuildHeadersMultipleTypes() {
     Schema keySchema = Schema.STRING_SCHEMA;
     Schema envSchema = EnvelopeSchemaBuilder.buildEnvelopeSchema(
-        keySchema, null, "STRING", "NONE");
+        keySchema, null, BackupEnvelope.TYPE_STRING, BackupEnvelope.TYPE_NONE);
 
     ConnectHeaders headers = new ConnectHeaders();
     headers.addString("str", "text");
@@ -233,8 +233,8 @@ public class EnvelopeSchemaBuilderTest {
 
     Struct envelope = EnvelopeSchemaBuilder.buildEnvelopeStruct(
         envSchema, record, "k", null,
-        new EnvelopeSchemaBuilder.SchemaDescriptor(null, "STRING", null, null),
-        new EnvelopeSchemaBuilder.SchemaDescriptor(null, "NONE", null, null));
+        new EnvelopeSchemaBuilder.SchemaDescriptor(null, BackupEnvelope.TYPE_STRING, null, null),
+        new EnvelopeSchemaBuilder.SchemaDescriptor(null, BackupEnvelope.TYPE_NONE, null, null));
 
     @SuppressWarnings("unchecked")
     List<Struct> hdrs = (List<Struct>) envelope.get(
@@ -245,14 +245,14 @@ public class EnvelopeSchemaBuilderTest {
         BackupEnvelope.FIELD_HEADER_KEY));
     assertEquals("text", hdrs.get(0).getString(
         BackupEnvelope.FIELD_HEADER_VALUE));
-    assertEquals("STRING", hdrs.get(0).getString(
+    assertEquals(BackupEnvelope.TYPE_STRING, hdrs.get(0).getString(
         BackupEnvelope.FIELD_HEADER_SCHEMA_TYPE));
 
     assertEquals("num", hdrs.get(1).getString(
         BackupEnvelope.FIELD_HEADER_KEY));
     assertEquals("42", hdrs.get(1).getString(
         BackupEnvelope.FIELD_HEADER_VALUE));
-    assertEquals("INT32", hdrs.get(1).getString(
+    assertEquals(BackupEnvelope.TYPE_INT32, hdrs.get(1).getString(
         BackupEnvelope.FIELD_HEADER_SCHEMA_TYPE));
 
     assertEquals("flag", hdrs.get(2).getString(

--- a/core/src/test/java/io/confluent/connect/storage/backup/EnvelopeSchemaBuilderTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/EnvelopeSchemaBuilderTest.java
@@ -41,7 +41,7 @@ public class EnvelopeSchemaBuilderTest {
         .field("name", Schema.STRING_SCHEMA).build();
 
     Schema envelope = EnvelopeSchemaBuilder.buildEnvelopeSchema(
-        keySchema, valueSchema, BackupEnvelope.TYPE_AVRO, BackupEnvelope.TYPE_AVRO);
+        keySchema, valueSchema);
 
     assertEquals(BackupEnvelope.NAME, envelope.name());
     assertEquals(keySchema,
@@ -53,7 +53,7 @@ public class EnvelopeSchemaBuilderTest {
   @Test
   public void testBuildWithNullSchemas() {
     Schema envelope = EnvelopeSchemaBuilder.buildEnvelopeSchema(
-        null, null, BackupEnvelope.TYPE_JSON_SCHEMALESS, BackupEnvelope.TYPE_JSON_SCHEMALESS);
+        null, null);
 
     assertEquals(Schema.OPTIONAL_STRING_SCHEMA,
         envelope.field(BackupEnvelope.FIELD_KEY).schema());
@@ -67,7 +67,7 @@ public class EnvelopeSchemaBuilderTest {
         .field("data", Schema.STRING_SCHEMA).build();
 
     Schema envelope = EnvelopeSchemaBuilder.buildEnvelopeSchema(
-        Schema.STRING_SCHEMA, valueSchema, BackupEnvelope.TYPE_STRING, BackupEnvelope.TYPE_AVRO);
+        Schema.STRING_SCHEMA, valueSchema);
 
     assertEquals(Schema.STRING_SCHEMA,
         envelope.field(BackupEnvelope.FIELD_KEY).schema());
@@ -78,8 +78,7 @@ public class EnvelopeSchemaBuilderTest {
   @Test
   public void testBuildWithPrimitiveSchemas() {
     Schema envelope = EnvelopeSchemaBuilder.buildEnvelopeSchema(
-        Schema.STRING_SCHEMA, Schema.INT32_SCHEMA,
-        BackupEnvelope.TYPE_STRING, BackupEnvelope.TYPE_INT32);
+        Schema.STRING_SCHEMA, Schema.INT32_SCHEMA);
 
     assertEquals(Schema.STRING_SCHEMA,
         envelope.field(BackupEnvelope.FIELD_KEY).schema());
@@ -90,7 +89,7 @@ public class EnvelopeSchemaBuilderTest {
   @Test
   public void testEnvelopeHasAllMetadataFields() {
     Schema envelope = EnvelopeSchemaBuilder.buildEnvelopeSchema(
-        null, null, BackupEnvelope.TYPE_NONE, BackupEnvelope.TYPE_NONE);
+        null, null);
 
     assertNotNull(envelope.field(BackupEnvelope.FIELD_TOPIC));
     assertNotNull(envelope.field(BackupEnvelope.FIELD_PARTITION));
@@ -123,7 +122,7 @@ public class EnvelopeSchemaBuilderTest {
     Schema valueSchema = SchemaBuilder.struct()
         .field("x", Schema.INT32_SCHEMA).build();
     Schema envSchema = EnvelopeSchemaBuilder.buildEnvelopeSchema(
-        keySchema, valueSchema, BackupEnvelope.TYPE_STRING, BackupEnvelope.TYPE_AVRO);
+        keySchema, valueSchema);
 
     Struct value = new Struct(valueSchema).put("x", 99);
     ConnectHeaders headers = new ConnectHeaders();
@@ -189,7 +188,7 @@ public class EnvelopeSchemaBuilderTest {
   @Test
   public void testTimestampTypeLogAppendTime() {
     Schema envSchema = EnvelopeSchemaBuilder.buildEnvelopeSchema(
-        Schema.STRING_SCHEMA, Schema.STRING_SCHEMA, BackupEnvelope.TYPE_STRING, BackupEnvelope.TYPE_STRING);
+        Schema.STRING_SCHEMA, Schema.STRING_SCHEMA);
     SinkRecord record = new SinkRecord(
         "t", 0, Schema.STRING_SCHEMA, "k", Schema.STRING_SCHEMA, "v",
         0L, 1L, TimestampType.LOG_APPEND_TIME);
@@ -206,7 +205,7 @@ public class EnvelopeSchemaBuilderTest {
   @Test
   public void testTimestampTypeNoTimestampType() {
     Schema envSchema = EnvelopeSchemaBuilder.buildEnvelopeSchema(
-        Schema.STRING_SCHEMA, Schema.STRING_SCHEMA, BackupEnvelope.TYPE_STRING, BackupEnvelope.TYPE_STRING);
+        Schema.STRING_SCHEMA, Schema.STRING_SCHEMA);
     SinkRecord record = new SinkRecord(
         "t", 0, Schema.STRING_SCHEMA, "k", Schema.STRING_SCHEMA, "v",
         0L, -1L, TimestampType.NO_TIMESTAMP_TYPE);
@@ -223,7 +222,7 @@ public class EnvelopeSchemaBuilderTest {
   @Test
   public void testBuildEnvelopeStructNullOptionals() {
     Schema envSchema = EnvelopeSchemaBuilder.buildEnvelopeSchema(
-        null, null, BackupEnvelope.TYPE_NONE, BackupEnvelope.TYPE_NONE);
+        null, null);
 
     SinkRecord record = new SinkRecord(
         "t", 0, null, null, null, null, 0L);
@@ -256,7 +255,7 @@ public class EnvelopeSchemaBuilderTest {
   public void testBuildHeadersMultipleTypes() {
     Schema keySchema = Schema.STRING_SCHEMA;
     Schema envSchema = EnvelopeSchemaBuilder.buildEnvelopeSchema(
-        keySchema, null, BackupEnvelope.TYPE_STRING, BackupEnvelope.TYPE_NONE);
+        keySchema, null);
 
     ConnectHeaders headers = new ConnectHeaders();
     headers.addString("str", "text");

--- a/core/src/test/java/io/confluent/connect/storage/backup/EnvelopeSchemaBuilderTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/EnvelopeSchemaBuilderTest.java
@@ -31,6 +31,8 @@ import org.junit.Test;
 
 public class EnvelopeSchemaBuilderTest {
 
+  private static final String KEY1 = "key1";
+
   @Test
   public void testBuildWithStructSchemas() {
     Schema keySchema = SchemaBuilder.struct()
@@ -128,18 +130,18 @@ public class EnvelopeSchemaBuilderTest {
     headers.addString("h1", "val1");
 
     SinkRecord record = new SinkRecord(
-        "test-topic", 0, keySchema, "key1",
+        "test-topic", 0, keySchema, KEY1,
         valueSchema, value, 100L,
         1234567890L,
         TimestampType.CREATE_TIME,
         headers);
 
     Struct envelope = EnvelopeSchemaBuilder.buildEnvelopeStruct(
-        envSchema, record, "key1", value,
+        envSchema, record, KEY1, value,
         new EnvelopeSchemaBuilder.SchemaDescriptor(null, BackupEnvelope.TYPE_STRING, null, null),
         new EnvelopeSchemaBuilder.SchemaDescriptor(42, BackupEnvelope.TYPE_AVRO, "test-value", null));
 
-    assertEquals("key1",
+    assertEquals(KEY1,
         envelope.get(BackupEnvelope.FIELD_KEY));
     assertEquals(value,
         envelope.get(BackupEnvelope.FIELD_VALUE));

--- a/core/src/test/java/io/confluent/connect/storage/backup/ObjectStoreSchemaBackupStoreTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/ObjectStoreSchemaBackupStoreTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.storage.backup;
+
+import org.apache.kafka.connect.errors.ConnectException;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ObjectStoreSchemaBackupStoreTest {
+
+  private StorageWriter writer;
+  private ObjectStoreSchemaBackupStore store;
+
+  @Before
+  public void setUp() {
+    writer = mock(StorageWriter.class);
+    store = new ObjectStoreSchemaBackupStore(writer, "topics", "/");
+  }
+
+  @Test
+  public void testBackupWritesSchemaAndEntryFiles() {
+    when(writer.exists(anyString())).thenReturn(false);
+
+    store.backupIfNeeded("orders", "42", 1, "AVRO",
+        "orders-value", "{\"type\":\"record\"}", null);
+
+    ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
+    verify(writer, times(2)).write(pathCaptor.capture(), anyString());
+
+    assertTrue(pathCaptor.getAllValues().get(0).endsWith("42.avsc"));
+    assertTrue(pathCaptor.getAllValues().get(1).endsWith("42.entry.json"));
+  }
+
+  @Test
+  public void testBackupProtobufExtension() {
+    when(writer.exists(anyString())).thenReturn(false);
+
+    store.backupIfNeeded("orders", "10", 1, "PROTOBUF",
+        "orders-value", "syntax=\"proto3\";", null);
+
+    ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
+    verify(writer, times(2)).write(pathCaptor.capture(), anyString());
+    assertTrue(pathCaptor.getAllValues().get(0).endsWith("10.proto"));
+  }
+
+  @Test
+  public void testBackupJsonSchemaExtension() {
+    when(writer.exists(anyString())).thenReturn(false);
+
+    store.backupIfNeeded("orders", "10", 1, "JSON_SCHEMA",
+        "orders-value", "{\"type\":\"object\"}", null);
+
+    ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
+    verify(writer, times(2)).write(pathCaptor.capture(), anyString());
+    assertTrue(pathCaptor.getAllValues().get(0).endsWith("10.json"));
+  }
+
+  @Test
+  public void testLevel1DedupInMemory() {
+    when(writer.exists(anyString())).thenReturn(false);
+
+    store.backupIfNeeded("orders", "42", 1, "AVRO",
+        "orders-value", "{}", null);
+    store.backupIfNeeded("orders", "42", 1, "AVRO",
+        "orders-value", "{}", null);
+
+    verify(writer, times(2)).write(anyString(), anyString());
+  }
+
+  @Test
+  public void testLevel2DedupExistsCheck() {
+    when(writer.exists(anyString())).thenReturn(true);
+
+    store.backupIfNeeded("orders", "42", 1, "AVRO",
+        "orders-value", "{}", null);
+
+    verify(writer, never()).write(anyString(), anyString());
+  }
+
+  @Test
+  public void testNullOrEmptySchemaKeySkipped() {
+    store.backupIfNeeded("orders", null, 1, "AVRO",
+        "orders-value", "{}", null);
+    store.backupIfNeeded("orders", "", 1, "AVRO",
+        "orders-value", "{}", null);
+
+    verify(writer, never()).write(anyString(), anyString());
+    verify(writer, never()).exists(anyString());
+  }
+
+  @Test
+  public void testEntryFileContainsReferences() {
+    when(writer.exists(anyString())).thenReturn(false);
+    SchemaManifest.SchemaReferenceEntry ref =
+        new SchemaManifest.SchemaReferenceEntry(
+            "Address", "address-value", 1, 10);
+
+    store.backupIfNeeded("orders", "42", 1, "AVRO",
+        "orders-value", "{}",
+        Collections.singletonList(ref));
+
+    ArgumentCaptor<String> contentCaptor = ArgumentCaptor.forClass(String.class);
+    verify(writer, times(2)).write(anyString(), contentCaptor.capture());
+
+    String entryJson = contentCaptor.getAllValues().get(1);
+    assertTrue(entryJson.contains("\"Address\""));
+    assertTrue(entryJson.contains("address-value"));
+  }
+
+  @Test
+  public void testEntryWriteFailureAllowsRetry() {
+    when(writer.exists(anyString())).thenReturn(false);
+    Mockito.doNothing()
+        .doThrow(new ConnectException("fail"))
+        .when(writer).write(anyString(), anyString());
+
+    try {
+      store.backupIfNeeded("orders", "42", 1, "AVRO",
+          "orders-value", "{}", null);
+    } catch (ConnectException expected) {
+      // first call: schema write succeeds, entry write fails
+    }
+
+    when(writer.exists(anyString())).thenReturn(false);
+    Mockito.doNothing().when(writer).write(anyString(), anyString());
+    store.backupIfNeeded("orders", "42", 1, "AVRO",
+        "orders-value", "{}", null);
+
+    verify(writer, times(4)).write(anyString(), anyString());
+  }
+
+  @Test
+  public void testSchemaPath() {
+    when(writer.exists(anyString())).thenReturn(false);
+
+    store.backupIfNeeded("orders", "42", 1, "AVRO",
+        "orders-value", "{}", null);
+
+    ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
+    verify(writer, times(2)).write(pathCaptor.capture(), anyString());
+
+    String schemaPath = pathCaptor.getAllValues().get(0);
+    assertTrue(schemaPath.startsWith("topics/orders/_metadata/schemas/"));
+  }
+}

--- a/core/src/test/java/io/confluent/connect/storage/backup/ObjectStoreSchemaBackupStoreTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/ObjectStoreSchemaBackupStoreTest.java
@@ -23,10 +23,8 @@ import org.mockito.Mockito;
 
 import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -35,21 +33,29 @@ import static org.mockito.Mockito.when;
 
 public class ObjectStoreSchemaBackupStoreTest {
 
+  private static final String TOPIC = "orders";
+  private static final String SUBJECT = "orders-value";
+  private static final String SCHEMA_KEY = "42";
+  private static final int VERSION = 1;
+  private static final String EMPTY_SCHEMA = "{}";
+  private static final String TOPICS_DIR = "topics";
+  private static final String DELIMITER = "/";
+
   private StorageWriter writer;
   private ObjectStoreSchemaBackupStore store;
 
   @Before
   public void setUp() {
     writer = mock(StorageWriter.class);
-    store = new ObjectStoreSchemaBackupStore(writer, "topics", "/");
+    store = new ObjectStoreSchemaBackupStore(writer, TOPICS_DIR, DELIMITER);
   }
 
   @Test
   public void testBackupWritesSchemaAndEntryFiles() {
     when(writer.exists(anyString())).thenReturn(false);
 
-    store.backupIfNeeded("orders", "42", 1, "AVRO",
-        "orders-value", "{\"type\":\"record\"}", null);
+    store.backupIfNeeded(TOPIC, SCHEMA_KEY, VERSION, BackupEnvelope.TYPE_AVRO,
+        SUBJECT, "{\"type\":\"record\"}", null);
 
     ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
     verify(writer, times(2)).write(pathCaptor.capture(), anyString());
@@ -62,8 +68,8 @@ public class ObjectStoreSchemaBackupStoreTest {
   public void testBackupProtobufExtension() {
     when(writer.exists(anyString())).thenReturn(false);
 
-    store.backupIfNeeded("orders", "10", 1, "PROTOBUF",
-        "orders-value", "syntax=\"proto3\";", null);
+    store.backupIfNeeded(TOPIC, "10", VERSION, BackupEnvelope.TYPE_PROTOBUF,
+        SUBJECT, "syntax=\"proto3\";", null);
 
     ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
     verify(writer, times(2)).write(pathCaptor.capture(), anyString());
@@ -74,8 +80,8 @@ public class ObjectStoreSchemaBackupStoreTest {
   public void testBackupJsonSchemaExtension() {
     when(writer.exists(anyString())).thenReturn(false);
 
-    store.backupIfNeeded("orders", "10", 1, "JSON_SCHEMA",
-        "orders-value", "{\"type\":\"object\"}", null);
+    store.backupIfNeeded(TOPIC, "10", VERSION, BackupEnvelope.TYPE_JSON_SCHEMA,
+        SUBJECT, "{\"type\":\"object\"}", null);
 
     ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
     verify(writer, times(2)).write(pathCaptor.capture(), anyString());
@@ -86,10 +92,10 @@ public class ObjectStoreSchemaBackupStoreTest {
   public void testLevel1DedupInMemory() {
     when(writer.exists(anyString())).thenReturn(false);
 
-    store.backupIfNeeded("orders", "42", 1, "AVRO",
-        "orders-value", "{}", null);
-    store.backupIfNeeded("orders", "42", 1, "AVRO",
-        "orders-value", "{}", null);
+    store.backupIfNeeded(TOPIC, SCHEMA_KEY, VERSION, BackupEnvelope.TYPE_AVRO,
+        SUBJECT, EMPTY_SCHEMA, null);
+    store.backupIfNeeded(TOPIC, SCHEMA_KEY, VERSION, BackupEnvelope.TYPE_AVRO,
+        SUBJECT, EMPTY_SCHEMA, null);
 
     verify(writer, times(2)).write(anyString(), anyString());
   }
@@ -98,18 +104,18 @@ public class ObjectStoreSchemaBackupStoreTest {
   public void testLevel2DedupExistsCheck() {
     when(writer.exists(anyString())).thenReturn(true);
 
-    store.backupIfNeeded("orders", "42", 1, "AVRO",
-        "orders-value", "{}", null);
+    store.backupIfNeeded(TOPIC, SCHEMA_KEY, VERSION, BackupEnvelope.TYPE_AVRO,
+        SUBJECT, EMPTY_SCHEMA, null);
 
     verify(writer, never()).write(anyString(), anyString());
   }
 
   @Test
   public void testNullOrEmptySchemaKeySkipped() {
-    store.backupIfNeeded("orders", null, 1, "AVRO",
-        "orders-value", "{}", null);
-    store.backupIfNeeded("orders", "", 1, "AVRO",
-        "orders-value", "{}", null);
+    store.backupIfNeeded(TOPIC, null, VERSION, BackupEnvelope.TYPE_AVRO,
+        SUBJECT, EMPTY_SCHEMA, null);
+    store.backupIfNeeded(TOPIC, "", VERSION, BackupEnvelope.TYPE_AVRO,
+        SUBJECT, EMPTY_SCHEMA, null);
 
     verify(writer, never()).write(anyString(), anyString());
     verify(writer, never()).exists(anyString());
@@ -119,12 +125,10 @@ public class ObjectStoreSchemaBackupStoreTest {
   public void testEntryFileContainsReferences() {
     when(writer.exists(anyString())).thenReturn(false);
     SchemaManifest.SchemaReferenceEntry ref =
-        new SchemaManifest.SchemaReferenceEntry(
-            "Address", "address-value", 1, 10);
+        new SchemaManifest.SchemaReferenceEntry("Address", "address-value", 1, 10);
 
-    store.backupIfNeeded("orders", "42", 1, "AVRO",
-        "orders-value", "{}",
-        Collections.singletonList(ref));
+    store.backupIfNeeded(TOPIC, SCHEMA_KEY, VERSION, BackupEnvelope.TYPE_AVRO,
+        SUBJECT, EMPTY_SCHEMA, Collections.singletonList(ref));
 
     ArgumentCaptor<String> contentCaptor = ArgumentCaptor.forClass(String.class);
     verify(writer, times(2)).write(anyString(), contentCaptor.capture());
@@ -142,16 +146,16 @@ public class ObjectStoreSchemaBackupStoreTest {
         .when(writer).write(anyString(), anyString());
 
     try {
-      store.backupIfNeeded("orders", "42", 1, "AVRO",
-          "orders-value", "{}", null);
+      store.backupIfNeeded(TOPIC, SCHEMA_KEY, VERSION, BackupEnvelope.TYPE_AVRO,
+          SUBJECT, EMPTY_SCHEMA, null);
     } catch (ConnectException expected) {
-      // first call: schema write succeeds, entry write fails
+      // schema write succeeds, entry write fails; retry below must resend both
     }
 
     when(writer.exists(anyString())).thenReturn(false);
     Mockito.doNothing().when(writer).write(anyString(), anyString());
-    store.backupIfNeeded("orders", "42", 1, "AVRO",
-        "orders-value", "{}", null);
+    store.backupIfNeeded(TOPIC, SCHEMA_KEY, VERSION, BackupEnvelope.TYPE_AVRO,
+        SUBJECT, EMPTY_SCHEMA, null);
 
     verify(writer, times(4)).write(anyString(), anyString());
   }
@@ -160,13 +164,12 @@ public class ObjectStoreSchemaBackupStoreTest {
   public void testSchemaPath() {
     when(writer.exists(anyString())).thenReturn(false);
 
-    store.backupIfNeeded("orders", "42", 1, "AVRO",
-        "orders-value", "{}", null);
+    store.backupIfNeeded(TOPIC, SCHEMA_KEY, VERSION, BackupEnvelope.TYPE_AVRO,
+        SUBJECT, EMPTY_SCHEMA, null);
 
     ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
     verify(writer, times(2)).write(pathCaptor.capture(), anyString());
 
-    String schemaPath = pathCaptor.getAllValues().get(0);
-    assertTrue(schemaPath.startsWith("topics/orders/_metadata/schemas/"));
+    assertTrue(pathCaptor.getAllValues().get(0).startsWith("topics/orders/_metadata/schemas/"));
   }
 }

--- a/core/src/test/java/io/confluent/connect/storage/backup/ObjectStoreSchemaBackupStoreTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/ObjectStoreSchemaBackupStoreTest.java
@@ -111,6 +111,21 @@ public class ObjectStoreSchemaBackupStoreTest {
   }
 
   @Test
+  public void testRepeatedCallsShortCircuitBeforeExistsCheck() {
+    when(writer.exists(anyString())).thenReturn(false);
+
+    store.backupIfNeeded(TOPIC, SCHEMA_KEY, VERSION, BackupEnvelope.TYPE_AVRO,
+        SUBJECT, EMPTY_SCHEMA, null);
+    store.backupIfNeeded(TOPIC, SCHEMA_KEY, VERSION, BackupEnvelope.TYPE_AVRO,
+        SUBJECT, EMPTY_SCHEMA, null);
+    store.backupIfNeeded(TOPIC, SCHEMA_KEY, VERSION, BackupEnvelope.TYPE_AVRO,
+        SUBJECT, EMPTY_SCHEMA, null);
+
+    verify(writer, times(1)).exists(anyString());
+    verify(writer, times(2)).write(anyString(), anyString());
+  }
+
+  @Test
   public void testNullOrEmptySchemaKeySkipped() {
     store.backupIfNeeded(TOPIC, null, VERSION, BackupEnvelope.TYPE_AVRO,
         SUBJECT, EMPTY_SCHEMA, null);

--- a/core/src/test/java/io/confluent/connect/storage/backup/SchemaManifestTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/SchemaManifestTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.storage.backup;
+
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class SchemaManifestTest {
+
+  @Test
+  public void testEntryFields() {
+    SchemaManifest.SchemaEntry entry = new SchemaManifest.SchemaEntry(
+        "42", "AVRO", "test-value", 1, "42.avsc",
+        Collections.emptyList());
+
+    assertEquals("42", entry.getId());
+    assertEquals("AVRO", entry.getType());
+    assertEquals("test-value", entry.getSubject());
+    assertEquals(1, entry.getVersion());
+    assertEquals("42.avsc", entry.getFile());
+    assertFalse(entry.hasReferences());
+  }
+
+  @Test
+  public void testEntryWithReferences() {
+    SchemaManifest.SchemaReferenceEntry ref = new SchemaManifest.SchemaReferenceEntry(
+        "Address", "address-value", 1, 10);
+    SchemaManifest.SchemaEntry entry = new SchemaManifest.SchemaEntry(
+        "42", "AVRO", "order-value", 1, "42.avsc",
+        Collections.singletonList(ref));
+
+    assertTrue(entry.hasReferences());
+    assertEquals(1, entry.getReferences().size());
+    assertEquals("Address", entry.getReferences().get(0).getName());
+    assertEquals("address-value", entry.getReferences().get(0).getSubject());
+    assertEquals(1, entry.getReferences().get(0).getVersion());
+    assertEquals(10, entry.getReferences().get(0).getGlobalId());
+  }
+
+  @Test
+  public void testEntryWithNullReferences() {
+    SchemaManifest.SchemaEntry entry = new SchemaManifest.SchemaEntry(
+        "10", "AVRO", "address-value", 1, "10.avsc", null);
+    assertFalse(entry.hasReferences());
+    assertTrue(entry.getReferences().isEmpty());
+  }
+
+  @Test
+  public void testEntryJsonRoundTrip() throws Exception {
+    SchemaManifest.SchemaReferenceEntry ref = new SchemaManifest.SchemaReferenceEntry(
+        "Country", "country-value", 1, 5);
+    SchemaManifest.SchemaEntry original = new SchemaManifest.SchemaEntry(
+        "42", "AVRO", "order-value", 3, "42.avsc",
+        Collections.singletonList(ref));
+
+    String json = original.toJsonString();
+    SchemaManifest.SchemaEntry restored = SchemaManifest.SchemaEntry.fromJsonString(json);
+
+    assertEquals(original.getId(), restored.getId());
+    assertEquals(original.getType(), restored.getType());
+    assertEquals(original.getSubject(), restored.getSubject());
+    assertEquals(original.getVersion(), restored.getVersion());
+    assertEquals(original.getFile(), restored.getFile());
+    assertTrue(restored.hasReferences());
+    assertEquals(1, restored.getReferences().size());
+    assertEquals("Country", restored.getReferences().get(0).getName());
+    assertEquals("country-value", restored.getReferences().get(0).getSubject());
+    assertEquals(1, restored.getReferences().get(0).getVersion());
+    assertEquals(5, restored.getReferences().get(0).getGlobalId());
+  }
+
+  @Test
+  public void testEntryJsonRoundTripNoReferences() throws Exception {
+    SchemaManifest.SchemaEntry original = new SchemaManifest.SchemaEntry(
+        "5", "PROTOBUF", "address-value", 1, "5.proto",
+        Collections.emptyList());
+
+    String json = original.toJsonString();
+    SchemaManifest.SchemaEntry restored = SchemaManifest.SchemaEntry.fromJsonString(json);
+
+    assertEquals("5", restored.getId());
+    assertEquals("PROTOBUF", restored.getType());
+    assertEquals("address-value", restored.getSubject());
+    assertEquals(1, restored.getVersion());
+    assertEquals("5.proto", restored.getFile());
+    assertFalse(restored.hasReferences());
+  }
+
+  @Test
+  public void testEntryJsonContainsFormatVersion() throws Exception {
+    SchemaManifest.SchemaEntry entry = new SchemaManifest.SchemaEntry(
+        "1", "AVRO", "test", 1, "1.avsc", null);
+    String json = entry.toJsonString();
+    assertTrue(json.contains("\"format\" : 1"));
+  }
+
+  @Test
+  public void testEntryFromJsonMissingFields() throws Exception {
+    String json = "{\"id\":7,\"type\":\"AVRO\",\"subject\":\"test\",\"file\":\"7.avsc\"}";
+    SchemaManifest.SchemaEntry entry =
+        SchemaManifest.SchemaEntry.fromJsonString(json);
+
+    assertEquals("7", entry.getId());
+    assertEquals("AVRO", entry.getType());
+    assertEquals("test", entry.getSubject());
+    assertEquals(0, entry.getVersion());
+    assertEquals("7.avsc", entry.getFile());
+    assertFalse(entry.hasReferences());
+  }
+
+  @Test
+  public void testEntryFromJsonUnknownFieldsIgnored() throws Exception {
+    String json = "{\"id\":1,\"type\":\"AVRO\",\"subject\":\"s\","
+        + "\"version\":1,\"file\":\"1.avsc\","
+        + "\"references\":[],\"futureField\":\"ignored\"}";
+    SchemaManifest.SchemaEntry entry =
+        SchemaManifest.SchemaEntry.fromJsonString(json);
+    assertNotNull(entry);
+    assertEquals("1", entry.getId());
+  }
+
+  @Test
+  public void testReferenceEntryJsonRoundTrip() throws Exception {
+    SchemaManifest.SchemaReferenceEntry original =
+        new SchemaManifest.SchemaReferenceEntry("Address", "address-value", 2, 10);
+
+    com.fasterxml.jackson.databind.JsonNode json = original.toJson();
+    SchemaManifest.SchemaReferenceEntry restored =
+        SchemaManifest.SchemaReferenceEntry.fromJson(json);
+
+    assertEquals("Address", restored.getName());
+    assertEquals("address-value", restored.getSubject());
+    assertEquals(2, restored.getVersion());
+    assertEquals(10, restored.getGlobalId());
+  }
+
+  @Test
+  public void testMultipleReferencesRoundTrip() throws Exception {
+    List<SchemaManifest.SchemaReferenceEntry> refs = java.util.Arrays.asList(
+        new SchemaManifest.SchemaReferenceEntry("Address", "address-value", 1, 10),
+        new SchemaManifest.SchemaReferenceEntry("Country", "country-value", 1, 5));
+    SchemaManifest.SchemaEntry original = new SchemaManifest.SchemaEntry(
+        "42", "AVRO", "user-value", 1, "42.avsc", refs);
+
+    String json = original.toJsonString();
+    SchemaManifest.SchemaEntry restored = SchemaManifest.SchemaEntry.fromJsonString(json);
+
+    assertEquals(2, restored.getReferences().size());
+    assertEquals("Address", restored.getReferences().get(0).getName());
+    assertEquals("Country", restored.getReferences().get(1).getName());
+  }
+}

--- a/core/src/test/java/io/confluent/connect/storage/backup/SchemaManifestTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/SchemaManifestTest.java
@@ -30,11 +30,11 @@ public class SchemaManifestTest {
   @Test
   public void testEntryFields() {
     SchemaManifest.SchemaEntry entry = new SchemaManifest.SchemaEntry(
-        "42", "AVRO", "test-value", 1, "42.avsc",
+        "42", BackupEnvelope.TYPE_AVRO, "test-value", 1, "42.avsc",
         Collections.emptyList());
 
     assertEquals("42", entry.getId());
-    assertEquals("AVRO", entry.getType());
+    assertEquals(BackupEnvelope.TYPE_AVRO, entry.getType());
     assertEquals("test-value", entry.getSubject());
     assertEquals(1, entry.getVersion());
     assertEquals("42.avsc", entry.getFile());
@@ -46,7 +46,7 @@ public class SchemaManifestTest {
     SchemaManifest.SchemaReferenceEntry ref = new SchemaManifest.SchemaReferenceEntry(
         "Address", "address-value", 1, 10);
     SchemaManifest.SchemaEntry entry = new SchemaManifest.SchemaEntry(
-        "42", "AVRO", "order-value", 1, "42.avsc",
+        "42", BackupEnvelope.TYPE_AVRO, "order-value", 1, "42.avsc",
         Collections.singletonList(ref));
 
     assertTrue(entry.hasReferences());
@@ -60,7 +60,7 @@ public class SchemaManifestTest {
   @Test
   public void testEntryWithNullReferences() {
     SchemaManifest.SchemaEntry entry = new SchemaManifest.SchemaEntry(
-        "10", "AVRO", "address-value", 1, "10.avsc", null);
+        "10", BackupEnvelope.TYPE_AVRO, "address-value", 1, "10.avsc", null);
     assertFalse(entry.hasReferences());
     assertTrue(entry.getReferences().isEmpty());
   }
@@ -70,7 +70,7 @@ public class SchemaManifestTest {
     SchemaManifest.SchemaReferenceEntry ref = new SchemaManifest.SchemaReferenceEntry(
         "Country", "country-value", 1, 5);
     SchemaManifest.SchemaEntry original = new SchemaManifest.SchemaEntry(
-        "42", "AVRO", "order-value", 3, "42.avsc",
+        "42", BackupEnvelope.TYPE_AVRO, "order-value", 3, "42.avsc",
         Collections.singletonList(ref));
 
     String json = original.toJsonString();
@@ -92,14 +92,14 @@ public class SchemaManifestTest {
   @Test
   public void testEntryJsonRoundTripNoReferences() throws Exception {
     SchemaManifest.SchemaEntry original = new SchemaManifest.SchemaEntry(
-        "5", "PROTOBUF", "address-value", 1, "5.proto",
+        "5", BackupEnvelope.TYPE_PROTOBUF, "address-value", 1, "5.proto",
         Collections.emptyList());
 
     String json = original.toJsonString();
     SchemaManifest.SchemaEntry restored = SchemaManifest.SchemaEntry.fromJsonString(json);
 
     assertEquals("5", restored.getId());
-    assertEquals("PROTOBUF", restored.getType());
+    assertEquals(BackupEnvelope.TYPE_PROTOBUF, restored.getType());
     assertEquals("address-value", restored.getSubject());
     assertEquals(1, restored.getVersion());
     assertEquals("5.proto", restored.getFile());
@@ -109,7 +109,7 @@ public class SchemaManifestTest {
   @Test
   public void testEntryJsonContainsFormatVersion() throws Exception {
     SchemaManifest.SchemaEntry entry = new SchemaManifest.SchemaEntry(
-        "1", "AVRO", "test", 1, "1.avsc", null);
+        "1", BackupEnvelope.TYPE_AVRO, "test", 1, "1.avsc", null);
     String json = entry.toJsonString();
     assertTrue(json.contains("\"format\" : 1"));
   }
@@ -121,7 +121,7 @@ public class SchemaManifestTest {
         SchemaManifest.SchemaEntry.fromJsonString(json);
 
     assertEquals("7", entry.getId());
-    assertEquals("AVRO", entry.getType());
+    assertEquals(BackupEnvelope.TYPE_AVRO, entry.getType());
     assertEquals("test", entry.getSubject());
     assertEquals(0, entry.getVersion());
     assertEquals("7.avsc", entry.getFile());
@@ -160,7 +160,7 @@ public class SchemaManifestTest {
         new SchemaManifest.SchemaReferenceEntry("Address", "address-value", 1, 10),
         new SchemaManifest.SchemaReferenceEntry("Country", "country-value", 1, 5));
     SchemaManifest.SchemaEntry original = new SchemaManifest.SchemaEntry(
-        "42", "AVRO", "user-value", 1, "42.avsc", refs);
+        "42", BackupEnvelope.TYPE_AVRO, "user-value", 1, "42.avsc", refs);
 
     String json = original.toJsonString();
     SchemaManifest.SchemaEntry restored = SchemaManifest.SchemaEntry.fromJsonString(json);

--- a/core/src/test/java/io/confluent/connect/storage/backup/SchemaManifestTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/SchemaManifestTest.java
@@ -27,6 +27,11 @@ import static org.junit.Assert.assertTrue;
 
 public class SchemaManifestTest {
 
+  private static final String REF_ADDRESS = "Address";
+  private static final String REF_ADDRESS_SUBJECT = "address-value";
+  private static final String REF_COUNTRY = "Country";
+  private static final String REF_COUNTRY_SUBJECT = "country-value";
+
   @Test
   public void testEntryFields() {
     SchemaManifest.SchemaEntry entry = new SchemaManifest.SchemaEntry(
@@ -44,15 +49,15 @@ public class SchemaManifestTest {
   @Test
   public void testEntryWithReferences() {
     SchemaManifest.SchemaReferenceEntry ref = new SchemaManifest.SchemaReferenceEntry(
-        "Address", "address-value", 1, 10);
+        REF_ADDRESS, REF_ADDRESS_SUBJECT, 1, 10);
     SchemaManifest.SchemaEntry entry = new SchemaManifest.SchemaEntry(
         "42", BackupEnvelope.TYPE_AVRO, "order-value", 1, "42.avsc",
         Collections.singletonList(ref));
 
     assertTrue(entry.hasReferences());
     assertEquals(1, entry.getReferences().size());
-    assertEquals("Address", entry.getReferences().get(0).getName());
-    assertEquals("address-value", entry.getReferences().get(0).getSubject());
+    assertEquals(REF_ADDRESS, entry.getReferences().get(0).getName());
+    assertEquals(REF_ADDRESS_SUBJECT, entry.getReferences().get(0).getSubject());
     assertEquals(1, entry.getReferences().get(0).getVersion());
     assertEquals(10, entry.getReferences().get(0).getGlobalId());
   }
@@ -60,7 +65,7 @@ public class SchemaManifestTest {
   @Test
   public void testEntryWithNullReferences() {
     SchemaManifest.SchemaEntry entry = new SchemaManifest.SchemaEntry(
-        "10", BackupEnvelope.TYPE_AVRO, "address-value", 1, "10.avsc", null);
+        "10", BackupEnvelope.TYPE_AVRO, REF_ADDRESS_SUBJECT, 1, "10.avsc", null);
     assertFalse(entry.hasReferences());
     assertTrue(entry.getReferences().isEmpty());
   }
@@ -68,7 +73,7 @@ public class SchemaManifestTest {
   @Test
   public void testEntryJsonRoundTrip() throws Exception {
     SchemaManifest.SchemaReferenceEntry ref = new SchemaManifest.SchemaReferenceEntry(
-        "Country", "country-value", 1, 5);
+        REF_COUNTRY, REF_COUNTRY_SUBJECT, 1, 5);
     SchemaManifest.SchemaEntry original = new SchemaManifest.SchemaEntry(
         "42", BackupEnvelope.TYPE_AVRO, "order-value", 3, "42.avsc",
         Collections.singletonList(ref));
@@ -83,8 +88,8 @@ public class SchemaManifestTest {
     assertEquals(original.getFile(), restored.getFile());
     assertTrue(restored.hasReferences());
     assertEquals(1, restored.getReferences().size());
-    assertEquals("Country", restored.getReferences().get(0).getName());
-    assertEquals("country-value", restored.getReferences().get(0).getSubject());
+    assertEquals(REF_COUNTRY, restored.getReferences().get(0).getName());
+    assertEquals(REF_COUNTRY_SUBJECT, restored.getReferences().get(0).getSubject());
     assertEquals(1, restored.getReferences().get(0).getVersion());
     assertEquals(5, restored.getReferences().get(0).getGlobalId());
   }
@@ -92,7 +97,7 @@ public class SchemaManifestTest {
   @Test
   public void testEntryJsonRoundTripNoReferences() throws Exception {
     SchemaManifest.SchemaEntry original = new SchemaManifest.SchemaEntry(
-        "5", BackupEnvelope.TYPE_PROTOBUF, "address-value", 1, "5.proto",
+        "5", BackupEnvelope.TYPE_PROTOBUF, REF_ADDRESS_SUBJECT, 1, "5.proto",
         Collections.emptyList());
 
     String json = original.toJsonString();
@@ -100,7 +105,7 @@ public class SchemaManifestTest {
 
     assertEquals("5", restored.getId());
     assertEquals(BackupEnvelope.TYPE_PROTOBUF, restored.getType());
-    assertEquals("address-value", restored.getSubject());
+    assertEquals(REF_ADDRESS_SUBJECT, restored.getSubject());
     assertEquals(1, restored.getVersion());
     assertEquals("5.proto", restored.getFile());
     assertFalse(restored.hasReferences());
@@ -142,14 +147,14 @@ public class SchemaManifestTest {
   @Test
   public void testReferenceEntryJsonRoundTrip() throws Exception {
     SchemaManifest.SchemaReferenceEntry original =
-        new SchemaManifest.SchemaReferenceEntry("Address", "address-value", 2, 10);
+        new SchemaManifest.SchemaReferenceEntry(REF_ADDRESS, REF_ADDRESS_SUBJECT, 2, 10);
 
     com.fasterxml.jackson.databind.JsonNode json = original.toJson();
     SchemaManifest.SchemaReferenceEntry restored =
         SchemaManifest.SchemaReferenceEntry.fromJson(json);
 
-    assertEquals("Address", restored.getName());
-    assertEquals("address-value", restored.getSubject());
+    assertEquals(REF_ADDRESS, restored.getName());
+    assertEquals(REF_ADDRESS_SUBJECT, restored.getSubject());
     assertEquals(2, restored.getVersion());
     assertEquals(10, restored.getGlobalId());
   }
@@ -157,8 +162,8 @@ public class SchemaManifestTest {
   @Test
   public void testMultipleReferencesRoundTrip() throws Exception {
     List<SchemaManifest.SchemaReferenceEntry> refs = java.util.Arrays.asList(
-        new SchemaManifest.SchemaReferenceEntry("Address", "address-value", 1, 10),
-        new SchemaManifest.SchemaReferenceEntry("Country", "country-value", 1, 5));
+        new SchemaManifest.SchemaReferenceEntry(REF_ADDRESS, REF_ADDRESS_SUBJECT, 1, 10),
+        new SchemaManifest.SchemaReferenceEntry(REF_COUNTRY, REF_COUNTRY_SUBJECT, 1, 5));
     SchemaManifest.SchemaEntry original = new SchemaManifest.SchemaEntry(
         "42", BackupEnvelope.TYPE_AVRO, "user-value", 1, "42.avsc", refs);
 
@@ -166,7 +171,7 @@ public class SchemaManifestTest {
     SchemaManifest.SchemaEntry restored = SchemaManifest.SchemaEntry.fromJsonString(json);
 
     assertEquals(2, restored.getReferences().size());
-    assertEquals("Address", restored.getReferences().get(0).getName());
-    assertEquals("Country", restored.getReferences().get(1).getName());
+    assertEquals(REF_ADDRESS, restored.getReferences().get(0).getName());
+    assertEquals(REF_COUNTRY, restored.getReferences().get(1).getName());
   }
 }

--- a/core/src/test/java/io/confluent/connect/storage/backup/SchemaManifestTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/backup/SchemaManifestTest.java
@@ -31,18 +31,20 @@ public class SchemaManifestTest {
   private static final String REF_ADDRESS_SUBJECT = "address-value";
   private static final String REF_COUNTRY = "Country";
   private static final String REF_COUNTRY_SUBJECT = "country-value";
+  private static final String ID_42 = "42";
+  private static final String FILE_42_AVSC = "42.avsc";
 
   @Test
   public void testEntryFields() {
     SchemaManifest.SchemaEntry entry = new SchemaManifest.SchemaEntry(
-        "42", BackupEnvelope.TYPE_AVRO, "test-value", 1, "42.avsc",
+        ID_42, BackupEnvelope.TYPE_AVRO, "test-value", 1, FILE_42_AVSC,
         Collections.emptyList());
 
-    assertEquals("42", entry.getId());
+    assertEquals(ID_42, entry.getId());
     assertEquals(BackupEnvelope.TYPE_AVRO, entry.getType());
     assertEquals("test-value", entry.getSubject());
     assertEquals(1, entry.getVersion());
-    assertEquals("42.avsc", entry.getFile());
+    assertEquals(FILE_42_AVSC, entry.getFile());
     assertFalse(entry.hasReferences());
   }
 
@@ -51,7 +53,7 @@ public class SchemaManifestTest {
     SchemaManifest.SchemaReferenceEntry ref = new SchemaManifest.SchemaReferenceEntry(
         REF_ADDRESS, REF_ADDRESS_SUBJECT, 1, 10);
     SchemaManifest.SchemaEntry entry = new SchemaManifest.SchemaEntry(
-        "42", BackupEnvelope.TYPE_AVRO, "order-value", 1, "42.avsc",
+        ID_42, BackupEnvelope.TYPE_AVRO, "order-value", 1, FILE_42_AVSC,
         Collections.singletonList(ref));
 
     assertTrue(entry.hasReferences());
@@ -75,7 +77,7 @@ public class SchemaManifestTest {
     SchemaManifest.SchemaReferenceEntry ref = new SchemaManifest.SchemaReferenceEntry(
         REF_COUNTRY, REF_COUNTRY_SUBJECT, 1, 5);
     SchemaManifest.SchemaEntry original = new SchemaManifest.SchemaEntry(
-        "42", BackupEnvelope.TYPE_AVRO, "order-value", 3, "42.avsc",
+        ID_42, BackupEnvelope.TYPE_AVRO, "order-value", 3, FILE_42_AVSC,
         Collections.singletonList(ref));
 
     String json = original.toJsonString();
@@ -165,7 +167,7 @@ public class SchemaManifestTest {
         new SchemaManifest.SchemaReferenceEntry(REF_ADDRESS, REF_ADDRESS_SUBJECT, 1, 10),
         new SchemaManifest.SchemaReferenceEntry(REF_COUNTRY, REF_COUNTRY_SUBJECT, 1, 5));
     SchemaManifest.SchemaEntry original = new SchemaManifest.SchemaEntry(
-        "42", BackupEnvelope.TYPE_AVRO, "user-value", 1, "42.avsc", refs);
+        ID_42, BackupEnvelope.TYPE_AVRO, "user-value", 1, FILE_42_AVSC, refs);
 
     String json = original.toJsonString();
     SchemaManifest.SchemaEntry restored = SchemaManifest.SchemaEntry.fromJsonString(json);

--- a/format/pom.xml
+++ b/format/pom.xml
@@ -39,6 +39,20 @@
             <artifactId>kafka-connect-avro-data</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-schema-converter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-connect-storage-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-connect-schema-backup-api</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-column</artifactId>
             <version>${parquet.version}</version>
@@ -57,6 +71,12 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.23.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/format/pom.xml
+++ b/format/pom.xml
@@ -45,8 +45,6 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-schema-backup-api</artifactId>
-            <version>8.4.0-736</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.parquet</groupId>

--- a/format/pom.xml
+++ b/format/pom.xml
@@ -40,16 +40,12 @@
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
-            <artifactId>kafka-schema-converter</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-storage-core</artifactId>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-schema-backup-api</artifactId>
-            <version>${io.confluent.schema-registry.version}</version>
+            <version>8.4.0-736</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -76,7 +72,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.23.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/format/src/main/java/io/confluent/connect/storage/format/backup/BackupWrapperExtractor.java
+++ b/format/src/main/java/io/confluent/connect/storage/format/backup/BackupWrapperExtractor.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.storage.format.backup;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.confluent.connect.schema.backup.api.BackupWrapper;
+import io.confluent.connect.storage.backup.BackupEnvelope;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Extracts data and metadata from a backup Wrapper struct.
+ * Handles SR-wrapped, tombstone, schemaless JSON, and non-SR record types.
+ */
+public final class BackupWrapperExtractor {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private BackupWrapperExtractor() {
+  }
+
+  /**
+   * Unwrap a key or value from a SinkRecord, extracting backup metadata
+   * if the data is wrapped in a Wrapper struct.
+   */
+  public static Unwrapped unwrap(
+      Object data, Schema schema, boolean isKey, String schemaTypeDefault) {
+    if (BackupWrapper.isWrapper(schema) && data instanceof Struct) {
+      return unwrapFromWrapper((Struct) data, schema);
+    }
+    if (schema == null && data == null) {
+      return Unwrapped.tombstone();
+    }
+    if (schema == null) {
+      return unwrapSchemaless(data);
+    }
+    return Unwrapped.passthrough(data, schema, schemaTypeDefault);
+  }
+
+  private static Unwrapped unwrapFromWrapper(Struct w, Schema schema) {
+    if (schema == null) {
+      throw new DataException("Wrapper schema is null — cannot unwrap backup metadata");
+    }
+    if (schema.field(BackupWrapper.FIELD_DATA) == null) {
+      throw new DataException("Wrapper schema missing 'data' field — corrupt Wrapper struct");
+    }
+    Integer schemaVersion = optionalInt32(w, schema, BackupWrapper.FIELD_SCHEMA_VERSION);
+    String referenceTreeJson = optionalString(w, schema, BackupWrapper.FIELD_REFERENCE_TREE);
+    String directRefsJson = optionalString(w, schema, BackupWrapper.FIELD_DIRECT_REFS);
+    String schemaGuid = optionalString(w, schema, BackupWrapper.FIELD_SCHEMA_GUID);
+    return new Unwrapped(
+        w.get(BackupWrapper.FIELD_DATA),
+        schema.field(BackupWrapper.FIELD_DATA).schema(),
+        optionalInt32(w, schema, BackupWrapper.FIELD_SCHEMA_ID),
+        schemaVersion,
+        optionalString(w, schema, BackupWrapper.FIELD_SCHEMA_TYPE),
+        optionalString(w, schema, BackupWrapper.FIELD_SCHEMA_SUBJECT),
+        optionalString(w, schema, BackupWrapper.FIELD_RAW_SCHEMA),
+        referenceTreeJson,
+        directRefsJson,
+        schemaGuid);
+  }
+
+  private static Unwrapped unwrapSchemaless(Object data) {
+    String stringData;
+    if (data instanceof Map || data instanceof List) {
+      try {
+        stringData = OBJECT_MAPPER.writeValueAsString(data);
+      } catch (JsonProcessingException e) {
+        throw new DataException("Failed to serialize schemaless data as JSON", e);
+      }
+    } else {
+      stringData = data != null ? data.toString() : null;
+    }
+    return new Unwrapped(stringData, null, null, null,
+        BackupEnvelope.TYPE_JSON_SCHEMALESS, null, null, null, null, null);
+  }
+
+  private static Integer optionalInt32(Struct s, Schema schema, String field) {
+    return schema.field(field) != null ? s.getInt32(field) : null;
+  }
+
+  private static String optionalString(Struct s, Schema schema, String field) {
+    return schema.field(field) != null ? s.getString(field) : null;
+  }
+
+  /**
+   * Result of unwrapping a Wrapper struct, containing all backup metadata.
+   */
+  public static class Unwrapped {
+    private final Object data;
+    private final Schema schema;
+    private final Integer schemaId;
+    private final Integer schemaVersion;
+    private final String schemaType;
+    private final String subject;
+    private final String rawSchema;
+    private final String referenceTreeJson;
+    private final String directRefsJson;
+    private final String schemaGuid;
+
+    Unwrapped(Object data, Schema schema,
+        Integer schemaId, Integer schemaVersion,
+        String schemaType, String subject, String rawSchema,
+        String referenceTreeJson, String directRefsJson,
+        String schemaGuid) {
+      this.data = data;
+      this.schema = schema;
+      this.schemaId = schemaId;
+      this.schemaVersion = schemaVersion;
+      this.schemaType = schemaType;
+      this.subject = subject;
+      this.rawSchema = rawSchema;
+      this.referenceTreeJson = referenceTreeJson;
+      this.directRefsJson = directRefsJson;
+      this.schemaGuid = schemaGuid;
+    }
+
+    static Unwrapped tombstone() {
+      return new Unwrapped(null, null, null, null,
+          BackupEnvelope.TYPE_NONE, null, null, null, null, null);
+    }
+
+    static Unwrapped passthrough(Object data, Schema schema, String schemaType) {
+      return new Unwrapped(data, schema, null, null,
+          schemaType, null, null, null, null, null);
+    }
+
+    public Object getData() {
+      return data;
+    }
+
+    public Schema getSchema() {
+      return schema;
+    }
+
+    public Integer getSchemaId() {
+      return schemaId;
+    }
+
+    public Integer getSchemaVersion() {
+      return schemaVersion;
+    }
+
+    public String getSchemaType() {
+      return schemaType;
+    }
+
+    public String getSubject() {
+      return subject;
+    }
+
+    public String getRawSchema() {
+      return rawSchema;
+    }
+
+    public String getReferenceTreeJson() {
+      return referenceTreeJson;
+    }
+
+    public String getDirectRefsJson() {
+      return directRefsJson;
+    }
+
+    public String getSchemaGuid() {
+      return schemaGuid;
+    }
+  }
+}

--- a/format/src/main/java/io/confluent/connect/storage/format/backup/BackupWrapperExtractor.java
+++ b/format/src/main/java/io/confluent/connect/storage/format/backup/BackupWrapperExtractor.java
@@ -55,25 +55,25 @@ public final class BackupWrapperExtractor {
     return Unwrapped.passthrough(data, schema, schemaTypeDefault);
   }
 
-  private static Unwrapped unwrapFromWrapper(Struct w, Schema schema) {
+  private static Unwrapped unwrapFromWrapper(Struct wrapper, Schema schema) {
     if (schema == null) {
       throw new DataException("Wrapper schema is null — cannot unwrap backup metadata");
     }
     if (schema.field(BackupWrapper.FIELD_DATA) == null) {
       throw new DataException("Wrapper schema missing 'data' field — corrupt Wrapper struct");
     }
-    Integer schemaVersion = optionalInt32(w, schema, BackupWrapper.FIELD_SCHEMA_VERSION);
-    String referenceTreeJson = optionalString(w, schema, BackupWrapper.FIELD_REFERENCE_TREE);
-    String directRefsJson = optionalString(w, schema, BackupWrapper.FIELD_DIRECT_REFS);
-    String schemaGuid = optionalString(w, schema, BackupWrapper.FIELD_SCHEMA_GUID);
+    Integer schemaVersion = optionalInt32(wrapper, schema, BackupWrapper.FIELD_SCHEMA_VERSION);
+    String referenceTreeJson = optionalString(wrapper, schema, BackupWrapper.FIELD_REFERENCE_TREE);
+    String directRefsJson = optionalString(wrapper, schema, BackupWrapper.FIELD_DIRECT_REFS);
+    String schemaGuid = optionalString(wrapper, schema, BackupWrapper.FIELD_SCHEMA_GUID);
     return new Unwrapped(
-        w.get(BackupWrapper.FIELD_DATA),
+        wrapper.get(BackupWrapper.FIELD_DATA),
         schema.field(BackupWrapper.FIELD_DATA).schema(),
-        optionalInt32(w, schema, BackupWrapper.FIELD_SCHEMA_ID),
+        optionalInt32(wrapper, schema, BackupWrapper.FIELD_SCHEMA_ID),
         schemaVersion,
-        optionalString(w, schema, BackupWrapper.FIELD_SCHEMA_TYPE),
-        optionalString(w, schema, BackupWrapper.FIELD_SCHEMA_SUBJECT),
-        optionalString(w, schema, BackupWrapper.FIELD_RAW_SCHEMA),
+        optionalString(wrapper, schema, BackupWrapper.FIELD_SCHEMA_TYPE),
+        optionalString(wrapper, schema, BackupWrapper.FIELD_SCHEMA_SUBJECT),
+        optionalString(wrapper, schema, BackupWrapper.FIELD_RAW_SCHEMA),
         referenceTreeJson,
         directRefsJson,
         schemaGuid);
@@ -94,12 +94,12 @@ public final class BackupWrapperExtractor {
         BackupEnvelope.TYPE_JSON_SCHEMALESS, null, null, null, null, null);
   }
 
-  private static Integer optionalInt32(Struct s, Schema schema, String field) {
-    return schema.field(field) != null ? s.getInt32(field) : null;
+  private static Integer optionalInt32(Struct wrapper, Schema schema, String field) {
+    return schema.field(field) != null ? wrapper.getInt32(field) : null;
   }
 
-  private static String optionalString(Struct s, Schema schema, String field) {
-    return schema.field(field) != null ? s.getString(field) : null;
+  private static String optionalString(Struct wrapper, Schema schema, String field) {
+    return schema.field(field) != null ? wrapper.getString(field) : null;
   }
 
   /**

--- a/format/src/main/java/io/confluent/connect/storage/format/backup/BackupWrapperExtractor.java
+++ b/format/src/main/java/io/confluent/connect/storage/format/backup/BackupWrapperExtractor.java
@@ -22,6 +22,8 @@ import io.confluent.connect.storage.backup.BackupEnvelope;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Extracts data and metadata from a backup Wrapper struct.
@@ -29,6 +31,8 @@ import org.apache.kafka.connect.errors.DataException;
  */
 public final class BackupWrapperExtractor {
 
+  private static final Logger log =
+      LoggerFactory.getLogger(BackupWrapperExtractor.class);
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private BackupWrapperExtractor() {
@@ -59,17 +63,22 @@ public final class BackupWrapperExtractor {
     if (schema.field(BackupWrapper.FIELD_DATA) == null) {
       throw new DataException("Wrapper schema missing 'data' field — corrupt Wrapper struct");
     }
+    Integer schemaId = optionalInt32(wrapper, schema, BackupWrapper.FIELD_SCHEMA_ID);
     Integer schemaVersion = optionalInt32(wrapper, schema, BackupWrapper.FIELD_SCHEMA_VERSION);
+    String schemaType = optionalString(wrapper, schema, BackupWrapper.FIELD_SCHEMA_TYPE);
+    String subject = optionalString(wrapper, schema, BackupWrapper.FIELD_SCHEMA_SUBJECT);
     String referenceTreeJson = optionalString(wrapper, schema, BackupWrapper.FIELD_REFERENCE_TREE);
     String directRefsJson = optionalString(wrapper, schema, BackupWrapper.FIELD_DIRECT_REFS);
     String schemaGuid = optionalString(wrapper, schema, BackupWrapper.FIELD_SCHEMA_GUID);
+    log.debug("Unwrapped Wrapper: schemaType={}, schemaId={}, subject={}, hasReferences={}",
+        schemaType, schemaId, subject, referenceTreeJson != null);
     return new Unwrapped(
         wrapper.get(BackupWrapper.FIELD_DATA),
         schema.field(BackupWrapper.FIELD_DATA).schema(),
-        optionalInt32(wrapper, schema, BackupWrapper.FIELD_SCHEMA_ID),
+        schemaId,
         schemaVersion,
-        optionalString(wrapper, schema, BackupWrapper.FIELD_SCHEMA_TYPE),
-        optionalString(wrapper, schema, BackupWrapper.FIELD_SCHEMA_SUBJECT),
+        schemaType,
+        subject,
         optionalString(wrapper, schema, BackupWrapper.FIELD_RAW_SCHEMA),
         referenceTreeJson,
         directRefsJson,

--- a/format/src/main/java/io/confluent/connect/storage/format/backup/BackupWrapperExtractor.java
+++ b/format/src/main/java/io/confluent/connect/storage/format/backup/BackupWrapperExtractor.java
@@ -72,17 +72,18 @@ public final class BackupWrapperExtractor {
     String schemaGuid = optionalString(wrapper, schema, BackupWrapper.FIELD_SCHEMA_GUID);
     log.debug("Unwrapped Wrapper: schemaType={}, schemaId={}, subject={}, hasReferences={}",
         schemaType, schemaId, subject, referenceTreeJson != null);
-    return new Unwrapped(
-        wrapper.get(BackupWrapper.FIELD_DATA),
-        schema.field(BackupWrapper.FIELD_DATA).schema(),
-        schemaId,
-        schemaVersion,
-        schemaType,
-        subject,
-        optionalString(wrapper, schema, BackupWrapper.FIELD_RAW_SCHEMA),
-        referenceTreeJson,
-        directRefsJson,
-        schemaGuid);
+    return Unwrapped.builder()
+        .data(wrapper.get(BackupWrapper.FIELD_DATA))
+        .schema(schema.field(BackupWrapper.FIELD_DATA).schema())
+        .schemaId(schemaId)
+        .schemaVersion(schemaVersion)
+        .schemaType(schemaType)
+        .subject(subject)
+        .rawSchema(optionalString(wrapper, schema, BackupWrapper.FIELD_RAW_SCHEMA))
+        .referenceTreeJson(referenceTreeJson)
+        .directRefsJson(directRefsJson)
+        .schemaGuid(schemaGuid)
+        .build();
   }
 
   private static Unwrapped unwrapSchemaless(Object data) {
@@ -96,8 +97,10 @@ public final class BackupWrapperExtractor {
         throw new DataException("Failed to serialize schemaless data as JSON", e);
       }
     }
-    return new Unwrapped(stringData, null, null, null,
-        BackupEnvelope.TYPE_JSON_SCHEMALESS, null, null, null, null, null);
+    return Unwrapped.builder()
+        .data(stringData)
+        .schemaType(BackupEnvelope.TYPE_JSON_SCHEMALESS)
+        .build();
   }
 
   private static Integer optionalInt32(Struct wrapper, Schema schema, String field) {
@@ -123,31 +126,96 @@ public final class BackupWrapperExtractor {
     private final String directRefsJson;
     private final String schemaGuid;
 
-    Unwrapped(Object data, Schema schema,
-        Integer schemaId, Integer schemaVersion,
-        String schemaType, String subject, String rawSchema,
-        String referenceTreeJson, String directRefsJson,
-        String schemaGuid) {
-      this.data = data;
-      this.schema = schema;
-      this.schemaId = schemaId;
-      this.schemaVersion = schemaVersion;
-      this.schemaType = schemaType;
-      this.subject = subject;
-      this.rawSchema = rawSchema;
-      this.referenceTreeJson = referenceTreeJson;
-      this.directRefsJson = directRefsJson;
-      this.schemaGuid = schemaGuid;
+    private Unwrapped(Builder b) {
+      this.data = b.data;
+      this.schema = b.schema;
+      this.schemaId = b.schemaId;
+      this.schemaVersion = b.schemaVersion;
+      this.schemaType = b.schemaType;
+      this.subject = b.subject;
+      this.rawSchema = b.rawSchema;
+      this.referenceTreeJson = b.referenceTreeJson;
+      this.directRefsJson = b.directRefsJson;
+      this.schemaGuid = b.schemaGuid;
+    }
+
+    static Builder builder() {
+      return new Builder();
     }
 
     static Unwrapped tombstone() {
-      return new Unwrapped(null, null, null, null,
-          BackupEnvelope.TYPE_NONE, null, null, null, null, null);
+      return builder().schemaType(BackupEnvelope.TYPE_NONE).build();
     }
 
     static Unwrapped passthrough(Object data, Schema schema, String schemaType) {
-      return new Unwrapped(data, schema, null, null,
-          schemaType, null, null, null, null, null);
+      return builder().data(data).schema(schema).schemaType(schemaType).build();
+    }
+
+    static class Builder {
+      private Object data;
+      private Schema schema;
+      private Integer schemaId;
+      private Integer schemaVersion;
+      private String schemaType;
+      private String subject;
+      private String rawSchema;
+      private String referenceTreeJson;
+      private String directRefsJson;
+      private String schemaGuid;
+
+      Builder data(Object v) {
+        this.data = v;
+        return this;
+      }
+
+      Builder schema(Schema v) {
+        this.schema = v;
+        return this;
+      }
+
+      Builder schemaId(Integer v) {
+        this.schemaId = v;
+        return this;
+      }
+
+      Builder schemaVersion(Integer v) {
+        this.schemaVersion = v;
+        return this;
+      }
+
+      Builder schemaType(String v) {
+        this.schemaType = v;
+        return this;
+      }
+
+      Builder subject(String v) {
+        this.subject = v;
+        return this;
+      }
+
+      Builder rawSchema(String v) {
+        this.rawSchema = v;
+        return this;
+      }
+
+      Builder referenceTreeJson(String v) {
+        this.referenceTreeJson = v;
+        return this;
+      }
+
+      Builder directRefsJson(String v) {
+        this.directRefsJson = v;
+        return this;
+      }
+
+      Builder schemaGuid(String v) {
+        this.schemaGuid = v;
+        return this;
+      }
+
+      Unwrapped build() {
+        return new Unwrapped(this);
+      }
     }
 
     public Object getData() {

--- a/format/src/main/java/io/confluent/connect/storage/format/backup/BackupWrapperExtractor.java
+++ b/format/src/main/java/io/confluent/connect/storage/format/backup/BackupWrapperExtractor.java
@@ -23,9 +23,6 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
 
-import java.util.List;
-import java.util.Map;
-
 /**
  * Extracts data and metadata from a backup Wrapper struct.
  * Handles SR-wrapped, tombstone, schemaless JSON, and non-SR record types.
@@ -81,14 +78,14 @@ public final class BackupWrapperExtractor {
 
   private static Unwrapped unwrapSchemaless(Object data) {
     String stringData;
-    if (data instanceof Map || data instanceof List) {
+    if (data == null) {
+      stringData = null;
+    } else {
       try {
         stringData = OBJECT_MAPPER.writeValueAsString(data);
       } catch (JsonProcessingException e) {
         throw new DataException("Failed to serialize schemaless data as JSON", e);
       }
-    } else {
-      stringData = data != null ? data.toString() : null;
     }
     return new Unwrapped(stringData, null, null, null,
         BackupEnvelope.TYPE_JSON_SCHEMALESS, null, null, null, null, null);

--- a/format/src/main/java/io/confluent/connect/storage/format/backup/EnvelopeTransformer.java
+++ b/format/src/main/java/io/confluent/connect/storage/format/backup/EnvelopeTransformer.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.storage.format.backup;
+
+import io.confluent.connect.storage.backup.EnvelopeSchemaBuilder;
+import io.confluent.connect.storage.backup.SchemaBackupStore;
+import io.confluent.connect.storage.format.backup.BackupWrapperExtractor.Unwrapped;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Transforms SinkRecords into envelope-wrapped SinkRecords for backup mode.
+ *
+ * <p>Wraps each record in a {@code KafkaRecordEnvelope} struct that captures
+ * the full record context (key, value, headers, topic, partition, offset,
+ * timestamp) along with schema metadata. Schema file backup is delegated
+ * to {@link SchemaBackupOrchestrator}.
+ *
+ * <p>The resulting envelope SinkRecord has a consistent, non-null schema
+ * that changes only when the key or value schema changes — including
+ * tombstone transitions. This allows {@code TopicPartitionWriter} to
+ * handle file rotation naturally via its existing schema change detection.
+ *
+ * <p>Created in {@code BackupSinkTask.start()}, used in {@code put()},
+ * released in {@code stop()}.
+ */
+public class EnvelopeTransformer {
+
+  private static final Logger log = LoggerFactory.getLogger(EnvelopeTransformer.class);
+
+  private final SchemaBackupOrchestrator schemaBackup;
+  private final String keySchemaTypeDefault;
+  private final String valueSchemaTypeDefault;
+
+  public EnvelopeTransformer(
+      SchemaBackupStore backupStore,
+      String keySchemaTypeDefault,
+      String valueSchemaTypeDefault) {
+    this.schemaBackup = new SchemaBackupOrchestrator(backupStore);
+    this.keySchemaTypeDefault = keySchemaTypeDefault;
+    this.valueSchemaTypeDefault = valueSchemaTypeDefault;
+  }
+
+  /**
+   * Wraps a batch of SinkRecords in envelope structs.
+   * Also backs up schema files for any new schemas encountered.
+   *
+   * @param records the records from {@code put()}
+   * @return wrapped records ready for {@code TopicPartitionWriter}
+   */
+  public Collection<SinkRecord> wrapAll(Collection<SinkRecord> records) {
+    List<SinkRecord> wrapped = new ArrayList<>(records.size());
+    for (SinkRecord record : records) {
+      wrapped.add(wrap(record));
+    }
+    return wrapped;
+  }
+
+  /**
+   * Wraps a single SinkRecord in an envelope struct.
+   * Backs up schema files as a side effect (idempotent).
+   *
+   * @param record the original SinkRecord
+   * @return a new SinkRecord with envelope schema and struct as value
+   */
+  public SinkRecord wrap(SinkRecord record) {
+    Unwrapped key = BackupWrapperExtractor.unwrap(
+        record.key(), record.keySchema(), true, keySchemaTypeDefault);
+    Unwrapped value = BackupWrapperExtractor.unwrap(
+        record.value(), record.valueSchema(), false, valueSchemaTypeDefault);
+
+    if (key.getData() == null && value.getData() == null) {
+      throw new DataException(
+          "Both key and value are null for record at topic=" + record.topic()
+              + ", partition=" + record.kafkaPartition()
+              + ", offset=" + record.kafkaOffset()
+              + ". Envelope backup requires at least one non-null.");
+    }
+
+    log.debug("Envelope: topic={}, offset={}, keyType={}, valType={}, keyId={}, valId={}",
+        record.topic(), record.kafkaOffset(),
+        key.getSchemaType(), value.getSchemaType(),
+        key.getSchemaId(), value.getSchemaId());
+
+    schemaBackup.backupIfNeeded(record.topic(), key);
+    schemaBackup.backupIfNeeded(record.topic(), value);
+
+    Schema envelopeSchema = EnvelopeSchemaBuilder
+        .buildEnvelopeSchema(key.getSchema(), value.getSchema(),
+            key.getSchemaType(), value.getSchemaType());
+
+    Struct envelope = EnvelopeSchemaBuilder
+        .buildEnvelopeStruct(envelopeSchema, record,
+            key.getData(), value.getData(),
+            new EnvelopeSchemaBuilder.SchemaDescriptor(
+                key.getSchemaId(), key.getSchemaType(),
+                key.getSubject(), key.getSchemaGuid()),
+            new EnvelopeSchemaBuilder.SchemaDescriptor(
+                value.getSchemaId(), value.getSchemaType(),
+                value.getSubject(), value.getSchemaGuid()));
+
+    return new SinkRecord(
+        record.topic(), record.kafkaPartition(),
+        null, null,
+        envelopeSchema, envelope,
+        record.kafkaOffset(),
+        record.timestamp(),
+        record.timestampType());
+  }
+}

--- a/format/src/main/java/io/confluent/connect/storage/format/backup/EnvelopeTransformer.java
+++ b/format/src/main/java/io/confluent/connect/storage/format/backup/EnvelopeTransformer.java
@@ -91,15 +91,16 @@ public class EnvelopeTransformer {
         record.value(), record.valueSchema(), false, valueSchemaTypeDefault);
 
     if (key.getData() == null && value.getData() == null) {
-      throw new DataException(
-          "Cannot backup record at topic=" + record.topic()
-              + ", partition=" + record.kafkaPartition()
-              + ", offset=" + record.kafkaOffset()
-              + ": both unwrapped key and value are null. This means either"
-              + " the source record had null key AND null value (which is not"
-              + " a meaningful Kafka message), or a wrapper struct's 'data'"
-              + " field was null on both sides. Envelope backup requires at"
-              + " least one non-null side.");
+      String msg = "Cannot backup record at topic=" + record.topic()
+          + ", partition=" + record.kafkaPartition()
+          + ", offset=" + record.kafkaOffset()
+          + ": both unwrapped key and value are null. This means either"
+          + " the source record had null key AND null value (which is not"
+          + " a meaningful Kafka message), or a wrapper struct's 'data'"
+          + " field was null on both sides. Envelope backup requires at"
+          + " least one non-null side.";
+      log.error(msg);
+      throw new DataException(msg);
     }
 
     log.debug("Envelope: topic={}, offset={}, keyType={}, valType={}, keyId={}, valId={}",

--- a/format/src/main/java/io/confluent/connect/storage/format/backup/EnvelopeTransformer.java
+++ b/format/src/main/java/io/confluent/connect/storage/format/backup/EnvelopeTransformer.java
@@ -92,10 +92,14 @@ public class EnvelopeTransformer {
 
     if (key.getData() == null && value.getData() == null) {
       throw new DataException(
-          "Both key and value are null for record at topic=" + record.topic()
+          "Cannot backup record at topic=" + record.topic()
               + ", partition=" + record.kafkaPartition()
               + ", offset=" + record.kafkaOffset()
-              + ". Envelope backup requires at least one non-null.");
+              + ": both unwrapped key and value are null. This means either"
+              + " the source record had null key AND null value (which is not"
+              + " a meaningful Kafka message), or a wrapper struct's 'data'"
+              + " field was null on both sides. Envelope backup requires at"
+              + " least one non-null side.");
     }
 
     log.debug("Envelope: topic={}, offset={}, keyType={}, valType={}, keyId={}, valId={}",

--- a/format/src/main/java/io/confluent/connect/storage/format/backup/EnvelopeTransformer.java
+++ b/format/src/main/java/io/confluent/connect/storage/format/backup/EnvelopeTransformer.java
@@ -71,8 +71,8 @@ public class EnvelopeTransformer {
    */
   public Collection<SinkRecord> wrapAll(Collection<SinkRecord> records) {
     List<SinkRecord> wrapped = new ArrayList<>(records.size());
-    for (SinkRecord record : records) {
-      wrapped.add(wrap(record));
+    for (SinkRecord sinkRecord : records) {
+      wrapped.add(wrap(sinkRecord));
     }
     return wrapped;
   }
@@ -81,19 +81,19 @@ public class EnvelopeTransformer {
    * Wraps a single SinkRecord in an envelope struct.
    * Backs up schema files as a side effect (idempotent).
    *
-   * @param record the original SinkRecord
+   * @param sinkRecord the original SinkRecord
    * @return a new SinkRecord with envelope schema and struct as value
    */
-  public SinkRecord wrap(SinkRecord record) {
+  public SinkRecord wrap(SinkRecord sinkRecord) {
     Unwrapped key = BackupWrapperExtractor.unwrap(
-        record.key(), record.keySchema(), true, keySchemaTypeDefault);
+        sinkRecord.key(), sinkRecord.keySchema(), true, keySchemaTypeDefault);
     Unwrapped value = BackupWrapperExtractor.unwrap(
-        record.value(), record.valueSchema(), false, valueSchemaTypeDefault);
+        sinkRecord.value(), sinkRecord.valueSchema(), false, valueSchemaTypeDefault);
 
     if (key.getData() == null && value.getData() == null) {
-      String msg = "Cannot backup record at topic=" + record.topic()
-          + ", partition=" + record.kafkaPartition()
-          + ", offset=" + record.kafkaOffset()
+      String msg = "Cannot backup record at topic=" + sinkRecord.topic()
+          + ", partition=" + sinkRecord.kafkaPartition()
+          + ", offset=" + sinkRecord.kafkaOffset()
           + ": both unwrapped key and value are null. This means either"
           + " the source record had null key AND null value (which is not"
           + " a meaningful Kafka message), or a wrapper struct's 'data'"
@@ -104,18 +104,18 @@ public class EnvelopeTransformer {
     }
 
     log.debug("Envelope: topic={}, offset={}, keyType={}, valType={}, keyId={}, valId={}",
-        record.topic(), record.kafkaOffset(),
+        sinkRecord.topic(), sinkRecord.kafkaOffset(),
         key.getSchemaType(), value.getSchemaType(),
         key.getSchemaId(), value.getSchemaId());
 
-    schemaBackup.backupIfNeeded(record.topic(), key);
-    schemaBackup.backupIfNeeded(record.topic(), value);
+    schemaBackup.backupIfNeeded(sinkRecord.topic(), key);
+    schemaBackup.backupIfNeeded(sinkRecord.topic(), value);
 
     Schema envelopeSchema = EnvelopeSchemaBuilder
         .buildEnvelopeSchema(key.getSchema(), value.getSchema());
 
     Struct envelope = EnvelopeSchemaBuilder
-        .buildEnvelopeStruct(envelopeSchema, record,
+        .buildEnvelopeStruct(envelopeSchema, sinkRecord,
             key.getData(), value.getData(),
             new EnvelopeSchemaBuilder.SchemaDescriptor(
                 key.getSchemaId(), key.getSchemaType(),
@@ -125,11 +125,11 @@ public class EnvelopeTransformer {
                 value.getSubject(), value.getSchemaGuid()));
 
     return new SinkRecord(
-        record.topic(), record.kafkaPartition(),
+        sinkRecord.topic(), sinkRecord.kafkaPartition(),
         null, null,
         envelopeSchema, envelope,
-        record.kafkaOffset(),
-        record.timestamp(),
-        record.timestampType());
+        sinkRecord.kafkaOffset(),
+        sinkRecord.timestamp(),
+        sinkRecord.timestampType());
   }
 }

--- a/format/src/main/java/io/confluent/connect/storage/format/backup/EnvelopeTransformer.java
+++ b/format/src/main/java/io/confluent/connect/storage/format/backup/EnvelopeTransformer.java
@@ -112,8 +112,7 @@ public class EnvelopeTransformer {
     schemaBackup.backupIfNeeded(record.topic(), value);
 
     Schema envelopeSchema = EnvelopeSchemaBuilder
-        .buildEnvelopeSchema(key.getSchema(), value.getSchema(),
-            key.getSchemaType(), value.getSchemaType());
+        .buildEnvelopeSchema(key.getSchema(), value.getSchema());
 
     Struct envelope = EnvelopeSchemaBuilder
         .buildEnvelopeStruct(envelopeSchema, record,

--- a/format/src/main/java/io/confluent/connect/storage/format/backup/SchemaBackupOrchestrator.java
+++ b/format/src/main/java/io/confluent/connect/storage/format/backup/SchemaBackupOrchestrator.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.storage.format.backup;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.confluent.connect.storage.backup.BackupEnvelope;
+import io.confluent.connect.storage.backup.BackupReferenceParser;
+import io.confluent.connect.storage.backup.SchemaBackupStore;
+import io.confluent.connect.storage.backup.SchemaManifest;
+import io.confluent.connect.storage.format.backup.BackupWrapperExtractor.Unwrapped;
+import org.apache.kafka.connect.errors.DataException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Orchestrates schema file backup during envelope wrapping.
+ *
+ * <p>Determines which schemas need to be backed up, traverses reference
+ * trees to back up transitive references, and delegates the actual
+ * file I/O to {@link SchemaBackupStore}.
+ *
+ * <p>Handles both root schemas and their reference chains. Reference
+ * trees are parsed from the Wrapper's JSON metadata and each referenced
+ * schema is backed up with its entry file.
+ */
+final class SchemaBackupOrchestrator {
+
+  private static final Logger log =
+      LoggerFactory.getLogger(SchemaBackupOrchestrator.class);
+  private static final ObjectMapper JSON = new ObjectMapper();
+
+  private final SchemaBackupStore backupStore;
+
+  SchemaBackupOrchestrator(SchemaBackupStore backupStore) {
+    this.backupStore = backupStore;
+  }
+
+  /**
+   * Backs up schema and entry files for an unwrapped record if needed.
+   * Handles both the root schema and any transitive references.
+   *
+   * @param topic the Kafka topic name
+   * @param unwrapped the unwrapped record metadata
+   */
+  void backupIfNeeded(String topic, Unwrapped unwrapped) {
+    if (unwrapped.getRawSchema() == null) {
+      return;
+    }
+    String schemaKey = resolveSchemaKey(unwrapped);
+    if (schemaKey == null) {
+      return;
+    }
+    backupReferenceSchemas(topic, unwrapped.getReferenceTreeJson());
+    List<SchemaManifest.SchemaReferenceEntry> refs =
+        BackupReferenceParser.parseDirectRefsToManifestEntries(
+            unwrapped.getDirectRefsJson(),
+            unwrapped.getReferenceTreeJson());
+    backupStore.backupIfNeeded(
+        topic,
+        schemaKey,
+        unwrapped.getSchemaVersion() != null ? unwrapped.getSchemaVersion() : 0,
+        unwrapped.getSchemaType(),
+        unwrapped.getSubject(),
+        unwrapped.getRawSchema(),
+        refs);
+  }
+
+  private static String resolveSchemaKey(Unwrapped unwrapped) {
+    if (unwrapped.getSchemaId() != null) {
+      return String.valueOf(unwrapped.getSchemaId());
+    }
+    if (unwrapped.getSchemaGuid() != null) {
+      return unwrapped.getSchemaGuid();
+    }
+    return null;
+  }
+
+  @SuppressWarnings("unchecked")
+  private void backupReferenceSchemas(String topic, String referenceTreeJson) {
+    if (referenceTreeJson == null || referenceTreeJson.isEmpty()) {
+      return;
+    }
+    try {
+      Map<String, Map<String, Object>> tree = JSON.readValue(
+          referenceTreeJson,
+          new TypeReference<Map<String, Map<String, Object>>>() {});
+      Set<Integer> visited = new HashSet<>();
+      for (Map.Entry<String, Map<String, Object>> entry : tree.entrySet()) {
+        backupSingleReference(topic, entry.getValue(), tree, visited);
+      }
+    } catch (DataException de) {
+      throw de;
+    } catch (Exception e) {
+      throw new DataException(
+          "Failed to backup reference schemas for topic="
+          + topic + ". Cannot guarantee pristine restore.", e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private void backupSingleReference(
+      String topic, Map<String, Object> node,
+      Map<String, Map<String, Object>> tree, Set<Integer> visited) {
+    int globalId = node.get(BackupEnvelope.REF_FIELD_GLOBAL_ID) instanceof Number
+        ? ((Number) node.get(BackupEnvelope.REF_FIELD_GLOBAL_ID)).intValue() : 0;
+    if (globalId <= 0 || !visited.add(globalId)) {
+      if (globalId <= 0) {
+        log.warn("Skipping reference with invalid globalId={} in topic={}",
+            globalId, topic);
+      }
+      return;
+    }
+    String schema = (String) node.get(BackupEnvelope.REF_FIELD_SCHEMA);
+    String subject = (String) node.get(BackupEnvelope.REF_FIELD_SUBJECT);
+    int version = node.get(BackupEnvelope.REF_FIELD_VERSION) instanceof Number
+        ? ((Number) node.get(BackupEnvelope.REF_FIELD_VERSION)).intValue() : 0;
+    String schemaType = node.get(BackupEnvelope.REF_FIELD_SCHEMA_TYPE) instanceof String
+        ? (String) node.get(BackupEnvelope.REF_FIELD_SCHEMA_TYPE) : null;
+    if (schema == null || schemaType == null) {
+      throw new DataException(
+          "Cannot backup reference schema: missing schema text or type"
+          + " for globalId=" + globalId + ", subject=" + subject
+          + ", topic=" + topic + ". Cannot guarantee pristine restore.");
+    }
+    List<SchemaManifest.SchemaReferenceEntry> childRefs =
+        extractChildRefs(node, tree);
+    backupStore.backupIfNeeded(
+        topic, String.valueOf(globalId), version, schemaType, subject, schema, childRefs);
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<SchemaManifest.SchemaReferenceEntry> extractChildRefs(
+      Map<String, Object> node, Map<String, Map<String, Object>> tree) {
+    Object refsObj = node.get(BackupEnvelope.REF_FIELD_REFERENCES);
+    if (!(refsObj instanceof List)) {
+      return Collections.emptyList();
+    }
+    List<SchemaManifest.SchemaReferenceEntry> childRefs = new ArrayList<>();
+    for (Object item : (List<?>) refsObj) {
+      if (!(item instanceof Map)) {
+        continue;
+      }
+      Map<String, Object> m = (Map<String, Object>) item;
+      String refName = (String) m.get(BackupEnvelope.REF_FIELD_NAME);
+      String refSubject = (String) m.get(BackupEnvelope.REF_FIELD_SUBJECT);
+      int refVersion = m.get(BackupEnvelope.REF_FIELD_VERSION) instanceof Number
+          ? ((Number) m.get(BackupEnvelope.REF_FIELD_VERSION)).intValue() : 0;
+      Map<String, Object> childNode = tree.get(refName);
+      int refGlobalId = childNode != null
+          && childNode.get(BackupEnvelope.REF_FIELD_GLOBAL_ID) instanceof Number
+          ? ((Number) childNode.get(BackupEnvelope.REF_FIELD_GLOBAL_ID)).intValue() : 0;
+      childRefs.add(new SchemaManifest.SchemaReferenceEntry(
+          refName, refSubject, refVersion, refGlobalId));
+    }
+    return childRefs;
+  }
+}

--- a/format/src/main/java/io/confluent/connect/storage/format/backup/SchemaBackupOrchestrator.java
+++ b/format/src/main/java/io/confluent/connect/storage/format/backup/SchemaBackupOrchestrator.java
@@ -23,6 +23,8 @@ import io.confluent.connect.storage.backup.SchemaBackupStore;
 import io.confluent.connect.storage.backup.SchemaManifest;
 import io.confluent.connect.storage.format.backup.BackupWrapperExtractor.Unwrapped;
 import org.apache.kafka.connect.errors.DataException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -45,6 +47,8 @@ import java.util.Set;
  */
 final class SchemaBackupOrchestrator {
 
+  private static final Logger log =
+      LoggerFactory.getLogger(SchemaBackupOrchestrator.class);
   private static final ObjectMapper JSON = new ObjectMapper();
 
   private final SchemaBackupStore backupStore;
@@ -104,9 +108,10 @@ final class SchemaBackupOrchestrator {
           referenceTreeJson,
           new TypeReference<Map<String, Map<String, Object>>>() {});
     } catch (IOException e) {
-      throw new DataException(
-          "Failed to parse reference tree JSON for topic="
-          + topic + ". Cannot guarantee pristine restore.", e);
+      String msg = "Failed to parse reference tree JSON for topic="
+          + topic + ". Cannot guarantee pristine restore.";
+      log.error(msg, e);
+      throw new DataException(msg, e);
     }
     Set<Integer> visited = new HashSet<>();
     for (Map.Entry<String, Map<String, Object>> entry : tree.entrySet()) {
@@ -121,9 +126,11 @@ final class SchemaBackupOrchestrator {
     int globalId = node.get(BackupEnvelope.REF_FIELD_GLOBAL_ID) instanceof Number
         ? ((Number) node.get(BackupEnvelope.REF_FIELD_GLOBAL_ID)).intValue() : 0;
     if (globalId <= 0) {
-      throw new DataException(
-          "Cannot backup reference schema: invalid globalId=" + globalId
-          + " in topic=" + topic + ". Cannot guarantee pristine restore.");
+      String msg = "Cannot backup reference schema: invalid globalId="
+          + globalId + " in topic=" + topic
+          + ". Cannot guarantee pristine restore.";
+      log.error(msg);
+      throw new DataException(msg);
     }
     if (!visited.add(globalId)) {
       return;
@@ -135,10 +142,11 @@ final class SchemaBackupOrchestrator {
     String schemaType = node.get(BackupEnvelope.REF_FIELD_SCHEMA_TYPE) instanceof String
         ? (String) node.get(BackupEnvelope.REF_FIELD_SCHEMA_TYPE) : null;
     if (schema == null || schemaType == null) {
-      throw new DataException(
-          "Cannot backup reference schema: missing schema text or type"
+      String msg = "Cannot backup reference schema: missing schema text or type"
           + " for globalId=" + globalId + ", subject=" + subject
-          + ", topic=" + topic + ". Cannot guarantee pristine restore.");
+          + ", topic=" + topic + ". Cannot guarantee pristine restore.";
+      log.error(msg);
+      throw new DataException(msg);
     }
     List<SchemaManifest.SchemaReferenceEntry> childRefs =
         extractChildRefs(node, tree);

--- a/format/src/main/java/io/confluent/connect/storage/format/backup/SchemaBackupOrchestrator.java
+++ b/format/src/main/java/io/confluent/connect/storage/format/backup/SchemaBackupOrchestrator.java
@@ -23,8 +23,6 @@ import io.confluent.connect.storage.backup.SchemaBackupStore;
 import io.confluent.connect.storage.backup.SchemaManifest;
 import io.confluent.connect.storage.format.backup.BackupWrapperExtractor.Unwrapped;
 import org.apache.kafka.connect.errors.DataException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -47,8 +45,6 @@ import java.util.Set;
  */
 final class SchemaBackupOrchestrator {
 
-  private static final Logger log =
-      LoggerFactory.getLogger(SchemaBackupOrchestrator.class);
   private static final ObjectMapper JSON = new ObjectMapper();
 
   private final SchemaBackupStore backupStore;

--- a/format/src/main/java/io/confluent/connect/storage/format/backup/SchemaBackupOrchestrator.java
+++ b/format/src/main/java/io/confluent/connect/storage/format/backup/SchemaBackupOrchestrator.java
@@ -50,6 +50,8 @@ final class SchemaBackupOrchestrator {
   private static final Logger log =
       LoggerFactory.getLogger(SchemaBackupOrchestrator.class);
   private static final ObjectMapper JSON = new ObjectMapper();
+  private static final String CANNOT_GUARANTEE_PRISTINE_RESTORE =
+      ". Cannot guarantee pristine restore.";
 
   private final SchemaBackupStore backupStore;
 
@@ -109,7 +111,7 @@ final class SchemaBackupOrchestrator {
           new TypeReference<Map<String, Map<String, Object>>>() {});
     } catch (IOException e) {
       String msg = "Failed to parse reference tree JSON for topic="
-          + topic + ". Cannot guarantee pristine restore.";
+          + topic + CANNOT_GUARANTEE_PRISTINE_RESTORE;
       log.error(msg, e);
       throw new DataException(msg, e);
     }
@@ -128,7 +130,7 @@ final class SchemaBackupOrchestrator {
     if (globalId <= 0) {
       String msg = "Cannot backup reference schema: invalid globalId="
           + globalId + " in topic=" + topic
-          + ". Cannot guarantee pristine restore.";
+          + CANNOT_GUARANTEE_PRISTINE_RESTORE;
       log.error(msg);
       throw new DataException(msg);
     }
@@ -144,7 +146,7 @@ final class SchemaBackupOrchestrator {
     if (schema == null || schemaType == null) {
       String msg = "Cannot backup reference schema: missing schema text or type"
           + " for globalId=" + globalId + ", subject=" + subject
-          + ", topic=" + topic + ". Cannot guarantee pristine restore.";
+          + ", topic=" + topic + CANNOT_GUARANTEE_PRISTINE_RESTORE;
       log.error(msg);
       throw new DataException(msg);
     }

--- a/format/src/main/java/io/confluent/connect/storage/format/backup/SchemaBackupOrchestrator.java
+++ b/format/src/main/java/io/confluent/connect/storage/format/backup/SchemaBackupOrchestrator.java
@@ -174,9 +174,23 @@ final class SchemaBackupOrchestrator {
       int refVersion = m.get(BackupEnvelope.REF_FIELD_VERSION) instanceof Number
           ? ((Number) m.get(BackupEnvelope.REF_FIELD_VERSION)).intValue() : 0;
       Map<String, Object> childNode = tree.get(refName);
-      int refGlobalId = childNode != null
-          && childNode.get(BackupEnvelope.REF_FIELD_GLOBAL_ID) instanceof Number
-          ? ((Number) childNode.get(BackupEnvelope.REF_FIELD_GLOBAL_ID)).intValue() : 0;
+      if (childNode == null
+          || !(childNode.get(BackupEnvelope.REF_FIELD_GLOBAL_ID) instanceof Number)) {
+        String msg = "Cannot backup reference schema: missing child reference '"
+            + refName + "' with a valid globalId in the reference tree"
+            + CANNOT_GUARANTEE_PRISTINE_RESTORE;
+        log.error(msg);
+        throw new DataException(msg);
+      }
+      int refGlobalId =
+          ((Number) childNode.get(BackupEnvelope.REF_FIELD_GLOBAL_ID)).intValue();
+      if (refGlobalId <= 0) {
+        String msg = "Cannot backup reference schema: invalid globalId="
+            + refGlobalId + " for child reference '" + refName + "'"
+            + CANNOT_GUARANTEE_PRISTINE_RESTORE;
+        log.error(msg);
+        throw new DataException(msg);
+      }
       childRefs.add(new SchemaManifest.SchemaReferenceEntry(
           refName, refSubject, refVersion, refGlobalId));
     }

--- a/format/src/main/java/io/confluent/connect/storage/format/backup/SchemaBackupOrchestrator.java
+++ b/format/src/main/java/io/confluent/connect/storage/format/backup/SchemaBackupOrchestrator.java
@@ -26,6 +26,7 @@ import org.apache.kafka.connect.errors.DataException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -101,20 +102,19 @@ final class SchemaBackupOrchestrator {
     if (referenceTreeJson == null || referenceTreeJson.isEmpty()) {
       return;
     }
+    Map<String, Map<String, Object>> tree;
     try {
-      Map<String, Map<String, Object>> tree = JSON.readValue(
+      tree = JSON.readValue(
           referenceTreeJson,
           new TypeReference<Map<String, Map<String, Object>>>() {});
-      Set<Integer> visited = new HashSet<>();
-      for (Map.Entry<String, Map<String, Object>> entry : tree.entrySet()) {
-        backupSingleReference(topic, entry.getValue(), tree, visited);
-      }
-    } catch (DataException de) {
-      throw de;
-    } catch (Exception e) {
+    } catch (IOException e) {
       throw new DataException(
-          "Failed to backup reference schemas for topic="
+          "Failed to parse reference tree JSON for topic="
           + topic + ". Cannot guarantee pristine restore.", e);
+    }
+    Set<Integer> visited = new HashSet<>();
+    for (Map.Entry<String, Map<String, Object>> entry : tree.entrySet()) {
+      backupSingleReference(topic, entry.getValue(), tree, visited);
     }
   }
 

--- a/format/src/main/java/io/confluent/connect/storage/format/backup/SchemaBackupOrchestrator.java
+++ b/format/src/main/java/io/confluent/connect/storage/format/backup/SchemaBackupOrchestrator.java
@@ -124,11 +124,12 @@ final class SchemaBackupOrchestrator {
       Map<String, Map<String, Object>> tree, Set<Integer> visited) {
     int globalId = node.get(BackupEnvelope.REF_FIELD_GLOBAL_ID) instanceof Number
         ? ((Number) node.get(BackupEnvelope.REF_FIELD_GLOBAL_ID)).intValue() : 0;
-    if (globalId <= 0 || !visited.add(globalId)) {
-      if (globalId <= 0) {
-        log.warn("Skipping reference with invalid globalId={} in topic={}",
-            globalId, topic);
-      }
+    if (globalId <= 0) {
+      throw new DataException(
+          "Cannot backup reference schema: invalid globalId=" + globalId
+          + " in topic=" + topic + ". Cannot guarantee pristine restore.");
+    }
+    if (!visited.add(globalId)) {
       return;
     }
     String schema = (String) node.get(BackupEnvelope.REF_FIELD_SCHEMA);

--- a/format/src/test/java/io/confluent/connect/storage/format/backup/BackupWrapperExtractorTest.java
+++ b/format/src/test/java/io/confluent/connect/storage/format/backup/BackupWrapperExtractorTest.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.storage.format.backup;
+
+import io.confluent.connect.schema.backup.api.BackupWrapper;
+import io.confluent.connect.storage.format.backup.BackupWrapperExtractor.Unwrapped;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class BackupWrapperExtractorTest {
+
+  @Test
+  public void testUnwrapSrWrapper() {
+    Schema dataSchema = SchemaBuilder.struct()
+        .field("name", Schema.STRING_SCHEMA).build();
+    Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
+
+    Struct data = new Struct(dataSchema).put("name", "Alice");
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        42, 1, "AVRO", "test-value", "{\"type\":\"record\"}",
+        "{\"tree\":{}}", "[{\"ref\":1}]");
+    Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, data, fields);
+
+    Unwrapped result = BackupWrapperExtractor.unwrap(
+        wrapper, wrapperSchema, false, "AVRO");
+
+    assertNotNull(result.getData());
+    assertEquals(42, (int) result.getSchemaId());
+    assertEquals(1, (int) result.getSchemaVersion());
+    assertEquals("AVRO", result.getSchemaType());
+    assertEquals("test-value", result.getSubject());
+    assertEquals("{\"type\":\"record\"}", result.getRawSchema());
+    assertEquals("{\"tree\":{}}", result.getReferenceTreeJson());
+    assertEquals("[{\"ref\":1}]", result.getDirectRefsJson());
+  }
+
+  @Test
+  public void testUnwrapTombstone() {
+    Unwrapped result = BackupWrapperExtractor.unwrap(
+        null, null, false, "AVRO");
+
+    assertNull(result.getData());
+    assertNull(result.getSchema());
+    assertNull(result.getSchemaId());
+    assertEquals("NONE", result.getSchemaType());
+  }
+
+  @Test
+  public void testUnwrapSchemalessMap() {
+    HashMap<String, Object> map = new HashMap<>();
+    map.put("key", "value");
+    map.put("num", 42);
+
+    Unwrapped result = BackupWrapperExtractor.unwrap(
+        map, null, false, "JSON_SCHEMALESS");
+
+    assertNotNull(result.getData());
+    String json = (String) result.getData();
+    assertTrue(json.contains("\"key\""));
+    assertTrue(json.contains("\"value\""));
+    assertEquals("JSON_SCHEMALESS", result.getSchemaType());
+    assertNull(result.getSchemaId());
+  }
+
+  @Test
+  public void testUnwrapSchemalessString() {
+    Unwrapped result = BackupWrapperExtractor.unwrap(
+        "plain text", null, false, "STRING");
+
+    assertEquals("plain text", result.getData());
+    assertEquals("JSON_SCHEMALESS", result.getSchemaType());
+  }
+
+  @Test
+  public void testUnwrapNonSrWithSchema() {
+    Unwrapped result = BackupWrapperExtractor.unwrap(
+        "hello", Schema.STRING_SCHEMA, true, "STRING");
+
+    assertEquals("hello", result.getData());
+    assertEquals(Schema.STRING_SCHEMA, result.getSchema());
+    assertEquals("STRING", result.getSchemaType());
+    assertNull(result.getSchemaId());
+    assertNull(result.getRawSchema());
+  }
+
+  @Test
+  public void testUnwrapWrapperWithNullOptionalFields() {
+    Schema dataSchema = Schema.STRING_SCHEMA;
+    Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
+
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        1, null, "STRING", "test-key", null, null, null);
+    Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, "hello", fields);
+
+    Unwrapped result = BackupWrapperExtractor.unwrap(
+        wrapper, wrapperSchema, true, "STRING");
+
+    assertEquals(1, (int) result.getSchemaId());
+    assertNull(result.getSchemaVersion());
+    assertNull(result.getRawSchema());
+    assertNull(result.getReferenceTreeJson());
+    assertNull(result.getDirectRefsJson());
+  }
+
+  @Test
+  public void testUnwrapSchemalessNestedMap() {
+    Map<String, Object> inner = new LinkedHashMap<>();
+    inner.put("city", "NYC");
+    inner.put("zip", 10001);
+    Map<String, Object> outer = new LinkedHashMap<>();
+    outer.put("name", "Alice");
+    outer.put("address", inner);
+
+    Unwrapped result = BackupWrapperExtractor.unwrap(
+        outer, null, false, "JSON_SCHEMALESS");
+
+    String json = (String) result.getData();
+    assertTrue(json.contains("\"address\""));
+    assertTrue(json.contains("\"city\":\"NYC\""));
+    assertTrue(json.contains("\"zip\":10001"));
+    assertEquals("JSON_SCHEMALESS", result.getSchemaType());
+  }
+
+  @Test
+  public void testUnwrapSchemalessArray() {
+    List<Object> list = Arrays.asList(1, "two", true, null);
+
+    Unwrapped result = BackupWrapperExtractor.unwrap(
+        list, null, false, "JSON_SCHEMALESS");
+
+    String json = (String) result.getData();
+    assertTrue(json.startsWith("["));
+    assertTrue(json.contains("\"two\""));
+    assertTrue(json.contains("true"));
+    assertTrue(json.contains("null"));
+  }
+
+  @Test
+  public void testUnwrapSchemalessEmptyMap() {
+    Unwrapped result = BackupWrapperExtractor.unwrap(
+        new HashMap<>(), null, false, "JSON_SCHEMALESS");
+
+    assertEquals("{}", result.getData());
+  }
+
+  @Test
+  public void testUnwrapSchemalessEmptyList() {
+    Unwrapped result = BackupWrapperExtractor.unwrap(
+        new ArrayList<>(), null, false, "JSON_SCHEMALESS");
+
+    assertEquals("[]", result.getData());
+  }
+
+  @Test
+  public void testUnwrapSchemalessNullValues() {
+    Map<String, Object> map = new LinkedHashMap<>();
+    map.put("present", "val");
+    map.put("absent", null);
+
+    Unwrapped result = BackupWrapperExtractor.unwrap(
+        map, null, false, "JSON_SCHEMALESS");
+
+    String json = (String) result.getData();
+    assertTrue(json.contains("\"absent\":null"));
+    assertTrue(json.contains("\"present\":\"val\""));
+  }
+
+  @Test
+  public void testUnwrapEmbeddedSchemaStruct() {
+    Schema s = SchemaBuilder.struct()
+        .field("name", Schema.STRING_SCHEMA)
+        .field("age", Schema.INT32_SCHEMA)
+        .build();
+    Struct data = new Struct(s)
+        .put("name", "Alice").put("age", 30);
+
+    Unwrapped result = BackupWrapperExtractor.unwrap(
+        data, s, false, "JSON_EMBEDDED_SCHEMA");
+
+    assertEquals(data, result.getData());
+    assertEquals(s, result.getSchema());
+    assertEquals("JSON_EMBEDDED_SCHEMA", result.getSchemaType());
+    assertNull(result.getSchemaId());
+  }
+
+  @Test
+  public void testUnwrapEmbeddedSchemaNestedStruct() {
+    Schema inner = SchemaBuilder.struct()
+        .field("city", Schema.STRING_SCHEMA).build();
+    Schema outer = SchemaBuilder.struct()
+        .field("name", Schema.STRING_SCHEMA)
+        .field("address", inner).build();
+    Struct addr = new Struct(inner).put("city", "NYC");
+    Struct data = new Struct(outer)
+        .put("name", "Alice").put("address", addr);
+
+    Unwrapped result = BackupWrapperExtractor.unwrap(
+        data, outer, false, "JSON_EMBEDDED_SCHEMA");
+
+    Struct restored = (Struct) result.getData();
+    Struct restoredAddr = restored.getStruct("address");
+    assertEquals("NYC", restoredAddr.getString("city"));
+  }
+
+  @Test
+  public void testUnwrapEmbeddedSchemaWithArray() {
+    Schema itemSchema = SchemaBuilder.struct()
+        .field("id", Schema.INT32_SCHEMA).build();
+    Schema s = SchemaBuilder.struct()
+        .field("items", SchemaBuilder.array(itemSchema)).build();
+    Struct item1 = new Struct(itemSchema).put("id", 1);
+    Struct item2 = new Struct(itemSchema).put("id", 2);
+    Struct data = new Struct(s)
+        .put("items", Arrays.asList(item1, item2));
+
+    Unwrapped result = BackupWrapperExtractor.unwrap(
+        data, s, false, "JSON_EMBEDDED_SCHEMA");
+
+    Struct restored = (Struct) result.getData();
+    List<?> items = restored.getArray("items");
+    assertEquals(2, items.size());
+  }
+
+  @Test
+  public void testUnwrapPrimitiveString() {
+    Unwrapped result = BackupWrapperExtractor.unwrap(
+        "hello", Schema.STRING_SCHEMA, true, "STRING");
+
+    assertEquals("hello", result.getData());
+    assertEquals(Schema.STRING_SCHEMA, result.getSchema());
+    assertEquals("STRING", result.getSchemaType());
+  }
+
+  @Test
+  public void testUnwrapPrimitiveInt32() {
+    Unwrapped result = BackupWrapperExtractor.unwrap(
+        42, Schema.INT32_SCHEMA, true, "INT32");
+
+    assertEquals(42, result.getData());
+    assertEquals(Schema.INT32_SCHEMA, result.getSchema());
+    assertEquals("INT32", result.getSchemaType());
+  }
+
+  @Test
+  public void testUnwrapPrimitiveBytes() {
+    byte[] bytes = new byte[]{1, 2, 3};
+
+    Unwrapped result = BackupWrapperExtractor.unwrap(
+        bytes, Schema.BYTES_SCHEMA, false, "BYTES");
+
+    assertEquals(bytes, result.getData());
+    assertEquals(Schema.BYTES_SCHEMA, result.getSchema());
+    assertEquals("BYTES", result.getSchemaType());
+  }
+
+  private static void assertTrue(boolean condition) {
+    org.junit.Assert.assertTrue(condition);
+  }
+}

--- a/format/src/test/java/io/confluent/connect/storage/format/backup/BackupWrapperExtractorTest.java
+++ b/format/src/test/java/io/confluent/connect/storage/format/backup/BackupWrapperExtractorTest.java
@@ -95,7 +95,25 @@ public class BackupWrapperExtractorTest {
     Unwrapped result = BackupWrapperExtractor.unwrap(
         "plain text", null, false, BackupEnvelope.TYPE_STRING);
 
-    assertEquals("plain text", result.getData());
+    assertEquals("\"plain text\"", result.getData());
+    assertEquals(BackupEnvelope.TYPE_JSON_SCHEMALESS, result.getSchemaType());
+  }
+
+  @Test
+  public void testUnwrapSchemalessNumber() {
+    Unwrapped result = BackupWrapperExtractor.unwrap(
+        42, null, false, BackupEnvelope.TYPE_JSON_SCHEMALESS);
+
+    assertEquals("42", result.getData());
+    assertEquals(BackupEnvelope.TYPE_JSON_SCHEMALESS, result.getSchemaType());
+  }
+
+  @Test
+  public void testUnwrapSchemalessBoolean() {
+    Unwrapped result = BackupWrapperExtractor.unwrap(
+        true, null, false, BackupEnvelope.TYPE_JSON_SCHEMALESS);
+
+    assertEquals("true", result.getData());
     assertEquals(BackupEnvelope.TYPE_JSON_SCHEMALESS, result.getSchemaType());
   }
 

--- a/format/src/test/java/io/confluent/connect/storage/format/backup/BackupWrapperExtractorTest.java
+++ b/format/src/test/java/io/confluent/connect/storage/format/backup/BackupWrapperExtractorTest.java
@@ -37,13 +37,20 @@ import static org.junit.Assert.assertTrue;
 
 public class BackupWrapperExtractorTest {
 
+  private static final String FIELD_NAME = "name";
+  private static final String NAME_ALICE = "Alice";
+  private static final String HELLO = "hello";
+  private static final String FIELD_ADDRESS = "address";
+  private static final String FIELD_CITY = "city";
+  private static final String FIELD_ITEMS = "items";
+
   @Test
   public void testUnwrapSrWrapper() {
     Schema dataSchema = SchemaBuilder.struct()
-        .field("name", Schema.STRING_SCHEMA).build();
+        .field(FIELD_NAME, Schema.STRING_SCHEMA).build();
     Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
 
-    Struct data = new Struct(dataSchema).put("name", "Alice");
+    Struct data = new Struct(dataSchema).put(FIELD_NAME, NAME_ALICE);
     BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
         42, 1, BackupEnvelope.TYPE_AVRO, "test-value", "{\"type\":\"record\"}",
         "{\"tree\":{}}", "[{\"ref\":1}]");
@@ -120,9 +127,9 @@ public class BackupWrapperExtractorTest {
   @Test
   public void testUnwrapNonSrWithSchema() {
     Unwrapped result = BackupWrapperExtractor.unwrap(
-        "hello", Schema.STRING_SCHEMA, true, BackupEnvelope.TYPE_STRING);
+        HELLO, Schema.STRING_SCHEMA, true, BackupEnvelope.TYPE_STRING);
 
-    assertEquals("hello", result.getData());
+    assertEquals(HELLO, result.getData());
     assertEquals(Schema.STRING_SCHEMA, result.getSchema());
     assertEquals(BackupEnvelope.TYPE_STRING, result.getSchemaType());
     assertNull(result.getSchemaId());
@@ -136,7 +143,7 @@ public class BackupWrapperExtractorTest {
 
     BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
         1, null, BackupEnvelope.TYPE_STRING, "test-key", null, null, null);
-    Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, "hello", fields);
+    Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, HELLO, fields);
 
     Unwrapped result = BackupWrapperExtractor.unwrap(
         wrapper, wrapperSchema, true, BackupEnvelope.TYPE_STRING);
@@ -151,11 +158,11 @@ public class BackupWrapperExtractorTest {
   @Test
   public void testUnwrapSchemalessNestedMap() {
     Map<String, Object> inner = new LinkedHashMap<>();
-    inner.put("city", "NYC");
+    inner.put(FIELD_CITY, "NYC");
     inner.put("zip", 10001);
     Map<String, Object> outer = new LinkedHashMap<>();
-    outer.put("name", "Alice");
-    outer.put("address", inner);
+    outer.put(FIELD_NAME, NAME_ALICE);
+    outer.put(FIELD_ADDRESS, inner);
 
     Unwrapped result = BackupWrapperExtractor.unwrap(
         outer, null, false, BackupEnvelope.TYPE_JSON_SCHEMALESS);
@@ -214,11 +221,11 @@ public class BackupWrapperExtractorTest {
   @Test
   public void testUnwrapEmbeddedSchemaStruct() {
     Schema s = SchemaBuilder.struct()
-        .field("name", Schema.STRING_SCHEMA)
+        .field(FIELD_NAME, Schema.STRING_SCHEMA)
         .field("age", Schema.INT32_SCHEMA)
         .build();
     Struct data = new Struct(s)
-        .put("name", "Alice").put("age", 30);
+        .put(FIELD_NAME, NAME_ALICE).put("age", 30);
 
     Unwrapped result = BackupWrapperExtractor.unwrap(
         data, s, false, BackupEnvelope.TYPE_JSON_EMBEDDED_SCHEMA);
@@ -232,20 +239,20 @@ public class BackupWrapperExtractorTest {
   @Test
   public void testUnwrapEmbeddedSchemaNestedStruct() {
     Schema inner = SchemaBuilder.struct()
-        .field("city", Schema.STRING_SCHEMA).build();
+        .field(FIELD_CITY, Schema.STRING_SCHEMA).build();
     Schema outer = SchemaBuilder.struct()
-        .field("name", Schema.STRING_SCHEMA)
-        .field("address", inner).build();
-    Struct addr = new Struct(inner).put("city", "NYC");
+        .field(FIELD_NAME, Schema.STRING_SCHEMA)
+        .field(FIELD_ADDRESS, inner).build();
+    Struct addr = new Struct(inner).put(FIELD_CITY, "NYC");
     Struct data = new Struct(outer)
-        .put("name", "Alice").put("address", addr);
+        .put(FIELD_NAME, NAME_ALICE).put(FIELD_ADDRESS, addr);
 
     Unwrapped result = BackupWrapperExtractor.unwrap(
         data, outer, false, BackupEnvelope.TYPE_JSON_EMBEDDED_SCHEMA);
 
     Struct restored = (Struct) result.getData();
-    Struct restoredAddr = restored.getStruct("address");
-    assertEquals("NYC", restoredAddr.getString("city"));
+    Struct restoredAddr = restored.getStruct(FIELD_ADDRESS);
+    assertEquals("NYC", restoredAddr.getString(FIELD_CITY));
   }
 
   @Test
@@ -253,26 +260,26 @@ public class BackupWrapperExtractorTest {
     Schema itemSchema = SchemaBuilder.struct()
         .field("id", Schema.INT32_SCHEMA).build();
     Schema s = SchemaBuilder.struct()
-        .field("items", SchemaBuilder.array(itemSchema)).build();
+        .field(FIELD_ITEMS, SchemaBuilder.array(itemSchema)).build();
     Struct item1 = new Struct(itemSchema).put("id", 1);
     Struct item2 = new Struct(itemSchema).put("id", 2);
     Struct data = new Struct(s)
-        .put("items", Arrays.asList(item1, item2));
+        .put(FIELD_ITEMS, Arrays.asList(item1, item2));
 
     Unwrapped result = BackupWrapperExtractor.unwrap(
         data, s, false, BackupEnvelope.TYPE_JSON_EMBEDDED_SCHEMA);
 
     Struct restored = (Struct) result.getData();
-    List<?> items = restored.getArray("items");
+    List<?> items = restored.getArray(FIELD_ITEMS);
     assertEquals(2, items.size());
   }
 
   @Test
   public void testUnwrapPrimitiveString() {
     Unwrapped result = BackupWrapperExtractor.unwrap(
-        "hello", Schema.STRING_SCHEMA, true, BackupEnvelope.TYPE_STRING);
+        HELLO, Schema.STRING_SCHEMA, true, BackupEnvelope.TYPE_STRING);
 
-    assertEquals("hello", result.getData());
+    assertEquals(HELLO, result.getData());
     assertEquals(Schema.STRING_SCHEMA, result.getSchema());
     assertEquals(BackupEnvelope.TYPE_STRING, result.getSchemaType());
   }

--- a/format/src/test/java/io/confluent/connect/storage/format/backup/BackupWrapperExtractorTest.java
+++ b/format/src/test/java/io/confluent/connect/storage/format/backup/BackupWrapperExtractorTest.java
@@ -16,6 +16,7 @@
 package io.confluent.connect.storage.format.backup;
 
 import io.confluent.connect.schema.backup.api.BackupWrapper;
+import io.confluent.connect.storage.backup.BackupEnvelope;
 import io.confluent.connect.storage.format.backup.BackupWrapperExtractor.Unwrapped;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -24,7 +25,6 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -33,6 +33,7 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class BackupWrapperExtractorTest {
 
@@ -44,17 +45,17 @@ public class BackupWrapperExtractorTest {
 
     Struct data = new Struct(dataSchema).put("name", "Alice");
     BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
-        42, 1, "AVRO", "test-value", "{\"type\":\"record\"}",
+        42, 1, BackupEnvelope.TYPE_AVRO, "test-value", "{\"type\":\"record\"}",
         "{\"tree\":{}}", "[{\"ref\":1}]");
     Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, data, fields);
 
     Unwrapped result = BackupWrapperExtractor.unwrap(
-        wrapper, wrapperSchema, false, "AVRO");
+        wrapper, wrapperSchema, false, BackupEnvelope.TYPE_AVRO);
 
     assertNotNull(result.getData());
     assertEquals(42, (int) result.getSchemaId());
     assertEquals(1, (int) result.getSchemaVersion());
-    assertEquals("AVRO", result.getSchemaType());
+    assertEquals(BackupEnvelope.TYPE_AVRO, result.getSchemaType());
     assertEquals("test-value", result.getSubject());
     assertEquals("{\"type\":\"record\"}", result.getRawSchema());
     assertEquals("{\"tree\":{}}", result.getReferenceTreeJson());
@@ -64,12 +65,12 @@ public class BackupWrapperExtractorTest {
   @Test
   public void testUnwrapTombstone() {
     Unwrapped result = BackupWrapperExtractor.unwrap(
-        null, null, false, "AVRO");
+        null, null, false, BackupEnvelope.TYPE_AVRO);
 
     assertNull(result.getData());
     assertNull(result.getSchema());
     assertNull(result.getSchemaId());
-    assertEquals("NONE", result.getSchemaType());
+    assertEquals(BackupEnvelope.TYPE_NONE, result.getSchemaType());
   }
 
   @Test
@@ -79,33 +80,33 @@ public class BackupWrapperExtractorTest {
     map.put("num", 42);
 
     Unwrapped result = BackupWrapperExtractor.unwrap(
-        map, null, false, "JSON_SCHEMALESS");
+        map, null, false, BackupEnvelope.TYPE_JSON_SCHEMALESS);
 
     assertNotNull(result.getData());
     String json = (String) result.getData();
     assertTrue(json.contains("\"key\""));
     assertTrue(json.contains("\"value\""));
-    assertEquals("JSON_SCHEMALESS", result.getSchemaType());
+    assertEquals(BackupEnvelope.TYPE_JSON_SCHEMALESS, result.getSchemaType());
     assertNull(result.getSchemaId());
   }
 
   @Test
   public void testUnwrapSchemalessString() {
     Unwrapped result = BackupWrapperExtractor.unwrap(
-        "plain text", null, false, "STRING");
+        "plain text", null, false, BackupEnvelope.TYPE_STRING);
 
     assertEquals("plain text", result.getData());
-    assertEquals("JSON_SCHEMALESS", result.getSchemaType());
+    assertEquals(BackupEnvelope.TYPE_JSON_SCHEMALESS, result.getSchemaType());
   }
 
   @Test
   public void testUnwrapNonSrWithSchema() {
     Unwrapped result = BackupWrapperExtractor.unwrap(
-        "hello", Schema.STRING_SCHEMA, true, "STRING");
+        "hello", Schema.STRING_SCHEMA, true, BackupEnvelope.TYPE_STRING);
 
     assertEquals("hello", result.getData());
     assertEquals(Schema.STRING_SCHEMA, result.getSchema());
-    assertEquals("STRING", result.getSchemaType());
+    assertEquals(BackupEnvelope.TYPE_STRING, result.getSchemaType());
     assertNull(result.getSchemaId());
     assertNull(result.getRawSchema());
   }
@@ -116,11 +117,11 @@ public class BackupWrapperExtractorTest {
     Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
 
     BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
-        1, null, "STRING", "test-key", null, null, null);
+        1, null, BackupEnvelope.TYPE_STRING, "test-key", null, null, null);
     Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, "hello", fields);
 
     Unwrapped result = BackupWrapperExtractor.unwrap(
-        wrapper, wrapperSchema, true, "STRING");
+        wrapper, wrapperSchema, true, BackupEnvelope.TYPE_STRING);
 
     assertEquals(1, (int) result.getSchemaId());
     assertNull(result.getSchemaVersion());
@@ -139,13 +140,13 @@ public class BackupWrapperExtractorTest {
     outer.put("address", inner);
 
     Unwrapped result = BackupWrapperExtractor.unwrap(
-        outer, null, false, "JSON_SCHEMALESS");
+        outer, null, false, BackupEnvelope.TYPE_JSON_SCHEMALESS);
 
     String json = (String) result.getData();
     assertTrue(json.contains("\"address\""));
     assertTrue(json.contains("\"city\":\"NYC\""));
     assertTrue(json.contains("\"zip\":10001"));
-    assertEquals("JSON_SCHEMALESS", result.getSchemaType());
+    assertEquals(BackupEnvelope.TYPE_JSON_SCHEMALESS, result.getSchemaType());
   }
 
   @Test
@@ -153,7 +154,7 @@ public class BackupWrapperExtractorTest {
     List<Object> list = Arrays.asList(1, "two", true, null);
 
     Unwrapped result = BackupWrapperExtractor.unwrap(
-        list, null, false, "JSON_SCHEMALESS");
+        list, null, false, BackupEnvelope.TYPE_JSON_SCHEMALESS);
 
     String json = (String) result.getData();
     assertTrue(json.startsWith("["));
@@ -165,7 +166,7 @@ public class BackupWrapperExtractorTest {
   @Test
   public void testUnwrapSchemalessEmptyMap() {
     Unwrapped result = BackupWrapperExtractor.unwrap(
-        new HashMap<>(), null, false, "JSON_SCHEMALESS");
+        new HashMap<>(), null, false, BackupEnvelope.TYPE_JSON_SCHEMALESS);
 
     assertEquals("{}", result.getData());
   }
@@ -173,7 +174,7 @@ public class BackupWrapperExtractorTest {
   @Test
   public void testUnwrapSchemalessEmptyList() {
     Unwrapped result = BackupWrapperExtractor.unwrap(
-        new ArrayList<>(), null, false, "JSON_SCHEMALESS");
+        new ArrayList<>(), null, false, BackupEnvelope.TYPE_JSON_SCHEMALESS);
 
     assertEquals("[]", result.getData());
   }
@@ -185,7 +186,7 @@ public class BackupWrapperExtractorTest {
     map.put("absent", null);
 
     Unwrapped result = BackupWrapperExtractor.unwrap(
-        map, null, false, "JSON_SCHEMALESS");
+        map, null, false, BackupEnvelope.TYPE_JSON_SCHEMALESS);
 
     String json = (String) result.getData();
     assertTrue(json.contains("\"absent\":null"));
@@ -202,11 +203,11 @@ public class BackupWrapperExtractorTest {
         .put("name", "Alice").put("age", 30);
 
     Unwrapped result = BackupWrapperExtractor.unwrap(
-        data, s, false, "JSON_EMBEDDED_SCHEMA");
+        data, s, false, BackupEnvelope.TYPE_JSON_EMBEDDED_SCHEMA);
 
     assertEquals(data, result.getData());
     assertEquals(s, result.getSchema());
-    assertEquals("JSON_EMBEDDED_SCHEMA", result.getSchemaType());
+    assertEquals(BackupEnvelope.TYPE_JSON_EMBEDDED_SCHEMA, result.getSchemaType());
     assertNull(result.getSchemaId());
   }
 
@@ -222,7 +223,7 @@ public class BackupWrapperExtractorTest {
         .put("name", "Alice").put("address", addr);
 
     Unwrapped result = BackupWrapperExtractor.unwrap(
-        data, outer, false, "JSON_EMBEDDED_SCHEMA");
+        data, outer, false, BackupEnvelope.TYPE_JSON_EMBEDDED_SCHEMA);
 
     Struct restored = (Struct) result.getData();
     Struct restoredAddr = restored.getStruct("address");
@@ -241,7 +242,7 @@ public class BackupWrapperExtractorTest {
         .put("items", Arrays.asList(item1, item2));
 
     Unwrapped result = BackupWrapperExtractor.unwrap(
-        data, s, false, "JSON_EMBEDDED_SCHEMA");
+        data, s, false, BackupEnvelope.TYPE_JSON_EMBEDDED_SCHEMA);
 
     Struct restored = (Struct) result.getData();
     List<?> items = restored.getArray("items");
@@ -251,21 +252,21 @@ public class BackupWrapperExtractorTest {
   @Test
   public void testUnwrapPrimitiveString() {
     Unwrapped result = BackupWrapperExtractor.unwrap(
-        "hello", Schema.STRING_SCHEMA, true, "STRING");
+        "hello", Schema.STRING_SCHEMA, true, BackupEnvelope.TYPE_STRING);
 
     assertEquals("hello", result.getData());
     assertEquals(Schema.STRING_SCHEMA, result.getSchema());
-    assertEquals("STRING", result.getSchemaType());
+    assertEquals(BackupEnvelope.TYPE_STRING, result.getSchemaType());
   }
 
   @Test
   public void testUnwrapPrimitiveInt32() {
     Unwrapped result = BackupWrapperExtractor.unwrap(
-        42, Schema.INT32_SCHEMA, true, "INT32");
+        42, Schema.INT32_SCHEMA, true, BackupEnvelope.TYPE_INT32);
 
     assertEquals(42, result.getData());
     assertEquals(Schema.INT32_SCHEMA, result.getSchema());
-    assertEquals("INT32", result.getSchemaType());
+    assertEquals(BackupEnvelope.TYPE_INT32, result.getSchemaType());
   }
 
   @Test
@@ -273,14 +274,11 @@ public class BackupWrapperExtractorTest {
     byte[] bytes = new byte[]{1, 2, 3};
 
     Unwrapped result = BackupWrapperExtractor.unwrap(
-        bytes, Schema.BYTES_SCHEMA, false, "BYTES");
+        bytes, Schema.BYTES_SCHEMA, false, BackupEnvelope.TYPE_BYTES);
 
     assertEquals(bytes, result.getData());
     assertEquals(Schema.BYTES_SCHEMA, result.getSchema());
-    assertEquals("BYTES", result.getSchemaType());
+    assertEquals(BackupEnvelope.TYPE_BYTES, result.getSchemaType());
   }
 
-  private static void assertTrue(boolean condition) {
-    org.junit.Assert.assertTrue(condition);
-  }
 }

--- a/format/src/test/java/io/confluent/connect/storage/format/backup/EnvelopeTransformerTest.java
+++ b/format/src/test/java/io/confluent/connect/storage/format/backup/EnvelopeTransformerTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.storage.format.backup;
+
+import io.confluent.connect.schema.backup.api.BackupWrapper;
+import io.confluent.connect.storage.backup.BackupEnvelope;
+import io.confluent.connect.storage.backup.SchemaBackupStore;
+import io.confluent.connect.storage.backup.SchemaManifest;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class EnvelopeTransformerTest {
+
+  private static final String TOPIC = "test-topic";
+  private static final int PARTITION = 0;
+  private static final long OFFSET = 100L;
+  private static final long TIMESTAMP = 1234567890L;
+  private static final String SCHEMA_TYPE_AVRO = "AVRO";
+  private static final String SCHEMA_TYPE_STRING = "STRING";
+  private static final String RAW_SCHEMA = "{\"type\":\"record\",\"name\":\"User\","
+      + "\"fields\":[{\"name\":\"name\",\"type\":\"string\"}]}";
+
+  private SchemaBackupStore backupStore;
+  private EnvelopeTransformer transformer;
+
+  @Before
+  public void setUp() {
+    backupStore = mock(SchemaBackupStore.class);
+    transformer = new EnvelopeTransformer(
+        backupStore, SCHEMA_TYPE_STRING, SCHEMA_TYPE_AVRO);
+  }
+
+  @Test
+  public void wrapRecordWithAvroKeyAndValue() {
+    Schema dataSchema = SchemaBuilder.struct()
+        .field("name", Schema.STRING_SCHEMA).build();
+    Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
+    Struct data = new Struct(dataSchema).put("name", "Alice");
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        42, 1, SCHEMA_TYPE_AVRO, "test-value", RAW_SCHEMA, null, null);
+    Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, data, fields);
+
+    SinkRecord record = new SinkRecord(
+        TOPIC, PARTITION,
+        Schema.STRING_SCHEMA, "key1",
+        wrapperSchema, wrapper,
+        OFFSET, TIMESTAMP, TimestampType.CREATE_TIME);
+
+    SinkRecord result = transformer.wrap(record);
+
+    assertNotNull(result);
+    assertEquals(TOPIC, result.topic());
+    assertEquals(PARTITION, (int) result.kafkaPartition());
+    assertEquals(OFFSET, (long) result.kafkaOffset());
+    assertNotNull(result.valueSchema());
+    assertEquals(BackupEnvelope.NAME, result.valueSchema().name());
+    assertTrue(result.value() instanceof Struct);
+  }
+
+  @Test
+  public void wrapRecordWithNullKey() {
+    Schema dataSchema = SchemaBuilder.struct()
+        .field("name", Schema.STRING_SCHEMA).build();
+    Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
+    Struct data = new Struct(dataSchema).put("name", "Alice");
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        42, 1, SCHEMA_TYPE_AVRO, "test-value", RAW_SCHEMA, null, null);
+    Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, data, fields);
+
+    SinkRecord record = new SinkRecord(
+        TOPIC, PARTITION, null, null,
+        wrapperSchema, wrapper, OFFSET);
+
+    SinkRecord result = transformer.wrap(record);
+
+    assertNotNull(result);
+    Struct envelope = (Struct) result.value();
+    assertNotNull(envelope.get(BackupEnvelope.FIELD_VALUE));
+  }
+
+  @Test
+  public void wrapRecordWithNullValue() {
+    SinkRecord record = new SinkRecord(
+        TOPIC, PARTITION,
+        Schema.STRING_SCHEMA, "key1",
+        null, null, OFFSET);
+
+    SinkRecord result = transformer.wrap(record);
+
+    assertNotNull(result);
+    Struct envelope = (Struct) result.value();
+    assertEquals("key1", envelope.get(BackupEnvelope.FIELD_KEY));
+  }
+
+  @Test(expected = DataException.class)
+  public void wrapRecordWithBothNullThrows() {
+    SinkRecord record = new SinkRecord(
+        TOPIC, PARTITION, null, null, null, null, OFFSET);
+
+    transformer.wrap(record);
+  }
+
+  @Test
+  public void wrapAllEmptyCollection() {
+    Collection<SinkRecord> result = transformer.wrapAll(Collections.emptyList());
+
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void wrapAllMultipleRecords() {
+    List<SinkRecord> records = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      records.add(new SinkRecord(
+          TOPIC, PARTITION,
+          Schema.STRING_SCHEMA, "key" + i,
+          Schema.STRING_SCHEMA, "value" + i, i));
+    }
+
+    Collection<SinkRecord> results = transformer.wrapAll(records);
+
+    assertEquals(3, results.size());
+    List<SinkRecord> resultList = new ArrayList<>(results);
+    for (int i = 0; i < 3; i++) {
+      assertEquals(TOPIC, resultList.get(i).topic());
+      assertEquals((long) i, (long) resultList.get(i).kafkaOffset());
+    }
+  }
+
+  @Test
+  public void wrapPreservesTopicPartitionOffset() {
+    SinkRecord record = new SinkRecord(
+        TOPIC, PARTITION,
+        Schema.STRING_SCHEMA, "key1",
+        Schema.STRING_SCHEMA, "value1",
+        OFFSET, TIMESTAMP, TimestampType.CREATE_TIME);
+
+    SinkRecord result = transformer.wrap(record);
+
+    assertEquals(TOPIC, result.topic());
+    assertEquals(PARTITION, (int) result.kafkaPartition());
+    assertEquals(OFFSET, (long) result.kafkaOffset());
+    assertEquals(TIMESTAMP, (long) result.timestamp());
+    assertEquals(TimestampType.CREATE_TIME, result.timestampType());
+  }
+
+  @Test
+  public void backupStoreCalledForSchema() {
+    Schema dataSchema = SchemaBuilder.struct()
+        .field("name", Schema.STRING_SCHEMA).build();
+    Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
+    Struct data = new Struct(dataSchema).put("name", "Alice");
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        42, 1, SCHEMA_TYPE_AVRO, "test-value", RAW_SCHEMA, null, null);
+    Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, data, fields);
+
+    SinkRecord record = new SinkRecord(
+        TOPIC, PARTITION, null, null,
+        wrapperSchema, wrapper, OFFSET);
+
+    transformer.wrap(record);
+
+    verify(backupStore).backupIfNeeded(
+        anyString(), anyString(), anyInt(), anyString(),
+        anyString(), anyString(), anyList());
+  }
+}

--- a/format/src/test/java/io/confluent/connect/storage/format/backup/EnvelopeTransformerTest.java
+++ b/format/src/test/java/io/confluent/connect/storage/format/backup/EnvelopeTransformerTest.java
@@ -18,7 +18,6 @@ package io.confluent.connect.storage.format.backup;
 import io.confluent.connect.schema.backup.api.BackupWrapper;
 import io.confluent.connect.storage.backup.BackupEnvelope;
 import io.confluent.connect.storage.backup.SchemaBackupStore;
-import io.confluent.connect.storage.backup.SchemaManifest;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -29,7 +28,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -50,6 +48,10 @@ public class EnvelopeTransformerTest {
   private static final int PARTITION = 0;
   private static final long OFFSET = 100L;
   private static final long TIMESTAMP = 1234567890L;
+  private static final String FIELD_NAME = "name";
+  private static final String NAME_ALICE = "Alice";
+  private static final String HEADER_KEY_1 = "key1";
+  private static final String TEST_VALUE = "test-value";
   private static final String RAW_SCHEMA = "{\"type\":\"record\",\"name\":\"User\","
       + "\"fields\":[{\"name\":\"name\",\"type\":\"string\"}]}";
 
@@ -66,16 +68,16 @@ public class EnvelopeTransformerTest {
   @Test
   public void wrapRecordWithAvroKeyAndValue() {
     Schema dataSchema = SchemaBuilder.struct()
-        .field("name", Schema.STRING_SCHEMA).build();
+        .field(FIELD_NAME, Schema.STRING_SCHEMA).build();
     Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
-    Struct data = new Struct(dataSchema).put("name", "Alice");
+    Struct data = new Struct(dataSchema).put(FIELD_NAME, NAME_ALICE);
     BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
-        42, 1, BackupEnvelope.TYPE_AVRO, "test-value", RAW_SCHEMA, null, null);
+        42, 1, BackupEnvelope.TYPE_AVRO, TEST_VALUE, RAW_SCHEMA, null, null);
     Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, data, fields);
 
     SinkRecord record = new SinkRecord(
         TOPIC, PARTITION,
-        Schema.STRING_SCHEMA, "key1",
+        Schema.STRING_SCHEMA, HEADER_KEY_1,
         wrapperSchema, wrapper,
         OFFSET, TIMESTAMP, TimestampType.CREATE_TIME);
 
@@ -93,11 +95,11 @@ public class EnvelopeTransformerTest {
   @Test
   public void wrapRecordWithNullKey() {
     Schema dataSchema = SchemaBuilder.struct()
-        .field("name", Schema.STRING_SCHEMA).build();
+        .field(FIELD_NAME, Schema.STRING_SCHEMA).build();
     Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
-    Struct data = new Struct(dataSchema).put("name", "Alice");
+    Struct data = new Struct(dataSchema).put(FIELD_NAME, NAME_ALICE);
     BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
-        42, 1, BackupEnvelope.TYPE_AVRO, "test-value", RAW_SCHEMA, null, null);
+        42, 1, BackupEnvelope.TYPE_AVRO, TEST_VALUE, RAW_SCHEMA, null, null);
     Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, data, fields);
 
     SinkRecord record = new SinkRecord(
@@ -115,14 +117,14 @@ public class EnvelopeTransformerTest {
   public void wrapRecordWithNullValue() {
     SinkRecord record = new SinkRecord(
         TOPIC, PARTITION,
-        Schema.STRING_SCHEMA, "key1",
+        Schema.STRING_SCHEMA, HEADER_KEY_1,
         null, null, OFFSET);
 
     SinkRecord result = transformer.wrap(record);
 
     assertNotNull(result);
     Struct envelope = (Struct) result.value();
-    assertEquals("key1", envelope.get(BackupEnvelope.FIELD_KEY));
+    assertEquals(HEADER_KEY_1, envelope.get(BackupEnvelope.FIELD_KEY));
   }
 
   @Test(expected = DataException.class)
@@ -165,7 +167,7 @@ public class EnvelopeTransformerTest {
   public void wrapPreservesTopicPartitionOffset() {
     SinkRecord record = new SinkRecord(
         TOPIC, PARTITION,
-        Schema.STRING_SCHEMA, "key1",
+        Schema.STRING_SCHEMA, HEADER_KEY_1,
         Schema.STRING_SCHEMA, "value1",
         OFFSET, TIMESTAMP, TimestampType.CREATE_TIME);
 
@@ -181,11 +183,11 @@ public class EnvelopeTransformerTest {
   @Test
   public void backupStoreCalledForSchema() {
     Schema dataSchema = SchemaBuilder.struct()
-        .field("name", Schema.STRING_SCHEMA).build();
+        .field(FIELD_NAME, Schema.STRING_SCHEMA).build();
     Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
-    Struct data = new Struct(dataSchema).put("name", "Alice");
+    Struct data = new Struct(dataSchema).put(FIELD_NAME, NAME_ALICE);
     BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
-        42, 1, BackupEnvelope.TYPE_AVRO, "test-value", RAW_SCHEMA, null, null);
+        42, 1, BackupEnvelope.TYPE_AVRO, TEST_VALUE, RAW_SCHEMA, null, null);
     Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, data, fields);
 
     SinkRecord record = new SinkRecord(

--- a/format/src/test/java/io/confluent/connect/storage/format/backup/EnvelopeTransformerTest.java
+++ b/format/src/test/java/io/confluent/connect/storage/format/backup/EnvelopeTransformerTest.java
@@ -39,7 +39,6 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 public class EnvelopeTransformerTest {

--- a/format/src/test/java/io/confluent/connect/storage/format/backup/EnvelopeTransformerTest.java
+++ b/format/src/test/java/io/confluent/connect/storage/format/backup/EnvelopeTransformerTest.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -177,6 +178,34 @@ public class EnvelopeTransformerTest {
     assertEquals(OFFSET, (long) result.kafkaOffset());
     assertEquals(TIMESTAMP, (long) result.timestamp());
     assertEquals(TimestampType.CREATE_TIME, result.timestampType());
+  }
+
+  @Test
+  public void wrapProducesDistinctEnvelopeSchemaPerValueSchema() {
+    // Load-bearing for TopicPartitionWriter file rotation: the envelope value schema must
+    // differ across records whose underlying value schema differs, so schema-change
+    // detection triggers a file rotation on the sink side.
+    SinkRecord stringValue = new SinkRecord(
+        TOPIC, PARTITION,
+        Schema.STRING_SCHEMA, HEADER_KEY_1,
+        Schema.STRING_SCHEMA, TEST_VALUE, OFFSET);
+    SinkRecord int64Value = new SinkRecord(
+        TOPIC, PARTITION,
+        Schema.STRING_SCHEMA, HEADER_KEY_1,
+        Schema.INT64_SCHEMA, 123L, OFFSET + 1);
+    SinkRecord tombstone = new SinkRecord(
+        TOPIC, PARTITION,
+        Schema.STRING_SCHEMA, HEADER_KEY_1,
+        null, null, OFFSET + 2);
+
+    Schema envelopeForString = transformer.wrap(stringValue).valueSchema();
+    Schema envelopeForInt64 = transformer.wrap(int64Value).valueSchema();
+    Schema envelopeForTombstone = transformer.wrap(tombstone).valueSchema();
+
+    assertNotEquals(envelopeForString, envelopeForInt64);
+    assertNotEquals(envelopeForString, envelopeForTombstone);
+    assertNotEquals(envelopeForInt64, envelopeForTombstone);
+    assertEquals(envelopeForString, transformer.wrap(stringValue).valueSchema());
   }
 
   @Test

--- a/format/src/test/java/io/confluent/connect/storage/format/backup/EnvelopeTransformerTest.java
+++ b/format/src/test/java/io/confluent/connect/storage/format/backup/EnvelopeTransformerTest.java
@@ -50,8 +50,6 @@ public class EnvelopeTransformerTest {
   private static final int PARTITION = 0;
   private static final long OFFSET = 100L;
   private static final long TIMESTAMP = 1234567890L;
-  private static final String SCHEMA_TYPE_AVRO = "AVRO";
-  private static final String SCHEMA_TYPE_STRING = "STRING";
   private static final String RAW_SCHEMA = "{\"type\":\"record\",\"name\":\"User\","
       + "\"fields\":[{\"name\":\"name\",\"type\":\"string\"}]}";
 
@@ -62,7 +60,7 @@ public class EnvelopeTransformerTest {
   public void setUp() {
     backupStore = mock(SchemaBackupStore.class);
     transformer = new EnvelopeTransformer(
-        backupStore, SCHEMA_TYPE_STRING, SCHEMA_TYPE_AVRO);
+        backupStore, BackupEnvelope.TYPE_STRING, BackupEnvelope.TYPE_AVRO);
   }
 
   @Test
@@ -72,7 +70,7 @@ public class EnvelopeTransformerTest {
     Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
     Struct data = new Struct(dataSchema).put("name", "Alice");
     BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
-        42, 1, SCHEMA_TYPE_AVRO, "test-value", RAW_SCHEMA, null, null);
+        42, 1, BackupEnvelope.TYPE_AVRO, "test-value", RAW_SCHEMA, null, null);
     Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, data, fields);
 
     SinkRecord record = new SinkRecord(
@@ -99,7 +97,7 @@ public class EnvelopeTransformerTest {
     Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
     Struct data = new Struct(dataSchema).put("name", "Alice");
     BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
-        42, 1, SCHEMA_TYPE_AVRO, "test-value", RAW_SCHEMA, null, null);
+        42, 1, BackupEnvelope.TYPE_AVRO, "test-value", RAW_SCHEMA, null, null);
     Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, data, fields);
 
     SinkRecord record = new SinkRecord(
@@ -187,7 +185,7 @@ public class EnvelopeTransformerTest {
     Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
     Struct data = new Struct(dataSchema).put("name", "Alice");
     BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
-        42, 1, SCHEMA_TYPE_AVRO, "test-value", RAW_SCHEMA, null, null);
+        42, 1, BackupEnvelope.TYPE_AVRO, "test-value", RAW_SCHEMA, null, null);
     Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, data, fields);
 
     SinkRecord record = new SinkRecord(

--- a/format/src/test/java/io/confluent/connect/storage/format/backup/SchemaBackupOrchestratorTest.java
+++ b/format/src/test/java/io/confluent/connect/storage/format/backup/SchemaBackupOrchestratorTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.storage.format.backup;
+
+import io.confluent.connect.schema.backup.api.BackupWrapper;
+import io.confluent.connect.storage.backup.BackupEnvelope;
+import io.confluent.connect.storage.backup.SchemaBackupStore;
+import io.confluent.connect.storage.format.backup.BackupWrapperExtractor.Unwrapped;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class SchemaBackupOrchestratorTest {
+
+  private static final String TOPIC = "test-topic";
+  private static final String SCHEMA_TYPE_AVRO = "AVRO";
+  private static final String SUBJECT = "test-value";
+  private static final String RAW_SCHEMA = "{\"type\":\"record\",\"name\":\"User\","
+      + "\"fields\":[{\"name\":\"name\",\"type\":\"string\"}]}";
+  private static final String SCHEMA_GUID = "550e8400-e29b-41d4-a716-446655440000";
+
+  private SchemaBackupStore backupStore;
+  private SchemaBackupOrchestrator orchestrator;
+
+  @Before
+  public void setUp() {
+    backupStore = mock(SchemaBackupStore.class);
+    orchestrator = new SchemaBackupOrchestrator(backupStore);
+  }
+
+  @Test
+  public void backupSkippedWhenRawSchemaNull() {
+    Unwrapped unwrapped = BackupWrapperExtractor.unwrap(
+        null, null, false, "AVRO");
+
+    orchestrator.backupIfNeeded(TOPIC, unwrapped);
+
+    verify(backupStore, never()).backupIfNeeded(
+        anyString(), anyString(), anyInt(), anyString(),
+        anyString(), anyString(), anyList());
+  }
+
+  @Test
+  public void backupSkippedWhenNoSchemaIdOrGuid() {
+    Schema dataSchema = SchemaBuilder.struct()
+        .field("name", Schema.STRING_SCHEMA).build();
+    Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
+    Struct data = new Struct(dataSchema).put("name", "Alice");
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        null, 1, SCHEMA_TYPE_AVRO, SUBJECT, RAW_SCHEMA, null, null);
+    Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, data, fields);
+
+    Unwrapped unwrapped = BackupWrapperExtractor.unwrap(
+        wrapper, wrapperSchema, false, SCHEMA_TYPE_AVRO);
+
+    orchestrator.backupIfNeeded(TOPIC, unwrapped);
+
+    verify(backupStore, never()).backupIfNeeded(
+        anyString(), anyString(), anyInt(), anyString(),
+        anyString(), anyString(), anyList());
+  }
+
+  @Test
+  public void backupCalledWithSchemaId() {
+    Unwrapped unwrapped = createUnwrappedWithId(42);
+
+    orchestrator.backupIfNeeded(TOPIC, unwrapped);
+
+    verify(backupStore).backupIfNeeded(
+        eq(TOPIC), eq("42"), eq(1), eq(SCHEMA_TYPE_AVRO),
+        eq(SUBJECT), eq(RAW_SCHEMA), anyList());
+  }
+
+  @Test
+  public void backupCalledWithSchemaGuid() {
+    Schema dataSchema = SchemaBuilder.struct()
+        .field("name", Schema.STRING_SCHEMA).build();
+    Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
+    Struct data = new Struct(dataSchema).put("name", "Alice");
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        null, 1, SCHEMA_TYPE_AVRO, SUBJECT, RAW_SCHEMA,
+        null, null, SCHEMA_GUID);
+    Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, data, fields);
+
+    Unwrapped unwrapped = BackupWrapperExtractor.unwrap(
+        wrapper, wrapperSchema, false, SCHEMA_TYPE_AVRO);
+
+    orchestrator.backupIfNeeded(TOPIC, unwrapped);
+
+    verify(backupStore).backupIfNeeded(
+        eq(TOPIC), eq(SCHEMA_GUID), eq(1), eq(SCHEMA_TYPE_AVRO),
+        eq(SUBJECT), eq(RAW_SCHEMA), anyList());
+  }
+
+  @Test
+  public void backupDefaultsVersionToZeroWhenNull() {
+    Schema dataSchema = SchemaBuilder.struct()
+        .field("name", Schema.STRING_SCHEMA).build();
+    Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
+    Struct data = new Struct(dataSchema).put("name", "Alice");
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        42, null, SCHEMA_TYPE_AVRO, SUBJECT, RAW_SCHEMA, null, null);
+    Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, data, fields);
+
+    Unwrapped unwrapped = BackupWrapperExtractor.unwrap(
+        wrapper, wrapperSchema, false, SCHEMA_TYPE_AVRO);
+
+    orchestrator.backupIfNeeded(TOPIC, unwrapped);
+
+    verify(backupStore).backupIfNeeded(
+        eq(TOPIC), eq("42"), eq(0), eq(SCHEMA_TYPE_AVRO),
+        eq(SUBJECT), eq(RAW_SCHEMA), anyList());
+  }
+
+  @Test
+  public void backupIncludesSubjectAndType() {
+    Unwrapped unwrapped = createUnwrappedWithId(10);
+
+    orchestrator.backupIfNeeded(TOPIC, unwrapped);
+
+    verify(backupStore).backupIfNeeded(
+        eq(TOPIC), anyString(), anyInt(),
+        eq(SCHEMA_TYPE_AVRO), eq(SUBJECT), anyString(), anyList());
+  }
+
+  @Test
+  public void backupCalledWithNoReferences() {
+    Unwrapped unwrapped = createUnwrappedWithId(42);
+
+    orchestrator.backupIfNeeded(TOPIC, unwrapped);
+
+    verify(backupStore).backupIfNeeded(
+        eq(TOPIC), eq("42"), anyInt(), anyString(),
+        anyString(), anyString(), anyList());
+  }
+
+  @Test
+  public void backupHandlesReferenceTree() {
+    String refTree = "{"
+        + "\"Country\":{\"subject\":\"Country\",\"version\":1,"
+        + "\"globalId\":10,\"schemaType\":\"AVRO\","
+        + "\"schema\":\"{}\",\"references\":[]}"
+        + "}";
+    String directRefs = "[{\"name\":\"Country\","
+        + "\"subject\":\"Country\",\"version\":1}]";
+
+    Schema dataSchema = SchemaBuilder.struct()
+        .field("name", Schema.STRING_SCHEMA).build();
+    Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
+    Struct data = new Struct(dataSchema).put("name", "Alice");
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        42, 1, SCHEMA_TYPE_AVRO, SUBJECT, RAW_SCHEMA, refTree, directRefs);
+    Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, data, fields);
+
+    Unwrapped unwrapped = BackupWrapperExtractor.unwrap(
+        wrapper, wrapperSchema, false, SCHEMA_TYPE_AVRO);
+
+    orchestrator.backupIfNeeded(TOPIC, unwrapped);
+
+    verify(backupStore).backupIfNeeded(
+        eq(TOPIC), eq("10"), eq(1), eq(SCHEMA_TYPE_AVRO),
+        eq("Country"), eq("{}"), anyList());
+    verify(backupStore).backupIfNeeded(
+        eq(TOPIC), eq("42"), eq(1), eq(SCHEMA_TYPE_AVRO),
+        eq(SUBJECT), eq(RAW_SCHEMA), anyList());
+  }
+
+  @Test(expected = DataException.class)
+  public void backupThrowsOnMissingSchemaInRef() {
+    String refTree = "{"
+        + "\"BadRef\":{\"subject\":\"Bad\",\"version\":1,"
+        + "\"globalId\":99,\"schemaType\":\"AVRO\"}"
+        + "}";
+
+    Schema dataSchema = SchemaBuilder.struct()
+        .field("name", Schema.STRING_SCHEMA).build();
+    Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
+    Struct data = new Struct(dataSchema).put("name", "Alice");
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        42, 1, SCHEMA_TYPE_AVRO, SUBJECT, RAW_SCHEMA, refTree, null);
+    Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, data, fields);
+
+    Unwrapped unwrapped = BackupWrapperExtractor.unwrap(
+        wrapper, wrapperSchema, false, SCHEMA_TYPE_AVRO);
+
+    orchestrator.backupIfNeeded(TOPIC, unwrapped);
+  }
+
+  private Unwrapped createUnwrappedWithId(int schemaId) {
+    Schema dataSchema = SchemaBuilder.struct()
+        .field("name", Schema.STRING_SCHEMA).build();
+    Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
+    Struct data = new Struct(dataSchema).put("name", "Alice");
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        schemaId, 1, SCHEMA_TYPE_AVRO, SUBJECT, RAW_SCHEMA, null, null);
+    Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, data, fields);
+    return BackupWrapperExtractor.unwrap(
+        wrapper, wrapperSchema, false, SCHEMA_TYPE_AVRO);
+  }
+}

--- a/format/src/test/java/io/confluent/connect/storage/format/backup/SchemaBackupOrchestratorTest.java
+++ b/format/src/test/java/io/confluent/connect/storage/format/backup/SchemaBackupOrchestratorTest.java
@@ -186,6 +186,38 @@ public class SchemaBackupOrchestratorTest {
     orchestrator.backupIfNeeded(TOPIC, unwrapped);
   }
 
+  @Test(expected = DataException.class)
+  public void backupThrowsWhenChildRefMissingFromTree() {
+    String refTree = "{"
+        + "\"Parent\":{\"subject\":\"Parent\",\"version\":1,"
+        + "\"globalId\":10,\"schemaType\":\"AVRO\",\"schema\":\"{}\","
+        + "\"references\":[{\"name\":\"Orphan\","
+        + "\"subject\":\"Orphan\",\"version\":1}]}"
+        + "}";
+
+    Unwrapped unwrapped = unwrapWith(new BackupWrapper.WrapperFields(
+        42, 1, BackupEnvelope.TYPE_AVRO, SUBJECT, RAW_SCHEMA, refTree, null));
+
+    orchestrator.backupIfNeeded(TOPIC, unwrapped);
+  }
+
+  @Test(expected = DataException.class)
+  public void backupThrowsWhenChildRefHasInvalidGlobalId() {
+    String refTree = "{"
+        + "\"Parent\":{\"subject\":\"Parent\",\"version\":1,"
+        + "\"globalId\":10,\"schemaType\":\"AVRO\",\"schema\":\"{}\","
+        + "\"references\":[{\"name\":\"Bad\","
+        + "\"subject\":\"Bad\",\"version\":1}]},"
+        + "\"Bad\":{\"subject\":\"Bad\",\"version\":1,"
+        + "\"globalId\":0,\"schemaType\":\"AVRO\",\"schema\":\"{}\"}"
+        + "}";
+
+    Unwrapped unwrapped = unwrapWith(new BackupWrapper.WrapperFields(
+        42, 1, BackupEnvelope.TYPE_AVRO, SUBJECT, RAW_SCHEMA, refTree, null));
+
+    orchestrator.backupIfNeeded(TOPIC, unwrapped);
+  }
+
   private Unwrapped createUnwrappedWithId(int schemaId) {
     return unwrapWith(new BackupWrapper.WrapperFields(
         schemaId, 1, BackupEnvelope.TYPE_AVRO, SUBJECT, RAW_SCHEMA, null, null));

--- a/format/src/test/java/io/confluent/connect/storage/format/backup/SchemaBackupOrchestratorTest.java
+++ b/format/src/test/java/io/confluent/connect/storage/format/backup/SchemaBackupOrchestratorTest.java
@@ -26,8 +26,6 @@ import org.apache.kafka.connect.errors.DataException;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.List;
-
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -40,9 +38,13 @@ public class SchemaBackupOrchestratorTest {
 
   private static final String TOPIC = "test-topic";
   private static final String SUBJECT = "test-value";
+  private static final String FIELD_NAME = "name";
+  private static final String FIELD_VALUE = "Alice";
   private static final String RAW_SCHEMA = "{\"type\":\"record\",\"name\":\"User\","
       + "\"fields\":[{\"name\":\"name\",\"type\":\"string\"}]}";
   private static final String SCHEMA_GUID = "550e8400-e29b-41d4-a716-446655440000";
+  private static final Schema DATA_SCHEMA = SchemaBuilder.struct()
+      .field(FIELD_NAME, Schema.STRING_SCHEMA).build();
 
   private SchemaBackupStore backupStore;
   private SchemaBackupOrchestrator orchestrator;
@@ -67,16 +69,8 @@ public class SchemaBackupOrchestratorTest {
 
   @Test
   public void backupSkippedWhenNoSchemaIdOrGuid() {
-    Schema dataSchema = SchemaBuilder.struct()
-        .field("name", Schema.STRING_SCHEMA).build();
-    Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
-    Struct data = new Struct(dataSchema).put("name", "Alice");
-    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
-        null, 1, BackupEnvelope.TYPE_AVRO, SUBJECT, RAW_SCHEMA, null, null);
-    Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, data, fields);
-
-    Unwrapped unwrapped = BackupWrapperExtractor.unwrap(
-        wrapper, wrapperSchema, false, BackupEnvelope.TYPE_AVRO);
+    Unwrapped unwrapped = unwrapWith(new BackupWrapper.WrapperFields(
+        null, 1, BackupEnvelope.TYPE_AVRO, SUBJECT, RAW_SCHEMA, null, null));
 
     orchestrator.backupIfNeeded(TOPIC, unwrapped);
 
@@ -98,17 +92,9 @@ public class SchemaBackupOrchestratorTest {
 
   @Test
   public void backupCalledWithSchemaGuid() {
-    Schema dataSchema = SchemaBuilder.struct()
-        .field("name", Schema.STRING_SCHEMA).build();
-    Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
-    Struct data = new Struct(dataSchema).put("name", "Alice");
-    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+    Unwrapped unwrapped = unwrapWith(new BackupWrapper.WrapperFields(
         null, 1, BackupEnvelope.TYPE_AVRO, SUBJECT, RAW_SCHEMA,
-        null, null, SCHEMA_GUID);
-    Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, data, fields);
-
-    Unwrapped unwrapped = BackupWrapperExtractor.unwrap(
-        wrapper, wrapperSchema, false, BackupEnvelope.TYPE_AVRO);
+        null, null, SCHEMA_GUID));
 
     orchestrator.backupIfNeeded(TOPIC, unwrapped);
 
@@ -119,16 +105,8 @@ public class SchemaBackupOrchestratorTest {
 
   @Test
   public void backupDefaultsVersionToZeroWhenNull() {
-    Schema dataSchema = SchemaBuilder.struct()
-        .field("name", Schema.STRING_SCHEMA).build();
-    Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
-    Struct data = new Struct(dataSchema).put("name", "Alice");
-    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
-        42, null, BackupEnvelope.TYPE_AVRO, SUBJECT, RAW_SCHEMA, null, null);
-    Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, data, fields);
-
-    Unwrapped unwrapped = BackupWrapperExtractor.unwrap(
-        wrapper, wrapperSchema, false, BackupEnvelope.TYPE_AVRO);
+    Unwrapped unwrapped = unwrapWith(new BackupWrapper.WrapperFields(
+        42, null, BackupEnvelope.TYPE_AVRO, SUBJECT, RAW_SCHEMA, null, null));
 
     orchestrator.backupIfNeeded(TOPIC, unwrapped);
 
@@ -169,16 +147,8 @@ public class SchemaBackupOrchestratorTest {
     String directRefs = "[{\"name\":\"Country\","
         + "\"subject\":\"Country\",\"version\":1}]";
 
-    Schema dataSchema = SchemaBuilder.struct()
-        .field("name", Schema.STRING_SCHEMA).build();
-    Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
-    Struct data = new Struct(dataSchema).put("name", "Alice");
-    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
-        42, 1, BackupEnvelope.TYPE_AVRO, SUBJECT, RAW_SCHEMA, refTree, directRefs);
-    Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, data, fields);
-
-    Unwrapped unwrapped = BackupWrapperExtractor.unwrap(
-        wrapper, wrapperSchema, false, BackupEnvelope.TYPE_AVRO);
+    Unwrapped unwrapped = unwrapWith(new BackupWrapper.WrapperFields(
+        42, 1, BackupEnvelope.TYPE_AVRO, SUBJECT, RAW_SCHEMA, refTree, directRefs));
 
     orchestrator.backupIfNeeded(TOPIC, unwrapped);
 
@@ -197,16 +167,8 @@ public class SchemaBackupOrchestratorTest {
         + "\"globalId\":99,\"schemaType\":\"AVRO\"}"
         + "}";
 
-    Schema dataSchema = SchemaBuilder.struct()
-        .field("name", Schema.STRING_SCHEMA).build();
-    Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
-    Struct data = new Struct(dataSchema).put("name", "Alice");
-    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
-        42, 1, BackupEnvelope.TYPE_AVRO, SUBJECT, RAW_SCHEMA, refTree, null);
-    Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, data, fields);
-
-    Unwrapped unwrapped = BackupWrapperExtractor.unwrap(
-        wrapper, wrapperSchema, false, BackupEnvelope.TYPE_AVRO);
+    Unwrapped unwrapped = unwrapWith(new BackupWrapper.WrapperFields(
+        42, 1, BackupEnvelope.TYPE_AVRO, SUBJECT, RAW_SCHEMA, refTree, null));
 
     orchestrator.backupIfNeeded(TOPIC, unwrapped);
   }
@@ -218,27 +180,20 @@ public class SchemaBackupOrchestratorTest {
         + "\"globalId\":0,\"schemaType\":\"AVRO\",\"schema\":\"{}\"}"
         + "}";
 
-    Schema dataSchema = SchemaBuilder.struct()
-        .field("name", Schema.STRING_SCHEMA).build();
-    Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
-    Struct data = new Struct(dataSchema).put("name", "Alice");
-    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
-        42, 1, BackupEnvelope.TYPE_AVRO, SUBJECT, RAW_SCHEMA, refTree, null);
-    Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, data, fields);
-
-    Unwrapped unwrapped = BackupWrapperExtractor.unwrap(
-        wrapper, wrapperSchema, false, BackupEnvelope.TYPE_AVRO);
+    Unwrapped unwrapped = unwrapWith(new BackupWrapper.WrapperFields(
+        42, 1, BackupEnvelope.TYPE_AVRO, SUBJECT, RAW_SCHEMA, refTree, null));
 
     orchestrator.backupIfNeeded(TOPIC, unwrapped);
   }
 
   private Unwrapped createUnwrappedWithId(int schemaId) {
-    Schema dataSchema = SchemaBuilder.struct()
-        .field("name", Schema.STRING_SCHEMA).build();
-    Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
-    Struct data = new Struct(dataSchema).put("name", "Alice");
-    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
-        schemaId, 1, BackupEnvelope.TYPE_AVRO, SUBJECT, RAW_SCHEMA, null, null);
+    return unwrapWith(new BackupWrapper.WrapperFields(
+        schemaId, 1, BackupEnvelope.TYPE_AVRO, SUBJECT, RAW_SCHEMA, null, null));
+  }
+
+  private Unwrapped unwrapWith(BackupWrapper.WrapperFields fields) {
+    Schema wrapperSchema = BackupWrapper.buildSchema(DATA_SCHEMA);
+    Struct data = new Struct(DATA_SCHEMA).put(FIELD_NAME, FIELD_VALUE);
     Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, data, fields);
     return BackupWrapperExtractor.unwrap(
         wrapper, wrapperSchema, false, BackupEnvelope.TYPE_AVRO);

--- a/format/src/test/java/io/confluent/connect/storage/format/backup/SchemaBackupOrchestratorTest.java
+++ b/format/src/test/java/io/confluent/connect/storage/format/backup/SchemaBackupOrchestratorTest.java
@@ -211,6 +211,27 @@ public class SchemaBackupOrchestratorTest {
     orchestrator.backupIfNeeded(TOPIC, unwrapped);
   }
 
+  @Test(expected = DataException.class)
+  public void backupThrowsOnInvalidGlobalIdInRef() {
+    String refTree = "{"
+        + "\"BadRef\":{\"subject\":\"Bad\",\"version\":1,"
+        + "\"globalId\":0,\"schemaType\":\"AVRO\",\"schema\":\"{}\"}"
+        + "}";
+
+    Schema dataSchema = SchemaBuilder.struct()
+        .field("name", Schema.STRING_SCHEMA).build();
+    Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
+    Struct data = new Struct(dataSchema).put("name", "Alice");
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        42, 1, BackupEnvelope.TYPE_AVRO, SUBJECT, RAW_SCHEMA, refTree, null);
+    Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, data, fields);
+
+    Unwrapped unwrapped = BackupWrapperExtractor.unwrap(
+        wrapper, wrapperSchema, false, BackupEnvelope.TYPE_AVRO);
+
+    orchestrator.backupIfNeeded(TOPIC, unwrapped);
+  }
+
   private Unwrapped createUnwrappedWithId(int schemaId) {
     Schema dataSchema = SchemaBuilder.struct()
         .field("name", Schema.STRING_SCHEMA).build();

--- a/format/src/test/java/io/confluent/connect/storage/format/backup/SchemaBackupOrchestratorTest.java
+++ b/format/src/test/java/io/confluent/connect/storage/format/backup/SchemaBackupOrchestratorTest.java
@@ -39,7 +39,6 @@ import static org.mockito.Mockito.verify;
 public class SchemaBackupOrchestratorTest {
 
   private static final String TOPIC = "test-topic";
-  private static final String SCHEMA_TYPE_AVRO = "AVRO";
   private static final String SUBJECT = "test-value";
   private static final String RAW_SCHEMA = "{\"type\":\"record\",\"name\":\"User\","
       + "\"fields\":[{\"name\":\"name\",\"type\":\"string\"}]}";
@@ -57,7 +56,7 @@ public class SchemaBackupOrchestratorTest {
   @Test
   public void backupSkippedWhenRawSchemaNull() {
     Unwrapped unwrapped = BackupWrapperExtractor.unwrap(
-        null, null, false, "AVRO");
+        null, null, false, BackupEnvelope.TYPE_AVRO);
 
     orchestrator.backupIfNeeded(TOPIC, unwrapped);
 
@@ -73,11 +72,11 @@ public class SchemaBackupOrchestratorTest {
     Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
     Struct data = new Struct(dataSchema).put("name", "Alice");
     BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
-        null, 1, SCHEMA_TYPE_AVRO, SUBJECT, RAW_SCHEMA, null, null);
+        null, 1, BackupEnvelope.TYPE_AVRO, SUBJECT, RAW_SCHEMA, null, null);
     Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, data, fields);
 
     Unwrapped unwrapped = BackupWrapperExtractor.unwrap(
-        wrapper, wrapperSchema, false, SCHEMA_TYPE_AVRO);
+        wrapper, wrapperSchema, false, BackupEnvelope.TYPE_AVRO);
 
     orchestrator.backupIfNeeded(TOPIC, unwrapped);
 
@@ -93,7 +92,7 @@ public class SchemaBackupOrchestratorTest {
     orchestrator.backupIfNeeded(TOPIC, unwrapped);
 
     verify(backupStore).backupIfNeeded(
-        eq(TOPIC), eq("42"), eq(1), eq(SCHEMA_TYPE_AVRO),
+        eq(TOPIC), eq("42"), eq(1), eq(BackupEnvelope.TYPE_AVRO),
         eq(SUBJECT), eq(RAW_SCHEMA), anyList());
   }
 
@@ -104,17 +103,17 @@ public class SchemaBackupOrchestratorTest {
     Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
     Struct data = new Struct(dataSchema).put("name", "Alice");
     BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
-        null, 1, SCHEMA_TYPE_AVRO, SUBJECT, RAW_SCHEMA,
+        null, 1, BackupEnvelope.TYPE_AVRO, SUBJECT, RAW_SCHEMA,
         null, null, SCHEMA_GUID);
     Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, data, fields);
 
     Unwrapped unwrapped = BackupWrapperExtractor.unwrap(
-        wrapper, wrapperSchema, false, SCHEMA_TYPE_AVRO);
+        wrapper, wrapperSchema, false, BackupEnvelope.TYPE_AVRO);
 
     orchestrator.backupIfNeeded(TOPIC, unwrapped);
 
     verify(backupStore).backupIfNeeded(
-        eq(TOPIC), eq(SCHEMA_GUID), eq(1), eq(SCHEMA_TYPE_AVRO),
+        eq(TOPIC), eq(SCHEMA_GUID), eq(1), eq(BackupEnvelope.TYPE_AVRO),
         eq(SUBJECT), eq(RAW_SCHEMA), anyList());
   }
 
@@ -125,16 +124,16 @@ public class SchemaBackupOrchestratorTest {
     Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
     Struct data = new Struct(dataSchema).put("name", "Alice");
     BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
-        42, null, SCHEMA_TYPE_AVRO, SUBJECT, RAW_SCHEMA, null, null);
+        42, null, BackupEnvelope.TYPE_AVRO, SUBJECT, RAW_SCHEMA, null, null);
     Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, data, fields);
 
     Unwrapped unwrapped = BackupWrapperExtractor.unwrap(
-        wrapper, wrapperSchema, false, SCHEMA_TYPE_AVRO);
+        wrapper, wrapperSchema, false, BackupEnvelope.TYPE_AVRO);
 
     orchestrator.backupIfNeeded(TOPIC, unwrapped);
 
     verify(backupStore).backupIfNeeded(
-        eq(TOPIC), eq("42"), eq(0), eq(SCHEMA_TYPE_AVRO),
+        eq(TOPIC), eq("42"), eq(0), eq(BackupEnvelope.TYPE_AVRO),
         eq(SUBJECT), eq(RAW_SCHEMA), anyList());
   }
 
@@ -146,7 +145,7 @@ public class SchemaBackupOrchestratorTest {
 
     verify(backupStore).backupIfNeeded(
         eq(TOPIC), anyString(), anyInt(),
-        eq(SCHEMA_TYPE_AVRO), eq(SUBJECT), anyString(), anyList());
+        eq(BackupEnvelope.TYPE_AVRO), eq(SUBJECT), anyString(), anyList());
   }
 
   @Test
@@ -175,19 +174,19 @@ public class SchemaBackupOrchestratorTest {
     Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
     Struct data = new Struct(dataSchema).put("name", "Alice");
     BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
-        42, 1, SCHEMA_TYPE_AVRO, SUBJECT, RAW_SCHEMA, refTree, directRefs);
+        42, 1, BackupEnvelope.TYPE_AVRO, SUBJECT, RAW_SCHEMA, refTree, directRefs);
     Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, data, fields);
 
     Unwrapped unwrapped = BackupWrapperExtractor.unwrap(
-        wrapper, wrapperSchema, false, SCHEMA_TYPE_AVRO);
+        wrapper, wrapperSchema, false, BackupEnvelope.TYPE_AVRO);
 
     orchestrator.backupIfNeeded(TOPIC, unwrapped);
 
     verify(backupStore).backupIfNeeded(
-        eq(TOPIC), eq("10"), eq(1), eq(SCHEMA_TYPE_AVRO),
+        eq(TOPIC), eq("10"), eq(1), eq(BackupEnvelope.TYPE_AVRO),
         eq("Country"), eq("{}"), anyList());
     verify(backupStore).backupIfNeeded(
-        eq(TOPIC), eq("42"), eq(1), eq(SCHEMA_TYPE_AVRO),
+        eq(TOPIC), eq("42"), eq(1), eq(BackupEnvelope.TYPE_AVRO),
         eq(SUBJECT), eq(RAW_SCHEMA), anyList());
   }
 
@@ -203,11 +202,11 @@ public class SchemaBackupOrchestratorTest {
     Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
     Struct data = new Struct(dataSchema).put("name", "Alice");
     BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
-        42, 1, SCHEMA_TYPE_AVRO, SUBJECT, RAW_SCHEMA, refTree, null);
+        42, 1, BackupEnvelope.TYPE_AVRO, SUBJECT, RAW_SCHEMA, refTree, null);
     Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, data, fields);
 
     Unwrapped unwrapped = BackupWrapperExtractor.unwrap(
-        wrapper, wrapperSchema, false, SCHEMA_TYPE_AVRO);
+        wrapper, wrapperSchema, false, BackupEnvelope.TYPE_AVRO);
 
     orchestrator.backupIfNeeded(TOPIC, unwrapped);
   }
@@ -218,9 +217,9 @@ public class SchemaBackupOrchestratorTest {
     Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
     Struct data = new Struct(dataSchema).put("name", "Alice");
     BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
-        schemaId, 1, SCHEMA_TYPE_AVRO, SUBJECT, RAW_SCHEMA, null, null);
+        schemaId, 1, BackupEnvelope.TYPE_AVRO, SUBJECT, RAW_SCHEMA, null, null);
     Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, data, fields);
     return BackupWrapperExtractor.unwrap(
-        wrapper, wrapperSchema, false, SCHEMA_TYPE_AVRO);
+        wrapper, wrapperSchema, false, BackupEnvelope.TYPE_AVRO);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,6 @@
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-connect-schema-backup-api</artifactId>
                 <version>${schema.backup.api.version}</version>
-                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.parquet</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>[7.7.8, 7.7.9)</version>
+        <version>[7.7.11, 7.7.12)</version>
     </parent>
 
     <artifactId>kafka-connect-storage-common-parent</artifactId>
@@ -87,6 +87,7 @@
         <jline.version>2.12.1</jline.version>
         <joda.version>2.13.1</joda.version>
         <kafka.connect.storage.common.version>12.1.0-SNAPSHOT</kafka.connect.storage.common.version>
+        <schema.backup.api.version>8.3.1-208</schema.backup.api.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
         <netty.version>4.1.130.Final</netty.version>
         <parquet.version>1.15.2</parquet.version>
@@ -155,6 +156,12 @@
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-connect-protobuf-converter</artifactId>
                 <version>${confluent.version.range}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.confluent</groupId>
+                <artifactId>kafka-connect-schema-backup-api</artifactId>
+                <version>${schema.backup.api.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>[7.7.8, 7.7.9)</version>
+        <version>8.4.0-1073</version>
     </parent>
 
     <artifactId>kafka-connect-storage-common-parent</artifactId>
@@ -68,7 +68,8 @@
     </modules>
 
     <properties>
-        <avro.version>1.11.5</avro.version>
+        <io.confluent.schema-registry.version>8.4.0-736</io.confluent.schema-registry.version>
+        <avro.version>1.12.1</avro.version>
         <commons-io.version>2.17.0</commons-io.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
         <commons.codec.version>1.15</commons.codec.version>
@@ -83,7 +84,6 @@
         <jackson.databind.version>2.21.5</jackson.databind.version>
         <jackson.annotations.version>2.21</jackson.annotations.version>
         <jackson.mapper.asl.version>1.9.14.jdk17-redhat-00001</jackson.mapper.asl.version>
-        <jetty.version>9.4.59</jetty.version>
         <jline.version>2.12.1</jline.version>
         <joda.version>2.13.1</joda.version>
         <kafka.connect.storage.common.version>12.1.0-SNAPSHOT</kafka.connect.storage.common.version>
@@ -150,6 +150,11 @@
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-connect-avro-data</artifactId>
                 <version>${confluent.version.range}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.confluent</groupId>
+                <artifactId>kafka-schema-converter</artifactId>
+                <version>${io.confluent.schema-registry.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.confluent</groupId>
@@ -344,6 +349,7 @@
                     <showWarnings>true</showWarnings>
                     <compilerArgs>
                         <arg>-Xlint:-processing</arg>
+                        <arg>-Xlint:-options</arg>
                         <arg>-Werror</arg>
                     </compilerArgs>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>8.4.0-1073</version>
+        <version>[7.7.8, 7.7.9)</version>
     </parent>
 
     <artifactId>kafka-connect-storage-common-parent</artifactId>
@@ -68,8 +68,7 @@
     </modules>
 
     <properties>
-        <io.confluent.schema-registry.version>8.4.0-736</io.confluent.schema-registry.version>
-        <avro.version>1.12.1</avro.version>
+        <avro.version>1.11.5</avro.version>
         <commons-io.version>2.17.0</commons-io.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
         <commons.codec.version>1.15</commons.codec.version>
@@ -84,6 +83,7 @@
         <jackson.databind.version>2.21.5</jackson.databind.version>
         <jackson.annotations.version>2.21</jackson.annotations.version>
         <jackson.mapper.asl.version>1.9.14.jdk17-redhat-00001</jackson.mapper.asl.version>
+        <jetty.version>9.4.59</jetty.version>
         <jline.version>2.12.1</jline.version>
         <joda.version>2.13.1</joda.version>
         <kafka.connect.storage.common.version>12.1.0-SNAPSHOT</kafka.connect.storage.common.version>
@@ -150,11 +150,6 @@
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-connect-avro-data</artifactId>
                 <version>${confluent.version.range}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.confluent</groupId>
-                <artifactId>kafka-schema-converter</artifactId>
-                <version>${io.confluent.schema-registry.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.confluent</groupId>
@@ -349,7 +344,6 @@
                     <showWarnings>true</showWarnings>
                     <compilerArgs>
                         <arg>-Xlint:-processing</arg>
-                        <arg>-Xlint:-options</arg>
                         <arg>-Werror</arg>
                     </compilerArgs>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <jline.version>2.12.1</jline.version>
         <joda.version>2.13.1</joda.version>
         <kafka.connect.storage.common.version>12.1.0-SNAPSHOT</kafka.connect.storage.common.version>
-        <schema.backup.api.version>8.3.1-208</schema.backup.api.version>
+        <schema.backup.api.version>8.3.2-20</schema.backup.api.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
         <netty.version>4.1.130.Final</netty.version>
         <parquet.version>1.15.2</parquet.version>


### PR DESCRIPTION
## Problem
     
  Object storage connectors (S3, GCS, Azure) need shared infrastructure for backup and restore of full Kafka records. The envelope wrapping, schema backup, schema manifest, and config validation logic must be common across all connector
  backends.
  
  ## Solution
  
  Add backup envelope infrastructure to storage-common, shared by all sink and source connectors:
  
  - BackupEnvelope: envelope schema constants and field definitions
  - EnvelopeSchemaBuilder: builds KafkaRecordEnvelope Connect struct (key, value, headers, metadata, schema info)
  - EnvelopeTransformer: wraps SinkRecords in envelope structs during backup
  - BackupWrapperExtractor: unwraps BackupWrapper metadata from converter output
  - SchemaBackupOrchestrator: triggers schema file backup with 3-level dedup and reference tree traversal
  - ObjectStoreSchemaBackupStore: writes schema files (.avsc/.proto/.json) and entry files (.entry.json)
  - SchemaManifest: schema entry and reference entry data model
  - BackupModeValidator: shared 3-tier config validation (fail/warn/info) for all backends
  - ConverterTypeDetector: maps converter class names to schema type tags
  - StorageSinkConnectorConfig: adds mode=BACKUP_FULL_RECORD config with ConfigDef validation
  
  ##### Does this solution apply anywhere else?
  - [x] yes
  - [ ] no
  
  ##### If yes, where? 
  Storage-cloud (S3 sink connector, PR pending), object-store-source (source connector, PR pending), GCS and Azure sink connectors (future PRs).
  
  ## Test Strategy
  
  ##### Testing done:
  - [x] Unit tests
  - [ ] Integration tests
  - [ ] System tests
  - [x] Manual tests

  154 unit tests (120 core + 34 format), 0 regressions. Covers envelope building, schema backup dedup, reference parsing, converter type detection, envelope transformer, schema backup orchestrator, and wrapper extraction (17 scenarios). E2E
  validated via Docker.
  
  ## Release Plan
  
  Merging to master via INIT-5113-phase2. Must merge before storage-cloud and object-store-source PRs. Part of Backup & Restore feature (INIT-5113).
