### PR TITLE
Merge Conflict Resolution (from 12.0.x to 13.0.x)

### DIFF
--- a/core/src/main/java/io/confluent/connect/storage/tools/SchemaSourceConnector.java
+++ b/core/src/main/java/io/confluent/connect/storage/tools/SchemaSourceConnector.java
@@ -16,21 +16,43 @@
 package io.confluent.connect.storage.tools;
 
 import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.source.SourceConnector;
 
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 public class SchemaSourceConnector extends SourceConnector {
+  private static final String VERSION = loadKafkaVersion();
+
   private Map<String, String> config;
 
   @Override
   public String version() {
-    return AppInfoParser.getVersion();
+    return VERSION;
+  }
+
+  // Minimal inline equivalent of AppInfoParser.getVersion(): read the Kafka
+  // version from /kafka/kafka-version.properties (shipped in kafka-clients)
+  // instead of referencing AppInfoParser, whose class moved from
+  // org.apache.kafka.common.utils to ...utils.internals in CP 8.4 / Apache
+  // Kafka 4.x. Referencing no Kafka class keeps a single jar loadable on both
+  // 8.3 and 8.4 workers.
+  private static String loadKafkaVersion() {
+    Properties props = new Properties();
+    try (InputStream in = SchemaSourceConnector.class
+        .getResourceAsStream("/kafka/kafka-version.properties")) {
+      if (in != null) {
+        props.load(in);
+      }
+    } catch (Exception e) {
+      // ignore and fall back to "unknown"
+    }
+    return props.getProperty("version", "unknown").trim();
   }
 
   @Override

--- a/core/src/test/java/io/confluent/connect/storage/tools/SchemaSourceConnectorTest.java
+++ b/core/src/test/java/io/confluent/connect/storage/tools/SchemaSourceConnectorTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.storage.tools;
+
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+public class SchemaSourceConnectorTest {
+
+  /**
+   * version() must always return a non-null, non-empty string and never throw.
+   * This is the property that keeps the plugin scan safe on CP 8.4 (Apache Kafka
+   * 4.x), where {@code Versioned.version()} is abstract: a connector whose
+   * version() throws (e.g. a NoClassDefFoundError from the relocated
+   * AppInfoParser) fails the scan.
+   */
+  @Test
+  public void versionIsNeverNullOrEmpty() {
+    String version = new SchemaSourceConnector().version();
+    assertNotNull("version() must not return null", version);
+    assertFalse("version() must not return an empty string", version.isEmpty());
+  }
+
+  /**
+   * version() reads the Kafka version from /kafka/kafka-version.properties
+   * (shipped in kafka-clients), the same resource AppInfoParser reads. Read it
+   * independently here and confirm version() returns exactly that value -- so
+   * the method is wired to the resource, not a hardcoded or stale string. When
+   * kafka-clients is on the classpath (as in this build) both are the real
+   * Kafka version; if the resource were ever absent, both would be "unknown".
+   */
+  @Test
+  public void versionMatchesKafkaVersionProperties() throws Exception {
+    Properties props = new Properties();
+    try (InputStream in = getClass().getResourceAsStream("/kafka/kafka-version.properties")) {
+      if (in != null) {
+        props.load(in);
+      }
+    }
+    String expected = props.getProperty("version", "unknown").trim();
+    assertEquals(expected, new SchemaSourceConnector().version());
+  }
+}


### PR DESCRIPTION
Merge-forward of the CC-42057 fix (#492) from `12.0.x` into `13.0.x`.

**Why:** required to unblock the **12.0.14** release. `pint merge --check-all` gates the release on every `12.0.x` commit being present on all higher lines; this and the master merge-forward are the only gap.

**What it brings:** the CP version-neutral `SchemaSourceConnector.version()` (reads the Kafka version from `/kafka/kafka-version.properties` instead of referencing `AppInfoParser`, which moved packages in CP 8.4 / Apache Kafka 4.x) plus its unit test. Nothing else.

**Version:** no pom/property changes — `13.0.x` keeps `12.1.0-SNAPSHOT`. Clean merge, zero conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
