### PR TITLE
CC-42057: make SchemaSourceConnector.version() version-neutral

### DIFF
--- a/core/src/main/java/io/confluent/connect/storage/tools/SchemaSourceConnector.java
+++ b/core/src/main/java/io/confluent/connect/storage/tools/SchemaSourceConnector.java
@@ -16,7 +16,6 @@
 package io.confluent.connect.storage.tools;
 
 import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.source.SourceConnector;
 
@@ -30,7 +29,13 @@ public class SchemaSourceConnector extends SourceConnector {
 
   @Override
   public String version() {
-    return AppInfoParser.getVersion();
+    // Version-neutral: read this module's own version from the jar manifest's
+    // Implementation-Version instead of AppInfoParser. AppInfoParser reports the
+    // Kafka version and, in CP 8.4 / Apache Kafka 4.x, moved to
+    // org.apache.kafka.common.utils.internals, so referencing it forces an
+    // 8.4-only jar. This keeps a single jar loadable on both 8.3 and 8.4 workers.
+    String version = getClass().getPackage().getImplementationVersion();
+    return version != null ? version : "unknown";
   }
 
   @Override


### PR DESCRIPTION
**What:** Make `SchemaSourceConnector.version()` version-neutral — read this module's own version from the jar manifest (`getClass().getPackage().getImplementationVersion()`, null-safe fallback to `"unknown"`) instead of `AppInfoParser.getVersion()`.

**Why:** CP 8.4 (Apache Kafka 4.x) relocated `AppInfoParser` from `org.apache.kafka.common.utils` to `...utils.internals` and deleted the old path. `SchemaSourceConnector` lives in the shared `kafka-connect-storage-core` jar that ships inside every object-store connector, so its `version()` referencing the old class throws `NoClassDefFoundError` during the plugin scan on a CP 8.4 worker. Surfaced by the managed-Connect base-image 8.3→8.4 bump (CC-42057).

**Why version-neutral instead of relocating the import:** `...utils.internals.AppInfoParser` does not exist before 8.4, so relocating the reference would force an 8.4-only jar. `getImplementationVersion()` references no Kafka class at all, so **a single `storage-core` jar loads cleanly on both 8.3 and 8.4 workers** — no parallel 8.3/8.4 split, no Java 17 build move. `SchemaSourceConnector` already implements `version()` concretely (`Connector.version()` has always been abstract), so this also satisfies the now-abstract `Versioned.version()` on 4.x with no `@Override`/compile subtlety.

**Behavior change:** `version()` now reports the storage-common **module** version (e.g. `12.0.14`) rather than the Kafka version. `SchemaSourceConnector` is a test/tools connector, so this is cosmetic (plugin-metadata/reporting only); it does not affect any data path.

## Testing

- **Mechanism proven on the identical fix in a sibling module.** The same `getImplementationVersion()` pattern was applied to `io.confluent.connect.binary.BinaryConverter` (Custom SMT) and validated by overlaying the fixed jar onto a locally-built CP-8.4 image and running `connect-plugin-path list`: the pre-fix jar throws `AbstractMethodError`/`NoClassDefFoundError` on the 8.4 plugin scan, the version-neutral jar scans clean (`Loadable / Compatible`), with the `"unknown"` manifest fallback exercised exactly as designed. `SchemaSourceConnector` uses the identical construct.
- **Confirmed sole 8.4 API break in storage-core.** A bytecode scan shows `AppInfoParser` is the only moved/removed reference in `core`; after this change no `org.apache.kafka.*` class is referenced by `version()`.
- Trivial change (one import removed, one method body), no new dependencies.

## Release line

Targets **`12.0.x`** (the latest pre-8.4 released line, CP 7.7 parent). Because the fix is backward-compatible, the same one-line change applies cleanly to any other active line (`master` / `13.0.x`) if we want one-jar-everywhere; not applied here to keep this PR scoped.

**Relationship to the 8.4 work:** this is the version-neutral alternative to the `internals.AppInfoParser` relocation on the new 8.4-only `13.0.x` line — it fixes the same plugin-scan crash while keeping the existing line's jar usable on both 8.3 and 8.4. The object-store connectors pick up the fix by consuming `12.0.14+`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
