### PR TITLE
CC-42057: make SchemaSourceConnector.version() version-neutral

### DIFF
--- a/core/src/main/java/io/confluent/connect/storage/tools/SchemaSourceConnector.java
+++ b/core/src/main/java/io/confluent/connect/storage/tools/SchemaSourceConnector.java
@@ -16,21 +16,43 @@
 package io.confluent.connect.storage.tools;
 
 import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.source.SourceConnector;
 
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 public class SchemaSourceConnector extends SourceConnector {
+  private static final String VERSION = loadKafkaVersion();
+
   private Map<String, String> config;
 
   @Override
   public String version() {
-    return AppInfoParser.getVersion();
+    return VERSION;
+  }
+
+  // Minimal inline equivalent of AppInfoParser.getVersion(): read the Kafka
+  // version from /kafka/kafka-version.properties (shipped in kafka-clients)
+  // instead of referencing AppInfoParser, whose class moved from
+  // org.apache.kafka.common.utils to ...utils.internals in CP 8.4 / Apache
+  // Kafka 4.x. Referencing no Kafka class keeps a single jar loadable on both
+  // 8.3 and 8.4 workers.
+  private static String loadKafkaVersion() {
+    Properties props = new Properties();
+    try (InputStream in = SchemaSourceConnector.class
+        .getResourceAsStream("/kafka/kafka-version.properties")) {
+      if (in != null) {
+        props.load(in);
+      }
+    } catch (Exception e) {
+      // ignore and fall back to "unknown"
+    }
+    return props.getProperty("version", "unknown").trim();
   }
 
   @Override

--- a/core/src/test/java/io/confluent/connect/storage/tools/SchemaSourceConnectorTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/tools/SchemaSourceConnectorTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.storage.tools;
+
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+public class SchemaSourceConnectorTest {
+
+  /**
+   * version() must always return a non-null, non-empty string and never throw.
+   * This is the property that keeps the plugin scan safe on CP 8.4 (Apache Kafka
+   * 4.x), where {@code Versioned.version()} is abstract: a connector whose
+   * version() throws (e.g. a NoClassDefFoundError from the relocated
+   * AppInfoParser) fails the scan.
+   */
+  @Test
+  public void versionIsNeverNullOrEmpty() {
+    String version = new SchemaSourceConnector().version();
+    assertNotNull("version() must not return null", version);
+    assertFalse("version() must not return an empty string", version.isEmpty());
+  }
+
+  /**
+   * version() reads the Kafka version from /kafka/kafka-version.properties
+   * (shipped in kafka-clients), the same resource AppInfoParser reads. Read it
+   * independently here and confirm version() returns exactly that value -- so
+   * the method is wired to the resource, not a hardcoded or stale string. When
+   * kafka-clients is on the classpath (as in this build) both are the real
+   * Kafka version; if the resource were ever absent, both would be "unknown".
+   */
+  @Test
+  public void versionMatchesKafkaVersionProperties() throws Exception {
+    Properties props = new Properties();
+    try (InputStream in = getClass().getResourceAsStream("/kafka/kafka-version.properties")) {
+      if (in != null) {
+        props.load(in);
+      }
+    }
+    String expected = props.getProperty("version", "unknown").trim();
+    assertEquals(expected, new SchemaSourceConnector().version());
+  }
+}


### PR DESCRIPTION
**What:** Make `SchemaSourceConnector.version()` read the Kafka version from `/kafka/kafka-version.properties` directly (the same resource `AppInfoParser` reads), instead of calling `AppInfoParser.getVersion()`.

**Why:** CP 8.4 (Apache Kafka 4.x) moved `AppInfoParser` from `org.apache.kafka.common.utils` to `...utils.internals` and deleted the old path. `SchemaSourceConnector` lives in the shared `kafka-connect-storage-core` jar bundled in every object-store connector, so referencing the old class threw `NoClassDefFoundError` during the plugin scan on a CP 8.4 worker. Surfaced by the managed-Connect base-image 8.3→8.4 bump (CC-42057).

**Why this approach (vs relocating to `internals.AppInfoParser`):** referencing `internals.AppInfoParser` doesn't compile/run before 8.4 (the class doesn't exist there), so it forces an 8.4-only jar. Reading the properties resource references **no Kafka class**, so a single `storage-core` jar loads on both 8.3 and 8.4 workers — no parallel 8.3/8.4 split, no parent bump, no Java 17 move. It still returns the real Kafka version (e.g. `7.7.11-5-ccs`), same as before — not `"unknown"`.

## Testing

- **Unit test** (`SchemaSourceConnectorTest`): `version()` is non-null/non-empty (the property that keeps the 8.4 plugin scan from failing, since `Versioned.version()` is abstract on 4.x), and returns exactly the value in `kafka-version.properties`. Verified locally — returns `7.7.11-5-ccs`, `Tests run: 2, Failures: 0`.
- **Runtime**, on a real CP-8.4 image: the identical construct on `BinaryConverter` (Custom SMT) was validated by overlaying the fixed jar and running `connect-plugin-path list` — the pre-fix jar throws `AbstractMethodError`/`NoClassDefFoundError` on the scan, the fixed jar scans clean.

## Release line

Targets **`12.0.x`** (latest pre-8.4 line). The change is backward-compatible, so it applies cleanly to any other active line (`master`/`13.0.x`) if we want one-jar-everywhere. Object-store connectors pick up the fix by consuming `12.0.14+`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
