### PR TITLE
CC-43907: bump common parent to 7.7.11 to fix jetty 9.4.59 source-build failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>[7.7.8, 7.7.9)</version>
+        <version>[7.7.11, 7.7.12)</version>
     </parent>
 
     <artifactId>kafka-connect-storage-common-parent</artifactId>


### PR DESCRIPTION
## Problem

External source builds of `kafka-connect-storage-common` (v12.0.12 and the 11.2.x line) fail with:

```
Could not find org.eclipse.jetty:jetty-bom:9.4.59
```

Reported by Datadog and multiple other users — see [#468](https://github.com/confluentinc/kafka-connect-storage-common/issues/468).

Root cause:
- PR #465 set `<jetty.version>9.4.59</jetty.version>`. 9.4.59 is a Webtide extended-support build published only on `packages.confluent.io`, **not** Maven Central.
- The parent `common` range `[7.7.8, 7.7.9)` resolves to common **7.7.8**, which imports the aggregate `org.eclipse.jetty:jetty-bom`. There is no `jetty-bom:9.4.59` on Maven Central, so the build cannot resolve it. This also defeats the documented `-Djetty.version=9.4.58.v20250814` workaround.

## Solution

Widen the `common` parent range to `[7.7.11, 7.7.12)`. common **7.7.11** contains [confluentinc/common#990](https://github.com/confluentinc/common/pull/990), which replaces the `jetty-bom` import with individual Jetty dependency definitions — so the per-artifact `jetty.version` override resolves cleanly for external builders, while internal CP builds keep jetty 9.4.59 from `packages.confluent.io`.

`jetty.version` is intentionally left at `9.4.59`.

## Release Plan

- Base is `11.2.x` (lowest affected branch on the 7.7.x common line). PINT merge propagates upward to `12.0.x` and `master`.
- **Note:** `11.1.x` is also affected but sits on the common **7.2.x** line (no #990 backport), so that is excluded from current task.

##### Testing done:
- [x] Verify external source build succeeds with `mvn clean install -Djetty.version=9.4.58.v20250814 -DskipTests`
- [x] Use this storage common in a S3 sink KDP test 

🤖 Generated with [Claude Code](https://claude.com/claude-code)