### PR TITLE
Fix stale AppInfoParser import in SchemaSourceConnector (KAFKA-20297)

### DIFF
--- a/core/src/main/java/io/confluent/connect/storage/tools/SchemaSourceConnector.java
+++ b/core/src/main/java/io/confluent/connect/storage/tools/SchemaSourceConnector.java
@@ -16,7 +16,7 @@
 package io.confluent.connect.storage.tools;
 
 import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.common.utils.AppInfoParser;
+import org.apache.kafka.common.utils.internals.AppInfoParser;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.source.SourceConnector;
 


### PR DESCRIPTION
## What
`SchemaSourceConnector.version()` imports `org.apache.kafka.common.utils.AppInfoParser`. That class moved to `org.apache.kafka.common.utils.internals.AppInfoParser` upstream (KAFKA-20297, [confluentinc/ce-kafka@1754bee6](https://github.com/confluentinc/ce-kafka/commit/1754bee646eb7b843597ef660758953cc9c6a026), cherry-picked 2026-05-01) to stop exposing internal-only classes as public API. This import wasn't touched since 2019 and never got updated for the relocation.

## Impact
Once a CP build resolves against a `ce-kafka` that contains the relocation, `SchemaSourceConnector.version()` throws `NoClassDefFoundError: org/apache/kafka/common/utils/AppInfoParser` at runtime — this is fatal during Connect standalone startup (either during `PluginScanner`'s plugin-path scan, or during connector-config validation if the connector is actually deployed), causing Connect to open its REST port briefly and immediately shut back down.

This has been failing muckrake's `ConnectCheckPluginTest` (the one system test that deploys `SchemaSourceConnector` live and scans the full plugin path) 100% of the time on every branch/package/CI-backend combination since the relocation landed in CP's dependency chain (~2026-08-18–20). See confluentinc/muckrake `ConnectCheckPluginTest`, JIRA CC-44052 and related tickets (CC-44336, CC-44362, CC-44440, CC-44500, CC-44505, ...).

## Fix
One-line import path update, no behavior change.

## Verification
Could not run a full local Maven build in this environment (no access to Confluent's internal CodeArtifact repo to resolve the parent POM), so this hasn't been build-verified locally — please let CI confirm. The change is a straight import-path swap matching the upstream class relocation; `kafka-connect-hdfs` has the identical copy-paste bug and needs the same fix (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)